### PR TITLE
Drop unsupported clusters early on

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -119,8 +119,21 @@ func (c *Controller) refresh() error {
 		return err
 	}
 
-	c.clusterList.UpdateAvailable(channels, clusters)
+	c.clusterList.UpdateAvailable(channels, c.dropUnsupported(clusters))
 	return nil
+}
+
+// dropUnsupported removes clusters not supported by the current provisioner
+func (c *Controller) dropUnsupported(clusters []*api.Cluster) []*api.Cluster {
+	result := make([]*api.Cluster, 0, len(clusters))
+	for _, cluster := range clusters {
+		if !c.provisioner.Supports(cluster) {
+			log.Debugf("Unsupported cluster: %s", cluster.ID)
+			continue
+		}
+		result = append(result, cluster)
+	}
+	return result
 }
 
 // doProcessCluster checks if an action needs to be taken depending on the

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -93,6 +93,10 @@ func NewClusterpyProvisioner(tokenSource oauth2.TokenSource, assumedRole string,
 	return provisioner
 }
 
+func (p *clusterpyProvisioner) Supports(cluster *api.Cluster) bool {
+	return cluster.Provider == providerID
+}
+
 // Provision provisions/updates a cluster on AWS. Provision is an idempotent
 // operation for the same input.
 func (p *clusterpyProvisioner) Provision(cluster *api.Cluster, channelConfig *channel.Config) error {

--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -25,6 +25,7 @@ type Options struct {
 // Provisioner is an interface describing how to provision or decommission
 // clusters.
 type Provisioner interface {
+	Supports(cluster *api.Cluster) bool
 	Provision(cluster *api.Cluster, channelConfig *channel.Config) error
 	Decommission(cluster *api.Cluster, channelConfig *channel.Config) error
 }

--- a/provisioner/stdout.go
+++ b/provisioner/stdout.go
@@ -14,6 +14,10 @@ func NewStdoutProvisioner() Provisioner {
 	return &stdoutProvisioner{}
 }
 
+func (p *stdoutProvisioner) Supports(cluster *api.Cluster) bool {
+	return true
+}
+
 // Provision mocks provisioning a cluster.
 func (p *stdoutProvisioner) Provision(cluster *api.Cluster, channelConfig *channel.Config) error {
 	log.Infof("stdout: Provisioning cluster %s.", cluster.ID)


### PR DESCRIPTION
Unsupported clusters should be completely ignored, otherwise CLM goes into an update loop (refresh -> find invalid status -> try to update -> bail out).