### PR TITLE
remove update command, add ARG instruction, change maintainer to label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 FROM registry.opensource.zalan.do/stups/alpine:latest
-MAINTAINER Team Teapot @ Zalando SE <team-teapot@zalando.de>
+LABEL maintainer="Team Teapot @ Zalando SE <team-teapot@zalando.de>"
+
+ARG K8S_VERSION=v1.9.5
 
 # install cluster.py dependencies
 # including kubectl
-RUN apk update && \
-    apk add python3 ca-certificates openssl git openssh-client && \
+RUN apk add --no-cache python3 ca-certificates openssl git openssh-client && \
     python3 -m ensurepip && \
     rm -r /usr/lib/python*/ensurepip && \
     pip3 install --upgrade stups-senza && \
-    wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.5/bin/linux/amd64/kubectl && \
+    wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$K8S_VERSION/bin/linux/amd64/kubectl && \
     chmod 755 /usr/local/bin/kubectl && \
     rm -rf /var/cache/apk/* /root/.cache /tmp/*
 


### PR DESCRIPTION
i changed maintainer to label since former is deprecated as of docker version 1.13
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

i added a variable for the kubernetes version 

i changed the apk update to `apk add --no-cache` since  IMHO you only want to install packages and not update your system with e.g. `apk upgrade`.

All the best,

Benjamin
