### PR TITLE
Add support for environment ordering

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -1,5 +1,16 @@
 package api
 
+import (
+	"bytes"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"sort"
+
+	"github.com/zalando-incubator/cluster-lifecycle-manager/channel"
+)
+
 // Cluster describes a kubernetes cluster and related configuration.
 type Cluster struct {
 	Alias                 string            `json:"alias"                  yaml:"alias"`
@@ -18,4 +29,107 @@ type Cluster struct {
 	Status                *ClusterStatus    `json:"status"                 yaml:"status"`
 	Outputs               map[string]string `json:"outputs"                yaml:"outputs"`
 	Owner                 string            `json:"owner"                  yaml:"owner"`
+}
+
+// Version returns the version derived from a sha1 hash of the cluster struct
+// and the channel config version.
+func (cluster *Cluster) Version(channelVersion channel.ConfigVersion) (string, error) {
+	state := new(bytes.Buffer)
+
+	_, err := state.WriteString(cluster.ID)
+	if err != nil {
+		return "", err
+	}
+	_, err = state.WriteString(cluster.InfrastructureAccount)
+	if err != nil {
+		return "", err
+	}
+	_, err = state.WriteString(cluster.LocalID)
+	if err != nil {
+		return "", err
+	}
+	_, err = state.WriteString(cluster.APIServerURL)
+	if err != nil {
+		return "", err
+	}
+	_, err = state.WriteString(cluster.Channel)
+	if err != nil {
+		return "", err
+	}
+	_, err = state.WriteString(cluster.Environment)
+	if err != nil {
+		return "", err
+	}
+	err = binary.Write(state, binary.LittleEndian, cluster.CriticalityLevel)
+	if err != nil {
+		return "", err
+	}
+	_, err = state.WriteString(cluster.LifecycleStatus)
+	if err != nil {
+		return "", err
+	}
+	_, err = state.WriteString(cluster.Provider)
+	if err != nil {
+		return "", err
+	}
+	_, err = state.WriteString(cluster.Region)
+	if err != nil {
+		return "", err
+	}
+
+	// config items are sorted by key to produce a predictable string for
+	// hashing.
+	keys := make([]string, 0, len(cluster.ConfigItems))
+	for key := range cluster.ConfigItems {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		_, err = state.WriteString(key)
+		if err != nil {
+			return "", err
+		}
+		_, err = state.WriteString(cluster.ConfigItems[key])
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// node pools
+	for _, nodePool := range cluster.NodePools {
+		_, err = state.WriteString(nodePool.Name)
+		if err != nil {
+			return "", err
+		}
+		_, err = state.WriteString(nodePool.Profile)
+		if err != nil {
+			return "", err
+		}
+		_, err = state.WriteString(nodePool.InstanceType)
+		if err != nil {
+			return "", err
+		}
+		_, err = state.WriteString(nodePool.DiscountStrategy)
+		if err != nil {
+			return "", err
+		}
+		err = binary.Write(state, binary.LittleEndian, nodePool.MinSize)
+		if err != nil {
+			return "", err
+		}
+		err = binary.Write(state, binary.LittleEndian, nodePool.MaxSize)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// sha1 hash the cluster content
+	hasher := sha1.New()
+	_, err = hasher.Write(state.Bytes())
+	if err != nil {
+		return "", err
+	}
+	sha := base64.RawURLEncoding.EncodeToString(hasher.Sum(nil))
+
+	return fmt.Sprintf("%s#%s", string(channelVersion), sha), nil
 }

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -129,5 +129,9 @@ func (cluster *Cluster) Version(channelVersion channel.ConfigVersion) (*ClusterV
 		return nil, err
 	}
 
-	return NewClusterVersion(channelVersion, base64.RawURLEncoding.EncodeToString(hasher.Sum(nil))), nil
+	result := &ClusterVersion{
+		ConfigVersion: channelVersion,
+		ClusterHash:   base64.RawURLEncoding.EncodeToString(hasher.Sum(nil)),
+	}
+	return result, nil
 }

--- a/api/cluster_test.go
+++ b/api/cluster_test.go
@@ -1,0 +1,132 @@
+package api
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zalando-incubator/cluster-lifecycle-manager/channel"
+)
+
+func fieldNames(value interface{}) ([]string, error) {
+	v := reflect.ValueOf(value)
+
+	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
+		return nil, fmt.Errorf("invalid value type, expected pointer to struct: %s", v.Kind())
+	}
+
+	v = v.Elem()
+
+	result := make([]string, v.Type().NumField())
+	for i := 0; i < v.NumField(); i++ {
+		result[i] = v.Type().Field(i).Name
+	}
+	return result, nil
+}
+
+func permute(value interface{}, field string) error {
+	v := reflect.ValueOf(value)
+
+	if v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
+		return fmt.Errorf("invalid value type, expected pointer to struct: %s", v.Kind())
+	}
+
+	fld := v.Elem().FieldByName(field)
+	switch fld.Type().Kind() {
+	case reflect.String:
+		fld.SetString("<permuted>")
+	case reflect.Int, reflect.Int32, reflect.Int64:
+		fld.SetInt(123456)
+	case reflect.Map:
+		switch v := fld.Interface().(type) {
+		case map[string]string:
+			v["<permuted_key>"] = "permuted_value"
+		default:
+			return fmt.Errorf("invalid map type for %s", field)
+		}
+	default:
+		return fmt.Errorf("unsupported type: %s", fld.Type())
+	}
+
+	return nil
+}
+
+func sampleCluster() *Cluster {
+	return &Cluster{
+		ID: "aws:123456789012:eu-central-1:kube-1",
+		InfrastructureAccount: "aws:123456789012",
+		LocalID:               "kube-1",
+		APIServerURL:          "https://kube-1.foo.example.org/",
+		Channel:               "alpha",
+		Environment:           "production",
+		CriticalityLevel:      1,
+		LifecycleStatus:       "ready",
+		Provider:              "zalando-aws",
+		Region:                "eu-central-1",
+		ConfigItems: map[string]string{
+			"product_x_key": "abcde",
+			"product_y_key": "12345",
+		},
+		Outputs: map[string]string{},
+		NodePools: []*NodePool{
+			{
+				Name:             "master-default",
+				Profile:          "master/default",
+				InstanceType:     "m3.medium",
+				DiscountStrategy: "none",
+				MinSize:          2,
+				MaxSize:          2,
+			},
+			{
+				Name:             "worker-default",
+				Profile:          "worker/default",
+				InstanceType:     "r4.large",
+				DiscountStrategy: "none",
+				MinSize:          3,
+				MaxSize:          20,
+			},
+		},
+	}
+}
+
+func TestVersion(t *testing.T) {
+	commitHash := channel.ConfigVersion("git-commit-hash")
+
+	version, err := sampleCluster().Version(commitHash)
+	require.NoError(t, err)
+
+	// cluster fields
+	fields, err := fieldNames(sampleCluster())
+	require.NoError(t, err)
+
+	for _, field := range fields {
+		if field == "Alias" || field == "NodePools" || field == "Outputs" || field == "Owner" || field == "Status" {
+			continue
+		}
+
+		cluster := sampleCluster()
+		err := permute(cluster, field)
+		require.NoError(t, err, "cluster field: %s", field)
+
+		newVersion, err := cluster.Version(commitHash)
+
+		require.NoError(t, err, "cluster field: %s", field)
+		require.NotEqual(t, version, newVersion, "cluster field: %s", field)
+	}
+
+	// node pool fields
+	fields, err = fieldNames(sampleCluster().NodePools[0])
+	require.NoError(t, err)
+
+	for _, field := range fields {
+		cluster := sampleCluster()
+		err := permute(cluster.NodePools[0], field)
+		require.NoError(t, err, "node pool field: %s", field)
+
+		newVersion, err := cluster.Version(commitHash)
+
+		require.NoError(t, err, "node pool field: %s", field)
+		require.NotEqual(t, version, newVersion, "cluster field: %s", field)
+	}
+}

--- a/api/cluster_test.go
+++ b/api/cluster_test.go
@@ -72,7 +72,7 @@ func sampleCluster() *Cluster {
 		NodePools: []*NodePool{
 			{
 				Name:             "master-default",
-				Profile:          "master/default",
+				Profile:          "master-default",
 				InstanceType:     "m3.medium",
 				DiscountStrategy: "none",
 				MinSize:          2,
@@ -80,7 +80,7 @@ func sampleCluster() *Cluster {
 			},
 			{
 				Name:             "worker-default",
-				Profile:          "worker/default",
+				Profile:          "worker-default",
 				InstanceType:     "r4.large",
 				DiscountStrategy: "none",
 				MinSize:          3,

--- a/api/cluster_version.go
+++ b/api/cluster_version.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"strings"
+
+	"github.com/zalando-incubator/cluster-lifecycle-manager/channel"
+)
+
+type ClusterVersion struct {
+	ConfigVersion channel.ConfigVersion
+	ClusterHash   string
+}
+
+func NewClusterVersion(configVersion channel.ConfigVersion, clusterHash string) *ClusterVersion {
+	return &ClusterVersion{
+		ConfigVersion: configVersion,
+		ClusterHash:   clusterHash,
+	}
+}
+
+func ParseVersion(version string) *ClusterVersion {
+	tokens := strings.Split(version, "#")
+	if len(tokens) != 2 {
+		return NewClusterVersion("", "")
+	}
+	return &ClusterVersion{
+		ConfigVersion: channel.ConfigVersion(tokens[0]),
+		ClusterHash:   tokens[1],
+	}
+}
+
+func (version *ClusterVersion) String() string {
+	if version == nil {
+		return ""
+	}
+
+	return string(version.ConfigVersion) + "#" + version.ClusterHash
+}

--- a/api/cluster_version.go
+++ b/api/cluster_version.go
@@ -6,22 +6,22 @@ import (
 	"github.com/zalando-incubator/cluster-lifecycle-manager/channel"
 )
 
+// ClusterVersion is a combination of configuration version from the configuration repository
+// and a hash of cluster's metadata.
 type ClusterVersion struct {
 	ConfigVersion channel.ConfigVersion
 	ClusterHash   string
 }
 
-func NewClusterVersion(configVersion channel.ConfigVersion, clusterHash string) *ClusterVersion {
-	return &ClusterVersion{
-		ConfigVersion: configVersion,
-		ClusterHash:   clusterHash,
-	}
-}
-
+// ParseVersion parses a version string into a ConfigVersion. Invalid version strings are parsed
+// into empty ClusterVersion structs.
 func ParseVersion(version string) *ClusterVersion {
 	tokens := strings.Split(version, "#")
 	if len(tokens) != 2 {
-		return NewClusterVersion("", "")
+		return &ClusterVersion{
+			ConfigVersion: "",
+			ClusterHash:   "",
+		}
 	}
 	return &ClusterVersion{
 		ConfigVersion: channel.ConfigVersion(tokens[0]),

--- a/api/node_pool_test.go
+++ b/api/node_pool_test.go
@@ -15,13 +15,13 @@ func TestSortNodePools(t *testing.T) {
 			msg: "test master sorted first stays first",
 			pools: NodePools([]*NodePool{
 				{
-					Profile: "master/default",
+					Profile: "master-default",
 					Name:    "one",
 					MinSize: 2,
 					MaxSize: 2,
 				},
 				{
-					Profile: "worker/default",
+					Profile: "worker-default",
 					Name:    "two",
 					MinSize: 3,
 					MaxSize: 20,
@@ -33,11 +33,11 @@ func TestSortNodePools(t *testing.T) {
 			msg: "test master sorted last becomes first",
 			pools: NodePools([]*NodePool{
 				{
-					Profile: "worker/default",
+					Profile: "worker-default",
 					Name:    "two",
 				},
 				{
-					Profile: "master/default",
+					Profile: "master-default",
 					Name:    "one",
 					MinSize: 2,
 					MaxSize: 2,

--- a/channel/config_source.go
+++ b/channel/config_source.go
@@ -1,21 +1,27 @@
 package channel
 
+type ConfigVersion string
+
 // ConfigSource is an interface for getting the cluster configuration for a
 // certain channel.
 type ConfigSource interface {
-	// Update synchronizes the local copy of the configuration with the remote one.
-	Update() error
+	// Update synchronizes the local copy of the configuration with the remote one
+	// and returns the available channel versions.
+	Update() (ConfigVersions, error)
 
-	// Get returns a Config related to the specified channel from the local copy.
-	Get(channel string) (*Config, error)
+	// Get returns a Config related to the specified version from the local copy.
+	Get(version ConfigVersion) (*Config, error)
 
 	// Delete deletes the config.
 	Delete(config *Config) error
 }
 
-// Config defines the current version of the channel and the path to the
-// directory of the channel configuration files.
+// ConfigVersions is a snapshot of the versions at the time of an update
+type ConfigVersions interface {
+	Version(channel string) (ConfigVersion, error)
+}
+
+// Config defines the path to the directory of the channel configuration files.
 type Config struct {
-	Version string
-	Path    string
+	Path string
 }

--- a/channel/directory.go
+++ b/channel/directory.go
@@ -5,24 +5,30 @@ type Directory struct {
 	location string
 }
 
+type directoryVersions struct{}
+
 // NewDirectory initializes a new directory-based ChannelSource.
 func NewDirectory(location string) ConfigSource {
 	return &Directory{location: location}
 }
 
-func (d *Directory) Update() error {
-	return nil
+func (d *Directory) Update() (ConfigVersions, error) {
+	result := &directoryVersions{}
+	return result, nil
 }
 
 // Get returns the contents from the directory.
-func (d *Directory) Get(channel string) (*Config, error) {
+func (d *Directory) Get(version ConfigVersion) (*Config, error) {
 	return &Config{
-		Version: channel,
-		Path:    d.location,
+		Path: d.location,
 	}, nil
 }
 
 // Delete is a no-op for the directory channelSource.
 func (d *Directory) Delete(config *Config) error {
 	return nil
+}
+
+func (d *directoryVersions) Version(channel string) (ConfigVersion, error) {
+	return "<dir>", nil
 }

--- a/channel/directory_test.go
+++ b/channel/directory_test.go
@@ -1,27 +1,23 @@
 package channel
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestDirectoryChannel(t *testing.T) {
 	location := "/test-dir"
-	channel := "local"
 
 	d := NewDirectory(location)
-	err := d.Update()
-	if err != nil {
-		t.Errorf("should not fail: %s", err)
-	}
+	channels, err := d.Update()
+	require.NoError(t, err)
+	require.NotEmpty(t, channels)
 
-	cc, err := d.Get(channel)
-	if err != nil {
-		t.Errorf("should not fail: %s", err)
-	}
+	cc, err := d.Get("channel")
+	require.NoError(t, err)
 
 	if cc.Path != location {
 		t.Errorf("expected %s, got %s", location, cc.Path)
-	}
-
-	if cc.Version != channel {
-		t.Errorf("expected %s, got %s", channel, cc.Version)
 	}
 }

--- a/channel/git.go
+++ b/channel/git.go
@@ -27,15 +27,15 @@ type Git struct {
 	mutex             *sync.Mutex
 }
 
-type staticVersions struct {
+type StaticVersions struct {
 	channels map[string]ConfigVersion
 }
 
-func NewStaticVersions(versions map[string]ConfigVersion) ConfigVersions {
-	return &staticVersions{channels: versions}
+func NewStaticVersions(versions map[string]ConfigVersion) *StaticVersions {
+	return &StaticVersions{channels: versions}
 }
 
-func (versions *staticVersions) Version(channel string) (ConfigVersion, error) {
+func (versions *StaticVersions) Version(channel string) (ConfigVersion, error) {
 	if version, ok := versions.channels[channel]; ok {
 		return version, nil
 	}
@@ -140,7 +140,7 @@ func (g *Git) availableChannels() (ConfigVersions, error) {
 			result[channel] = ConfigVersion(hash)
 		}
 	}
-	return &staticVersions{channels: result}, nil
+	return NewStaticVersions(result), nil
 }
 
 // localClone duplicates a repo by cloning to temp location with unix time

--- a/channel/git_test.go
+++ b/channel/git_test.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"path"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // helper function to setup a test repository.
@@ -57,32 +59,20 @@ func TestGitGet(t *testing.T) {
 	defer os.RemoveAll(tmpRepo)
 
 	c, err := NewGit(workdir, tmpRepo, "")
-	if err != nil {
-		t.Errorf("should not fail: %s", err)
-	}
+	require.NoError(t, err)
 
-	err = c.Update()
-	if err != nil {
-		t.Errorf("should not fail: %s", err)
-	}
+	versions, err := c.Update()
+	require.NoError(t, err)
 
-	_, err = c.Get(channel)
-	if err != nil {
-		t.Errorf("should not fail: %s", err)
-	}
+	version, err := versions.Version(channel)
+	require.NoError(t, err)
 
-	// test geting channel when the repo has already been cloned once. E.i.
-	// do a pull in that case.
-	_, err = c.Get(channel)
-	if err != nil {
-		t.Errorf("should not fail: %s", err)
-	}
+	_, err = c.Get(version)
+	require.NoError(t, err)
 
 	// cleanup repo
 	err = os.RemoveAll(workdir)
-	if err != nil {
-		t.Errorf("should not fail: %s", err)
-	}
+	require.NoError(t, err)
 }
 
 func TestGetRepoName(t *testing.T) {

--- a/cmd/clm/main.go
+++ b/cmd/clm/main.go
@@ -98,6 +98,7 @@ func main() {
 			DryRun:            cfg.DryRun,
 			SecretDecrypter:   secretDecrypter,
 			ConcurrentUpdates: cfg.ConcurrentUpdates,
+			EnvironmentOrder:  cfg.EnvironmentOrder,
 		}
 
 		ctrl := controller.New(clusterRegistry, p, configSource, opts)

--- a/cmd/clm/main.go
+++ b/cmd/clm/main.go
@@ -114,7 +114,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("%+v", err)
 	}
-	sortByEnvironmentPriority(clusters, cfg.EnvironmentOrder)
+	orderByEnvironmentOrder(clusters, cfg.EnvironmentOrder)
 
 	for _, cluster := range clusters {
 		if !cfg.AccountFilter.Allowed(cluster.InfrastructureAccount) {
@@ -167,9 +167,13 @@ func main() {
 	}
 }
 
-func sortByEnvironmentPriority(clusters []*api.Cluster, environmentPriority []string) {
+// orderByEnvironmentOrder orders the clusters based on the provided environment ordering.
+// If environmentOrder is [A, B], all clusters with environment A will be reordered
+// before clusters with environment B. Position of clusters with environment not in
+// environmentOrder is unspecified (current implementation will order them first)
+func orderByEnvironmentOrder(clusters []*api.Cluster, environmentOrder []string) {
 	computedPriorities := make(map[string]int)
-	for i, env := range environmentPriority {
+	for i, env := range environmentOrder {
 		computedPriorities[env] = i + 1
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ type LifecycleManagerConfig struct {
 	GitRepositoryURL    string
 	SSHPrivateKeyFile   string
 	CredentialsDir      string
+	EnvironmentOrder    []string
 	ApplyOnly           bool
 	AwsMaxRetries       int
 	AwsMaxRetryInterval time.Duration
@@ -100,5 +101,6 @@ func (cfg *LifecycleManagerConfig) ParseFlags() string {
 	kingpin.Flag("update-max-evict-timeout", "Maximum timeout for evicting pods during update.").Default(defaultUpdateMaxEvictTimeout).DurationVar(&cfg.UpdateStrategy.MaxEvictTimeout)
 	kingpin.Flag("update-strategy", "Update strategy to use when updating node pools.").Default(defaultUpdateStrategy).EnumVar(&cfg.UpdateStrategy.Strategy, "rolling")
 	kingpin.Flag("remove-volumes", "Remove EBS volumes when decommissioning").BoolVar(&cfg.RemoveVolumes)
+	kingpin.Flag("environment-order", "Roll out channel updates to the environments in a specific order").StringsVar(&cfg.EnvironmentOrder)
 	return kingpin.Parse()
 }

--- a/controller/channel_versions.go
+++ b/controller/channel_versions.go
@@ -1,0 +1,41 @@
+package controller
+
+import "github.com/zalando-incubator/cluster-lifecycle-manager/channel"
+
+type tag struct{}
+
+type versionKey struct {
+	environment string
+	channel     string
+}
+
+// usedVersions contains information about the channel versions of clusters, grouped by environment and channel
+type usedVersions map[versionKey]map[channel.ConfigVersion]tag
+
+func newUsedVersions() usedVersions {
+	return make(usedVersions)
+}
+
+func (cv usedVersions) addCluster(clusterInfo *ClusterInfo) {
+	key := versionKey{environment: clusterInfo.Cluster.Environment, channel: clusterInfo.Cluster.Channel}
+	if versions, ok := cv[key]; ok {
+		versions[clusterInfo.CurrentVersion.ConfigVersion] = tag{}
+	} else {
+		cv[key] = map[channel.ConfigVersion]tag{clusterInfo.CurrentVersion.ConfigVersion: {}}
+	}
+}
+
+// fullyUpdated returns true if all clusters with the provided environment and channel use the provided version
+func (cv usedVersions) fullyUpdated(environment, channel string, version channel.ConfigVersion) bool {
+	key := versionKey{environment: environment, channel: channel}
+	if versions, ok := cv[key]; ok {
+		if len(versions) != 1 {
+			return false
+		}
+
+		_, used := versions[version]
+		return used
+	} else {
+		return false
+	}
+}

--- a/controller/cluster_list.go
+++ b/controller/cluster_list.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"sort"
 	"sync"
 	"time"
 
@@ -11,7 +12,8 @@ import (
 )
 
 const (
-	updatePriorityNormal = iota
+	updatePriorityNone = iota
+	updatePriorityNormal
 	updatePriorityDecommissionRequested
 	updatePriorityAlreadyUpdating
 
@@ -24,7 +26,10 @@ type ClusterInfo struct {
 	lastProcessed time.Time
 	state         int
 	Cluster       *api.Cluster
-	ConfigVersion channel.ConfigVersion
+
+	CurrentVersion *api.ClusterVersion
+	NextVersion    *api.ClusterVersion
+	NextError      error
 }
 
 // ClusterList maintains the state of all active clusters
@@ -32,6 +37,7 @@ type ClusterList struct {
 	sync.Mutex
 	accountFilter config.IncludeExcludeFilter
 	clusters      map[string]*ClusterInfo
+	pendingUpdate []*ClusterInfo
 }
 
 func NewClusterList(accountFilter config.IncludeExcludeFilter) *ClusterList {
@@ -42,7 +48,7 @@ func NewClusterList(accountFilter config.IncludeExcludeFilter) *ClusterList {
 }
 
 // UpdateAvailable adds new clusters to the list, updates the cluster data for existing ones and removes clusters
-// that are no longer active
+// that are no longer active.
 func (clusterList *ClusterList) UpdateAvailable(channels channel.ConfigVersions, availableClusters []*api.Cluster) {
 	clusterList.Lock()
 	defer clusterList.Unlock()
@@ -62,23 +68,32 @@ func (clusterList *ClusterList) UpdateAvailable(channels channel.ConfigVersions,
 
 		availableClusterIds[cluster.ID] = true
 
-		channelVersion, err := channels.Version(cluster.Channel)
-		if err != nil {
-			channelVersion = ""
+		currentVersion := api.ParseVersion(cluster.Status.CurrentVersion)
+
+		var channelVersion channel.ConfigVersion
+		var nextVersion *api.ClusterVersion
+		var nextError error
+		channelVersion, nextError = channels.Version(cluster.Channel)
+		if nextError == nil {
+			nextVersion, nextError = cluster.Version(channelVersion)
 		}
 
 		if existing, ok := clusterList.clusters[cluster.ID]; ok {
 			if existing.state != stateProcessing {
 				existing.state = stateIdle
 				existing.Cluster = cluster
-				existing.ConfigVersion = channelVersion
+				existing.CurrentVersion = currentVersion
+				existing.NextVersion = nextVersion
+				existing.NextError = nextError
 			}
 		} else {
 			clusterList.clusters[cluster.ID] = &ClusterInfo{
-				lastProcessed: time.Unix(0, 0),
-				state:         stateIdle,
-				Cluster:       cluster,
-				ConfigVersion: channelVersion,
+				lastProcessed:  time.Unix(0, 0),
+				state:          stateIdle,
+				Cluster:        cluster,
+				CurrentVersion: currentVersion,
+				NextVersion:    nextVersion,
+				NextError:      nextError,
 			}
 		}
 	}
@@ -94,54 +109,70 @@ func (clusterList *ClusterList) UpdateAvailable(channels channel.ConfigVersions,
 			delete(clusterList.clusters, id)
 		}
 	}
+
+	// find out which clusters need updating
+	var pendingUpdate []*ClusterInfo
+	for _, cluster := range clusterList.clusters {
+		if cluster.state != stateIdle {
+			continue
+		}
+
+		if updatePriority(cluster) != updatePriorityNone {
+			pendingUpdate = append(pendingUpdate, cluster)
+		}
+	}
+	sort.Slice(pendingUpdate, func(i, j int) bool {
+		pi := updatePriority(pendingUpdate[i])
+		pj := updatePriority(pendingUpdate[j])
+
+		if pi > pj {
+			return true
+		} else if pi < pj {
+			return false
+		} else {
+			return pendingUpdate[i].lastProcessed.Before(pendingUpdate[j].lastProcessed)
+		}
+	})
+
+	clusterList.pendingUpdate = pendingUpdate
 }
 
 // updatePriority returns the update priority of the clusters. Clusters with higher priority will always be selected
-// for update before clusters with lower priority.
-func updatePriority(cluster *api.Cluster) uint32 {
+// for update before clusters with lower priority. A special value updatePriorityNone signifies that no update is needed.
+func updatePriority(clusterInfo *ClusterInfo) uint32 {
+	cluster := clusterInfo.Cluster
+
 	if cluster.Status.NextVersion != "" && cluster.Status.NextVersion != cluster.Status.CurrentVersion {
 		return updatePriorityAlreadyUpdating
 	}
+
 	if cluster.LifecycleStatus == statusDecommissionRequested {
 		return updatePriorityDecommissionRequested
 	}
-	return updatePriorityNormal
+
+	if clusterInfo.NextError != nil || *clusterInfo.NextVersion != *clusterInfo.CurrentVersion {
+		return updatePriorityNormal
+	}
+
+	return updatePriorityNone
 }
 
-// SelectNext returns the next cluster of update, if any, and marks it as being processed. A cluster with higher
+// SelectNext returns the next cluster to update, if any, and marks it as being processed. A cluster with higher
 // priority will be selected first, in case of ties it'll select a cluster that hasn't been updated for the longest
 // time.
 func (clusterList *ClusterList) SelectNext() *ClusterInfo {
 	clusterList.Lock()
 	defer clusterList.Unlock()
 
-	var nextCluster *ClusterInfo
-	var nextClusterPriority uint32
-
-	for _, cluster := range clusterList.clusters {
-		if cluster.state != stateIdle {
-			continue
-		}
-
-		if nextCluster == nil {
-			nextCluster = cluster
-			nextClusterPriority = updatePriority(cluster.Cluster)
-		} else {
-			priority := updatePriority(cluster.Cluster)
-
-			if priority > nextClusterPriority || (priority == nextClusterPriority && cluster.lastProcessed.Before(nextCluster.lastProcessed)) {
-				nextCluster = cluster
-				nextClusterPriority = priority
-			}
-		}
-	}
-
-	if nextCluster == nil {
+	if len(clusterList.pendingUpdate) == 0 {
 		return nil
 	}
 
-	nextCluster.state = stateProcessing
-	return nextCluster
+	result := clusterList.pendingUpdate[0]
+	result.state = stateProcessing
+	clusterList.pendingUpdate = clusterList.pendingUpdate[1:]
+
+	return result
 }
 
 // ClusterProcessed marks a cluster as no longer being processed.

--- a/controller/cluster_list.go
+++ b/controller/cluster_list.go
@@ -20,7 +20,7 @@ type ClusterInfo struct {
 	lastProcessed time.Time
 	processing    bool
 	Cluster       *api.Cluster
-	Version       channel.ConfigVersion
+	ConfigVersion channel.ConfigVersion
 }
 
 // ClusterList maintains the state of all active clusters
@@ -66,14 +66,14 @@ func (clusterList *ClusterList) UpdateAvailable(channels channel.ConfigVersions,
 		if existing, ok := clusterList.clusters[cluster.ID]; ok {
 			if !existing.processing {
 				existing.Cluster = cluster
-				existing.Version = channelVersion
+				existing.ConfigVersion = channelVersion
 			}
 		} else {
 			clusterList.clusters[cluster.ID] = &ClusterInfo{
 				lastProcessed: time.Unix(0, 0),
 				processing:    false,
 				Cluster:       cluster,
-				Version:       channelVersion,
+				ConfigVersion: channelVersion,
 			}
 		}
 	}

--- a/controller/cluster_list_test.go
+++ b/controller/cluster_list_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
+	"github.com/zalando-incubator/cluster-lifecycle-manager/channel"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/config"
 )
 
@@ -14,6 +16,11 @@ var mockStatus = &api.ClusterStatus{
 	NextVersion:    "",
 	CurrentVersion: "abc123",
 }
+
+var devRevision = channel.ConfigVersion("<dev-channel>")
+var defaultChannels = channel.NewStaticVersions(map[string]channel.ConfigVersion{
+	"dev": devRevision,
+})
 
 func TestUpdateIgnoresClusters(t *testing.T) {
 	filter := config.IncludeExcludeFilter{
@@ -30,6 +37,7 @@ func TestUpdateIgnoresClusters(t *testing.T) {
 				ID: "aws:123456789011:eu-central-1:decommissioned",
 				InfrastructureAccount: "aws:123456789011",
 				LifecycleStatus:       "decommissioned",
+				Channel:               "dev",
 				Status:                mockStatus,
 			},
 			ignored: true,
@@ -39,6 +47,7 @@ func TestUpdateIgnoresClusters(t *testing.T) {
 				ID: "aws:123456789011:eu-central-1:ready",
 				InfrastructureAccount: "aws:123456789011",
 				LifecycleStatus:       "ready",
+				Channel:               "dev",
 				Status:                mockStatus,
 			},
 			ignored: false,
@@ -48,6 +57,7 @@ func TestUpdateIgnoresClusters(t *testing.T) {
 				ID: "aws:123456789011:eu-central-1:requested",
 				InfrastructureAccount: "aws:123456789011",
 				LifecycleStatus:       "ready",
+				Channel:               "dev",
 				Status:                mockStatus,
 			},
 			ignored: false,
@@ -57,6 +67,7 @@ func TestUpdateIgnoresClusters(t *testing.T) {
 				ID: "aws:123456789011:eu-central-1:decommission-requested",
 				InfrastructureAccount: "aws:123456789011",
 				LifecycleStatus:       "decommission-requested",
+				Channel:               "dev",
 				Status:                mockStatus,
 			},
 			ignored: false,
@@ -66,6 +77,7 @@ func TestUpdateIgnoresClusters(t *testing.T) {
 				ID: "aws:123456789222:eu-central-1:excluded",
 				InfrastructureAccount: "aws:123456789222",
 				LifecycleStatus:       "ready",
+				Channel:               "dev",
 				Status:                mockStatus,
 			},
 			ignored: true,
@@ -75,13 +87,14 @@ func TestUpdateIgnoresClusters(t *testing.T) {
 				ID: "foobar:123456789011:eu-central-1:not-included",
 				InfrastructureAccount: "foobar:123456789011",
 				LifecycleStatus:       "ready",
+				Channel:               "dev",
 				Status:                mockStatus,
 			},
 			ignored: true,
 		},
 	} {
 		clusterList := NewClusterList(filter)
-		clusterList.UpdateAvailable([]*api.Cluster{ti.cluster})
+		clusterList.UpdateAvailable(defaultChannels, []*api.Cluster{ti.cluster})
 		nextCluster := clusterList.SelectNext()
 		if ti.ignored {
 			assert.Nil(t, nextCluster, "cluster wasn't ignored: %s", ti.cluster.ID)
@@ -92,16 +105,18 @@ func TestUpdateIgnoresClusters(t *testing.T) {
 }
 
 func allClusterIds(clusterList *ClusterList) []string {
+	var clusters []*ClusterInfo
 	var result []string
 	for {
-		cluster := clusterList.SelectNext()
-		if cluster == nil {
-			for _, id := range result {
-				clusterList.ClusterProcessed(id)
+		clusterInfo := clusterList.SelectNext()
+		if clusterInfo == nil {
+			for _, info := range clusters {
+				clusterList.ClusterProcessed(info)
 			}
 			return result
 		} else {
-			result = append(result, cluster.ID)
+			clusters = append(clusters, clusterInfo)
+			result = append(result, clusterInfo.Cluster.ID)
 		}
 	}
 }
@@ -111,27 +126,29 @@ func TestUpdateAddsNewClusters(t *testing.T) {
 		ID: "aws:123456789011:eu-central-1:cluster1",
 		InfrastructureAccount: "aws:123456789011",
 		LifecycleStatus:       "ready",
+		Channel:               "dev",
 		Status:                mockStatus,
 	}
 	cluster2 := &api.Cluster{
 		ID: "aws:123456789012:eu-central-1:cluster2",
 		InfrastructureAccount: "aws:123456789012",
 		LifecycleStatus:       "ready",
+		Channel:               "dev",
 		Status:                mockStatus,
 	}
 
 	clusterList := NewClusterList(config.DefaultFilter)
 
 	// No clusters yet
-	assert.Nil(t, clusterList.SelectNext())
+	require.Nil(t, clusterList.SelectNext())
 
 	// One new cluster
-	clusterList.UpdateAvailable([]*api.Cluster{cluster1})
-	assert.Equal(t, []string{cluster1.ID}, allClusterIds(clusterList))
+	clusterList.UpdateAvailable(defaultChannels, []*api.Cluster{cluster1})
+	require.Equal(t, []string{cluster1.ID}, allClusterIds(clusterList))
 
 	// Another new cluster
-	clusterList.UpdateAvailable([]*api.Cluster{cluster1, cluster2})
-	assert.Equal(t, []string{cluster2.ID, cluster1.ID}, allClusterIds(clusterList))
+	clusterList.UpdateAvailable(defaultChannels, []*api.Cluster{cluster1, cluster2})
+	require.Equal(t, []string{cluster2.ID, cluster1.ID}, allClusterIds(clusterList))
 }
 
 func TestUpdateUpdatesExistingClusters(t *testing.T) {
@@ -139,24 +156,31 @@ func TestUpdateUpdatesExistingClusters(t *testing.T) {
 		ID: "aws:123456789011:eu-central-1:cluster1",
 		InfrastructureAccount: "aws:123456789011",
 		LifecycleStatus:       "requested",
+		Channel:               "dev",
 		Status:                mockStatus,
 	}
 
 	clusterList := NewClusterList(config.DefaultFilter)
 
-	clusterList.UpdateAvailable([]*api.Cluster{cluster})
-	assert.Equal(t, cluster.LifecycleStatus, clusterList.SelectNext().LifecycleStatus)
-	clusterList.ClusterProcessed(cluster.ID)
+	clusterList.UpdateAvailable(defaultChannels, []*api.Cluster{cluster})
+
+	next := clusterList.SelectNext()
+	require.NotNil(t, next)
+	require.Equal(t, cluster.LifecycleStatus, next.Cluster.LifecycleStatus)
+	clusterList.ClusterProcessed(next)
 
 	updated := &api.Cluster{
 		ID: "aws:123456789011:eu-central-1:cluster1",
 		InfrastructureAccount: "aws:123456789011",
 		LifecycleStatus:       "ready",
+		Channel:               "dev",
 		Status:                mockStatus,
 	}
-	clusterList.UpdateAvailable([]*api.Cluster{updated})
-	assert.Equal(t, updated.LifecycleStatus, clusterList.SelectNext().LifecycleStatus)
-	clusterList.ClusterProcessed(updated.ID)
+	clusterList.UpdateAvailable(defaultChannels, []*api.Cluster{updated})
+	next = clusterList.SelectNext()
+	require.NotNil(t, next)
+	require.Equal(t, updated.LifecycleStatus, next.Cluster.LifecycleStatus)
+	clusterList.ClusterProcessed(next)
 
 	assert.Equal(t, []string{cluster.ID}, allClusterIds(clusterList))
 }
@@ -171,22 +195,24 @@ func TestUpdateDeletesUnusedClusters(t *testing.T) {
 		ID: "aws:123456789011:eu-central-1:cluster1",
 		InfrastructureAccount: "aws:123456789011",
 		LifecycleStatus:       "ready",
+		Channel:               "dev",
 		Status:                mockStatus,
 	}
 	cluster2 := &api.Cluster{
 		ID: "aws:123456789012:eu-central-1:cluster2",
 		InfrastructureAccount: "aws:123456789012",
 		LifecycleStatus:       "ready",
+		Channel:               "dev",
 		Status:                mockStatus,
 	}
 
 	clusterList := NewClusterList(config.DefaultFilter)
 
-	clusterList.UpdateAvailable([]*api.Cluster{cluster1, cluster2})
-	assert.Equal(t, []string{cluster1.ID, cluster2.ID}, sortedStrings(allClusterIds(clusterList)))
+	clusterList.UpdateAvailable(defaultChannels, []*api.Cluster{cluster1, cluster2})
+	require.Equal(t, []string{cluster1.ID, cluster2.ID}, sortedStrings(allClusterIds(clusterList)))
 
-	clusterList.UpdateAvailable([]*api.Cluster{cluster2})
-	assert.Equal(t, []string{cluster2.ID}, allClusterIds(clusterList))
+	clusterList.UpdateAvailable(defaultChannels, []*api.Cluster{cluster2})
+	require.Equal(t, []string{cluster2.ID}, allClusterIds(clusterList))
 }
 
 func TestClusterPriority(t *testing.T) {
@@ -194,18 +220,21 @@ func TestClusterPriority(t *testing.T) {
 		ID: "aws:123456789011:eu-central-1:normal",
 		InfrastructureAccount: "aws:123456789011",
 		LifecycleStatus:       "ready",
+		Channel:               "dev",
 		Status:                mockStatus,
 	}
 	decommissionRequested := &api.Cluster{
 		ID: "aws:123456789012:eu-central-1:decommission-requested",
 		InfrastructureAccount: "aws:123456789012",
 		LifecycleStatus:       "decommission-requested",
+		Channel:               "dev",
 		Status:                mockStatus,
 	}
 	pendingUpdate := &api.Cluster{
 		ID: "aws:123456789013:eu-central-1:pendingUpdate",
 		InfrastructureAccount: "aws:123456789013",
 		LifecycleStatus:       "ready",
+		Channel:               "dev",
 		Status: &api.ClusterStatus{
 			NextVersion:    "abc123",
 			CurrentVersion: "def456",
@@ -215,6 +244,7 @@ func TestClusterPriority(t *testing.T) {
 		ID: "aws:123456789014:eu-central-1:normal-2",
 		InfrastructureAccount: "aws:123456789014",
 		LifecycleStatus:       "ready",
+		Channel:               "dev",
 		Status:                mockStatus,
 	}
 
@@ -228,34 +258,37 @@ func TestClusterPriority(t *testing.T) {
 	} {
 		clusterList := NewClusterList(config.DefaultFilter)
 
-		clusterList.UpdateAvailable(clusters)
+		clusterList.UpdateAvailable(defaultChannels, clusters)
 		assert.Equal(t, []string{pendingUpdate.ID, decommissionRequested.ID, normal.ID}, allClusterIds(clusterList))
 
 		// add normal2, it should now be updated before normal1
-		clusterList.UpdateAvailable(append(clusters, normal2))
+		clusterList.UpdateAvailable(defaultChannels, append(clusters, normal2))
 		assert.Equal(t, []string{pendingUpdate.ID, decommissionRequested.ID, normal2.ID, normal.ID}, allClusterIds(clusterList))
 	}
 }
 
 func TestClusterLastUpdated(t *testing.T) {
 	clusterList := NewClusterList(config.DefaultFilter)
-	clusterList.UpdateAvailable([]*api.Cluster{
+	clusterList.UpdateAvailable(defaultChannels, []*api.Cluster{
 		{
 			ID: "aws:123456789011:eu-central-1:cluster1",
 			InfrastructureAccount: "aws:123456789011",
 			LifecycleStatus:       "ready",
+			Channel:               "dev",
 			Status:                mockStatus,
 		},
 		{
 			ID: "aws:123456789012:eu-central-1:cluster2",
 			InfrastructureAccount: "aws:123456789012",
 			LifecycleStatus:       "ready",
+			Channel:               "dev",
 			Status:                mockStatus,
 		},
 		{
 			ID: "aws:123456789013:eu-central-1:cluster3",
 			InfrastructureAccount: "aws:123456789013",
 			LifecycleStatus:       "ready",
+			Channel:               "dev",
 			Status:                mockStatus,
 		},
 	})
@@ -266,12 +299,12 @@ func TestClusterLastUpdated(t *testing.T) {
 	next3 := clusterList.SelectNext()
 
 	// finish processing in a different order (2->1->3)
-	clusterList.ClusterProcessed(next2.ID)
-	clusterList.ClusterProcessed(next1.ID)
-	clusterList.ClusterProcessed(next3.ID)
+	clusterList.ClusterProcessed(next2)
+	clusterList.ClusterProcessed(next1)
+	clusterList.ClusterProcessed(next3)
 
 	// the same order should be preserved for next update attempts
-	assert.Equal(t, []string{next2.ID, next1.ID, next3.ID}, allClusterIds(clusterList))
+	require.Equal(t, []string{next2.Cluster.ID, next1.Cluster.ID, next3.Cluster.ID}, allClusterIds(clusterList))
 }
 
 func TestProcessingClusterNotDeleted(t *testing.T) {
@@ -279,23 +312,29 @@ func TestProcessingClusterNotDeleted(t *testing.T) {
 		ID: "aws:123456789011:eu-central-1:cluster1",
 		InfrastructureAccount: "aws:123456789011",
 		LifecycleStatus:       "ready",
+		Channel:               "dev",
 		Status:                mockStatus,
 	}
 
 	clusterList := NewClusterList(config.DefaultFilter)
-	clusterList.UpdateAvailable([]*api.Cluster{cluster})
-	assert.Equal(t, cluster.ID, clusterList.SelectNext().ID)
+	clusterList.UpdateAvailable(defaultChannels, []*api.Cluster{cluster})
+	next := clusterList.SelectNext()
+	require.NotNil(t, next)
+	require.Equal(t, cluster.ID, next.Cluster.ID)
 
 	// remove the cluster
-	clusterList.UpdateAvailable([]*api.Cluster{})
+	clusterList.UpdateAvailable(defaultChannels, []*api.Cluster{})
 
 	// add it back, but it still should be processing
-	clusterList.UpdateAvailable([]*api.Cluster{cluster})
-	assert.Nil(t, clusterList.SelectNext())
+	clusterList.UpdateAvailable(defaultChannels, []*api.Cluster{cluster})
+	require.Nil(t, clusterList.SelectNext())
 
 	// finish processing
-	clusterList.ClusterProcessed(cluster.ID)
-	assert.Equal(t, cluster.ID, clusterList.SelectNext().ID)
+	clusterList.ClusterProcessed(next)
+
+	next = clusterList.SelectNext()
+	require.NotNil(t, next)
+	require.Equal(t, cluster.ID, next.Cluster.ID)
 }
 
 func TestProcessingClusterNotUpdated(t *testing.T) {
@@ -303,23 +342,29 @@ func TestProcessingClusterNotUpdated(t *testing.T) {
 		ID: "aws:123456789011:eu-central-1:cluster1",
 		InfrastructureAccount: "aws:123456789011",
 		LifecycleStatus:       "ready",
+		Channel:               "dev",
 		Status:                mockStatus,
 	}
 
 	clusterList := NewClusterList(config.DefaultFilter)
-	clusterList.UpdateAvailable([]*api.Cluster{cluster})
-	assert.Equal(t, cluster.ID, clusterList.SelectNext().ID)
+	clusterList.UpdateAvailable(defaultChannels, []*api.Cluster{cluster})
+	next := clusterList.SelectNext()
+	require.NotNil(t, next)
+	require.Equal(t, cluster.ID, next.Cluster.ID)
 
 	updated := &api.Cluster{
 		ID: "aws:123456789011:eu-central-1:cluster1",
 		InfrastructureAccount: "aws:123456789011",
 		LifecycleStatus:       "decommission-pending",
+		Channel:               "dev",
 		Status:                mockStatus,
 	}
 
-	clusterList.UpdateAvailable([]*api.Cluster{updated})
-	clusterList.ClusterProcessed(cluster.ID)
+	clusterList.UpdateAvailable(defaultChannels, []*api.Cluster{updated})
+	clusterList.ClusterProcessed(next)
 
 	// cluster should not be overwritten
-	assert.Equal(t, cluster.LifecycleStatus, clusterList.SelectNext().LifecycleStatus)
+	next = clusterList.SelectNext()
+	require.NotNil(t, next)
+	require.Equal(t, cluster.LifecycleStatus, next.Cluster.LifecycleStatus)
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -130,11 +130,11 @@ func (c *Controller) doProcessCluster(clusterInfo *ClusterInfo) error {
 		cluster.Status = &api.ClusterStatus{}
 	}
 
-	if clusterInfo.Version == "" {
+	if clusterInfo.ConfigVersion == "" {
 		return fmt.Errorf("no version for channel %s", cluster.Channel)
 	}
 
-	config, err := c.channelConfigSourcer.Get(clusterInfo.Version)
+	config, err := c.channelConfigSourcer.Get(clusterInfo.ConfigVersion)
 	if err != nil {
 		return err
 	}
@@ -149,7 +149,7 @@ func (c *Controller) doProcessCluster(clusterInfo *ClusterInfo) error {
 	switch cluster.LifecycleStatus {
 	case statusRequested, statusReady:
 		var nextVersion string
-		nextVersion, err = c.provisioner.Version(cluster, clusterInfo.Version)
+		nextVersion, err = cluster.Version(clusterInfo.ConfigVersion)
 		if err != nil {
 			return err
 		}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -36,6 +36,7 @@ type Options struct {
 	DryRun            bool
 	SecretDecrypter   decrypter.SecretDecrypter
 	ConcurrentUpdates uint
+	EnvironmentOrder  []string
 }
 
 // Controller defines the main control loop for the cluster-lifecycle-manager.
@@ -59,7 +60,7 @@ func New(registry registry.Registry, provisioner provisioner.Provisioner, channe
 		secretDecrypter:      options.SecretDecrypter,
 		interval:             options.Interval,
 		dryRun:               options.DryRun,
-		clusterList:          NewClusterList(options.AccountFilter),
+		clusterList:          NewClusterList(options.AccountFilter, options.EnvironmentOrder),
 		concurrentUpdates:    options.ConcurrentUpdates,
 	}
 }

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -20,10 +20,6 @@ var defaultVersions = map[string]channel.ConfigVersion{"alpha": "<alpha-sha>"}
 
 type mockProvisioner struct{}
 
-func (p *mockProvisioner) Version(cluster *api.Cluster, configVersion channel.ConfigVersion) (string, error) {
-	return nextVersion, nil
-}
-
 func (p *mockProvisioner) Provision(cluster *api.Cluster, config *channel.Config) error {
 	return nil
 }
@@ -33,10 +29,6 @@ func (p *mockProvisioner) Decommission(cluster *api.Cluster, config *channel.Con
 }
 
 type mockErrProvisioner mockProvisioner
-
-func (p *mockErrProvisioner) Version(cluster *api.Cluster, configVersion channel.ConfigVersion) (string, error) {
-	return "", fmt.Errorf("failed getting version")
-}
 
 func (p *mockErrProvisioner) Provision(cluster *api.Cluster, config *channel.Config) error {
 	return fmt.Errorf("failed to provision")

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/channel"
@@ -15,9 +16,11 @@ import (
 
 const nextVersion = "version"
 
+var defaultVersions = map[string]channel.ConfigVersion{"alpha": "<alpha-sha>"}
+
 type mockProvisioner struct{}
 
-func (p *mockProvisioner) Version(cluster *api.Cluster, config *channel.Config) (string, error) {
+func (p *mockProvisioner) Version(cluster *api.Cluster, configVersion channel.ConfigVersion) (string, error) {
 	return nextVersion, nil
 }
 
@@ -31,7 +34,7 @@ func (p *mockProvisioner) Decommission(cluster *api.Cluster, config *channel.Con
 
 type mockErrProvisioner mockProvisioner
 
-func (p *mockErrProvisioner) Version(cluster *api.Cluster, config *channel.Config) (string, error) {
+func (p *mockErrProvisioner) Version(cluster *api.Cluster, configVersion channel.ConfigVersion) (string, error) {
 	return "", fmt.Errorf("failed getting version")
 }
 
@@ -50,43 +53,57 @@ func (p *mockErrCreateProvisioner) Provision(cluster *api.Cluster, config *chann
 }
 
 type mockRegistry struct {
+	theCluster *api.Cluster
 	lastUpdate *api.Cluster
 }
 
+func MockRegistry(lifecycleStatus string, status *api.ClusterStatus) *mockRegistry {
+	if status == nil {
+		status = &api.ClusterStatus{}
+	}
+	cluster := &api.Cluster{
+		ID: "aws:123456789012:eu-central-1:kube-1",
+		InfrastructureAccount: "aws:123456789012",
+		Channel:               "alpha",
+		LifecycleStatus:       lifecycleStatus,
+		Status:                status,
+	}
+	return &mockRegistry{theCluster: cluster}
+}
+
 func (r *mockRegistry) ListClusters(filter registry.Filter) ([]*api.Cluster, error) {
-	return nil, nil
+	return []*api.Cluster{r.theCluster}, nil
 }
 func (r *mockRegistry) UpdateCluster(cluster *api.Cluster) error {
 	r.lastUpdate = cluster
 	return nil
 }
 
-type mockChannelSource struct{}
-
-func (r *mockChannelSource) Get(ch string) (*channel.Config, error) {
-	return &channel.Config{Version: nextVersion}, nil
+type mockChannelSource struct {
+	configVersions channel.ConfigVersions
+	failGet        bool
 }
 
-func (r *mockChannelSource) Update() error {
-	return nil
+func MockChannelSource(configVersions map[string]channel.ConfigVersion, failGet bool) channel.ConfigSource {
+	return &mockChannelSource{
+		configVersions: channel.NewStaticVersions(configVersions),
+		failGet:        failGet,
+	}
+}
+
+func (r *mockChannelSource) Get(version channel.ConfigVersion) (*channel.Config, error) {
+	if r.failGet {
+		return nil, fmt.Errorf("failed to checkout version %s", version)
+	}
+	return &channel.Config{}, nil
+}
+
+func (r *mockChannelSource) Update() (channel.ConfigVersions, error) {
+	return r.configVersions, nil
 }
 
 func (r *mockChannelSource) Delete(config *channel.Config) error {
 	return nil
-}
-
-type mockErrChannelSource struct{}
-
-func (r *mockErrChannelSource) Update() error {
-	return fmt.Errorf("failed to update channel config")
-}
-
-func (r *mockErrChannelSource) Get(channel string) (*channel.Config, error) {
-	return nil, fmt.Errorf("failed to get channel config")
-}
-
-func (r *mockErrChannelSource) Delete(config *channel.Config) error {
-	return fmt.Errorf("failed to delete config")
 }
 
 var defaultOptions = &Options{
@@ -94,140 +111,102 @@ var defaultOptions = &Options{
 }
 
 func TestProcessCluster(t *testing.T) {
-	cluster := &api.Cluster{
-		ID: "aws:123456789012:eu-central-1:kube-1",
-		InfrastructureAccount: "aws:123456789012",
-		Channel:               "alpha",
-		LifecycleStatus:       "ready",
-	}
-
 	for _, ti := range []struct {
-		registry        registry.Registry
-		provisioner     provisioner.Provisioner
-		channelSource   channel.ConfigSource
-		clusterStatus   *api.ClusterStatus
-		options         *Options
-		lifecycleStatus string
-		success         bool
+		testcase      string
+		registry      registry.Registry
+		provisioner   provisioner.Provisioner
+		channelSource channel.ConfigSource
+		options       *Options
+		success       bool
 	}{
-		// test when lifecyclestatus is requested
 		{
-			registry:        &mockRegistry{},
-			provisioner:     &mockProvisioner{},
-			channelSource:   &mockChannelSource{},
-			lifecycleStatus: statusRequested,
-			options:         defaultOptions,
-			success:         true,
+			testcase:      "lifecycle status requested",
+			registry:      MockRegistry(statusRequested, nil),
+			provisioner:   &mockProvisioner{},
+			channelSource: MockChannelSource(defaultVersions, false),
+			options:       defaultOptions,
+			success:       true,
 		},
-		// test when lifecyclestatus is ready
 		{
-			registry:        &mockRegistry{},
-			provisioner:     &mockProvisioner{},
-			channelSource:   &mockChannelSource{},
-			lifecycleStatus: statusReady,
-			options:         defaultOptions,
-			success:         true,
+			testcase:      "lifecycle status ready",
+			registry:      MockRegistry(statusReady, nil),
+			provisioner:   &mockProvisioner{},
+			channelSource: MockChannelSource(defaultVersions, false),
+			options:       defaultOptions,
+			success:       true,
 		},
-		// test when lifecyclestatus is decommission-requested
 		{
-			registry:        &mockRegistry{},
-			provisioner:     &mockProvisioner{},
-			channelSource:   &mockChannelSource{},
-			lifecycleStatus: statusDecommissionRequested,
-			options:         defaultOptions,
-			success:         true,
+			testcase:      "lifecycle status decommission-requested",
+			registry:      MockRegistry(statusDecommissionRequested, nil),
+			provisioner:   &mockProvisioner{},
+			channelSource: MockChannelSource(defaultVersions, false),
+			options:       defaultOptions,
+			success:       true,
 		},
-		// test when lifecyclestatus is decommissioned
 		{
-			registry:        &mockRegistry{},
-			provisioner:     &mockProvisioner{},
-			channelSource:   &mockChannelSource{},
-			lifecycleStatus: statusDecommissioned,
-			options:         defaultOptions,
-			success:         true,
+			testcase:      "lifecycle status requested, provisioner.Create fails",
+			registry:      MockRegistry(statusRequested, &api.ClusterStatus{CurrentVersion: nextVersion}),
+			provisioner:   &mockErrCreateProvisioner{},
+			channelSource: MockChannelSource(defaultVersions, false),
+			options:       defaultOptions,
+			success:       false,
 		},
-		// test when lifecyclestatus is requested and provisoner.Create
-		// fails
 		{
-			registry:        &mockRegistry{},
-			provisioner:     &mockErrCreateProvisioner{},
-			channelSource:   &mockChannelSource{},
-			clusterStatus:   &api.ClusterStatus{CurrentVersion: nextVersion},
-			lifecycleStatus: statusRequested,
-			options:         defaultOptions,
-			success:         false,
+			testcase:      "lifecycle status ready, version up to date fails",
+			registry:      MockRegistry(statusReady, &api.ClusterStatus{CurrentVersion: nextVersion}),
+			provisioner:   &mockProvisioner{},
+			channelSource: MockChannelSource(defaultVersions, false),
+			options:       defaultOptions,
+			success:       true,
 		},
-		// test when lifecyclestatus is requested and provisoner.Create
-		// fails
 		{
-			registry:        &mockRegistry{},
-			provisioner:     &mockErrCreateProvisioner{},
-			channelSource:   &mockChannelSource{},
-			clusterStatus:   &api.ClusterStatus{CurrentVersion: nextVersion},
-			lifecycleStatus: statusRequested,
-			options:         defaultOptions,
-			success:         false,
+			testcase:      "lifecycle status ready, provisioner.Version failing",
+			registry:      MockRegistry(statusReady, nil),
+			provisioner:   &mockErrProvisioner{},
+			channelSource: MockChannelSource(defaultVersions, false),
+			options:       defaultOptions,
+			success:       false,
 		},
-		// test when lifecyclestatus is ready and version is up to date
-		// fails
 		{
-			registry:        &mockRegistry{},
-			provisioner:     &mockProvisioner{},
-			channelSource:   &mockChannelSource{},
-			clusterStatus:   &api.ClusterStatus{CurrentVersion: nextVersion},
-			lifecycleStatus: statusReady,
-			options:         defaultOptions,
-			success:         true,
-		},
-		// test when lifecyclestatus is ready and provisioner.Version
-		// is failing.
-		{
-			registry:        &mockRegistry{},
-			provisioner:     &mockErrProvisioner{},
-			channelSource:   &mockChannelSource{},
-			lifecycleStatus: statusReady,
-			options:         defaultOptions,
-			success:         false,
-		},
-		// test when channel.Channel fails.
-		{
-			registry:        &mockRegistry{},
-			provisioner:     &mockErrProvisioner{},
-			channelSource:   &mockErrChannelSource{},
-			lifecycleStatus: statusReady,
-			options:         defaultOptions,
-			success:         false,
+			testcase:      "lifecycle status ready, channelSource.Get() fails",
+			registry:      MockRegistry(statusReady, nil),
+			provisioner:   &mockErrProvisioner{},
+			channelSource: MockChannelSource(defaultVersions, true),
+			options:       defaultOptions,
+			success:       false,
 		},
 	} {
 		controller := New(ti.registry, ti.provisioner, ti.channelSource, ti.options)
-		cluster.LifecycleStatus = ti.lifecycleStatus
-		cluster.Status = ti.clusterStatus
-		err := controller.doProcessCluster(cluster)
-		if err != nil && ti.success {
-			t.Errorf("should not fail: %s", err)
+		err := controller.refresh()
+		assert.NoError(t, err)
+
+		next := controller.clusterList.SelectNext()
+		if !assert.NotNil(t, next, ti.testcase) {
+			continue
 		}
 
-		if err == nil && !ti.success {
-			t.Errorf("expected failure")
+		err = controller.doProcessCluster(next)
+		if ti.success {
+			assert.NoError(t, err, ti.testcase)
+		} else {
+			assert.Error(t, err, ti.testcase)
 		}
 	}
 }
 
 func TestCoalesceFailures(t *testing.T) {
-	cluster := &api.Cluster{
-		ID: "aws:123456789012:eu-central-1:kube-1",
-		InfrastructureAccount: "aws:123456789012",
-		Channel:               "alpha",
-		LifecycleStatus:       "ready",
-	}
-
-	registry := &mockRegistry{}
-	controller := New(registry, &mockErrProvisioner{}, &mockChannelSource{}, defaultOptions)
+	registry := MockRegistry("ready", nil)
+	controller := New(registry, &mockErrProvisioner{}, MockChannelSource(defaultVersions, false), defaultOptions)
 
 	for i := 0; i < 100; i++ {
-		registry.lastUpdate = nil
-		controller.processCluster(0, cluster)
+		err := controller.refresh()
+		require.NoError(t, err)
 
-		require.EqualValues(t, math.Min(errorLimit, float64(i+1)), len(registry.lastUpdate.Status.Problems))
+		next := controller.clusterList.SelectNext()
+		require.NotNil(t, next)
+		controller.processCluster(0, next)
+
+		registry.theCluster.Status = registry.lastUpdate.Status
+		require.EqualValues(t, math.Min(errorLimit, float64(i+1)), len(registry.theCluster.Status.Problems))
 	}
 }

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -98,7 +98,7 @@ func NewClusterpyProvisioner(tokenSource oauth2.TokenSource, assumedRole string,
 
 // Version returns the version derived from a sha1 hash of the cluster struct
 // and the channel config version.
-func (p *clusterpyProvisioner) Version(cluster *api.Cluster, channelConfig *channel.Config) (string, error) {
+func (p *clusterpyProvisioner) Version(cluster *api.Cluster, channelVersion channel.ConfigVersion) (string, error) {
 	if cluster.Provider != providerID {
 		return "", ErrProviderNotSupported
 	}
@@ -200,7 +200,7 @@ func (p *clusterpyProvisioner) Version(cluster *api.Cluster, channelConfig *chan
 	}
 	sha := base64.RawURLEncoding.EncodeToString(hasher.Sum(nil))
 
-	return fmt.Sprintf(versionFmt, channelConfig.Version, sha), nil
+	return fmt.Sprintf(versionFmt, string(channelVersion), sha), nil
 }
 
 // Provision provisions/updates a cluster on AWS. Provision is an idempotent

--- a/provisioner/clusterpy_test.go
+++ b/provisioner/clusterpy_test.go
@@ -11,7 +11,6 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
-	"github.com/zalando-incubator/cluster-lifecycle-manager/channel"
 )
 
 func TestVersion(t *testing.T) {
@@ -50,18 +49,14 @@ func TestVersion(t *testing.T) {
 		},
 	}
 
-	channelConfig := &channel.Config{
-		Version: "git-commit-hash",
-	}
-
 	token := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "foo.bar.token"})
 	provisioner := NewClusterpyProvisioner(token, "", aws.NewConfig(), nil)
-	version, err := provisioner.Version(cluster, channelConfig)
+	version, err := provisioner.Version(cluster, "git-commit-hash")
 	if err != nil {
 		t.Errorf("should not fail: %v", err)
 	}
 
-	version2, err := provisioner.Version(cluster, channelConfig)
+	version2, err := provisioner.Version(cluster, "git-commit-hash")
 	if err != nil {
 		t.Errorf("should not fail: %v", err)
 	}

--- a/provisioner/clusterpy_test.go
+++ b/provisioner/clusterpy_test.go
@@ -7,64 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/stretchr/testify/assert"
-
-	"golang.org/x/oauth2"
-
-	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
 )
-
-func TestVersion(t *testing.T) {
-	cluster := &api.Cluster{
-		ID: "aws:123456789012:eu-central-1:kube-1",
-		InfrastructureAccount: "aws:123456789012",
-		LocalID:               "kube-1",
-		APIServerURL:          "https://kube-1.foo.example.org/",
-		Channel:               "alpha",
-		Environment:           "production",
-		CriticalityLevel:      1,
-		LifecycleStatus:       "ready",
-		Provider:              "zalando-aws",
-		Region:                "eu-central-1",
-		ConfigItems: map[string]string{
-			"product_x_key": "abcde",
-			"product_y_key": "12345",
-		},
-		NodePools: []*api.NodePool{
-			{
-				Name:             "master-default",
-				Profile:          "master/default",
-				InstanceType:     "m3.medium",
-				DiscountStrategy: "none",
-				MinSize:          2,
-				MaxSize:          2,
-			},
-			{
-				Name:             "worker-default",
-				Profile:          "worker/default",
-				InstanceType:     "r4.large",
-				DiscountStrategy: "none",
-				MinSize:          3,
-				MaxSize:          20,
-			},
-		},
-	}
-
-	token := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "foo.bar.token"})
-	provisioner := NewClusterpyProvisioner(token, "", aws.NewConfig(), nil)
-	version, err := provisioner.Version(cluster, "git-commit-hash")
-	if err != nil {
-		t.Errorf("should not fail: %v", err)
-	}
-
-	version2, err := provisioner.Version(cluster, "git-commit-hash")
-	if err != nil {
-		t.Errorf("should not fail: %v", err)
-	}
-
-	if version != version2 {
-		t.Errorf("expected version %s, got %s", version, version2)
-	}
-}
 
 func TestGetInfrastructureID(t *testing.T) {
 	expected := "12345678910"

--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -27,5 +27,4 @@ type Options struct {
 type Provisioner interface {
 	Provision(cluster *api.Cluster, channelConfig *channel.Config) error
 	Decommission(cluster *api.Cluster, channelConfig *channel.Config) error
-	Version(cluster *api.Cluster, channelVersion channel.ConfigVersion) (string, error)
 }

--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -27,5 +27,5 @@ type Options struct {
 type Provisioner interface {
 	Provision(cluster *api.Cluster, channelConfig *channel.Config) error
 	Decommission(cluster *api.Cluster, channelConfig *channel.Config) error
-	Version(cluster *api.Cluster, channelConfig *channel.Config) (string, error)
+	Version(cluster *api.Cluster, channelVersion channel.ConfigVersion) (string, error)
 }

--- a/provisioner/stdout.go
+++ b/provisioner/stdout.go
@@ -29,6 +29,6 @@ func (p *stdoutProvisioner) Decommission(cluster *api.Cluster, channelConfig *ch
 }
 
 // Version mocks geting the version based on cluster resource and channel config.
-func (p *stdoutProvisioner) Version(cluster *api.Cluster, channelConfig *channel.Config) (string, error) {
+func (p *stdoutProvisioner) Version(cluster *api.Cluster, channelVersion channel.ConfigVersion) (string, error) {
 	return "", nil
 }

--- a/provisioner/stdout.go
+++ b/provisioner/stdout.go
@@ -27,8 +27,3 @@ func (p *stdoutProvisioner) Decommission(cluster *api.Cluster, channelConfig *ch
 
 	return nil
 }
-
-// Version mocks geting the version based on cluster resource and channel config.
-func (p *stdoutProvisioner) Version(cluster *api.Cluster, channelVersion channel.ConfigVersion) (string, error) {
-	return "", nil
-}


### PR DESCRIPTION
Track the _current_ versions of channels for all active clusters, grouped by environment and channel. If a cluster's channel version changes, and we have an environment configured as a dependency, the
update is skipped unless all the clusters in the preceding environment use the new version. Note that this takes precedence even over the "already updating" case, otherwise we might get updates that shouldn't happen in rare cases.

A lot of controller code was refactored to support this. It will now determine during `refresh()` whether a cluster needs to be updated or not, and workers will not have to do a lot of useless work every iteration.

Fix #6.