### PR TITLE
git: support SHA versions, add tests

### DIFF
--- a/channel/git_test.go
+++ b/channel/git_test.go
@@ -1,78 +1,110 @@
 package channel
 
 import (
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
+	"strings"
 	"testing"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+	"github.com/zalando-incubator/cluster-lifecycle-manager/pkg/util/command"
 )
 
 // helper function to setup a test repository.
 func createGitRepo(t *testing.T, dir string) {
 	err := os.MkdirAll(dir, 0755)
-	if err != nil {
-		t.Errorf("should not fail: %s", err)
+	require.NoError(t, err)
+
+	err = exec.Command("git", "-C", dir, "init").Run()
+	require.NoError(t, err)
+
+	commit := func(message string) {
+		cmd := exec.Command("git", "-C", dir, "commit", "-am", message)
+		cmd.Env = []string{
+			"GIT_AUTHOR_EMAIL=go-test",
+			"GIT_AUTHOR_NAME=go-test",
+			"GIT_COMMITTER_EMAIL=go-test",
+			"GIT_COMMITTER_NAME=go-test",
+		}
+		log.Printf("test")
+		err := command.Run(log.StandardLogger(), cmd)
+		require.NoError(t, err)
 	}
 
-	cmd := exec.Command("git", "-C", dir, "init")
-	err = cmd.Run()
-	if err != nil {
-		t.Errorf("should not fail: %s", err)
-	}
+	err = ioutil.WriteFile(path.Join(dir, "init_file"), []byte{}, 0644)
+	require.NoError(t, err)
 
-	f, err := os.Create(path.Join(dir, "init_file"))
-	if err != nil {
-		t.Errorf("should not fail: %s", err)
-	}
+	err = exec.Command("git", "-C", dir, "add", "init_file").Run()
+	require.NoError(t, err)
 
-	err = f.Close()
-	if err != nil {
-		t.Errorf("should not fail: %s", err)
-	}
+	commit("initial commit")
 
-	cmd = exec.Command("git", "-C", dir, "add", "init_file")
-	err = cmd.Run()
-	if err != nil {
-		t.Errorf("should not fail: %s", err)
-	}
+	err = exec.Command("git", "-C", dir, "checkout", "-b", "channel2").Run()
+	require.NoError(t, err)
 
-	cmd = exec.Command("git", "-C", dir, "commit", "-m", "init commit")
-	cmd.Env = []string{
-		"GIT_AUTHOR_EMAIL=go-test",
-		"GIT_AUTHOR_NAME=go-test",
-		"GIT_COMMITTER_EMAIL=go-test",
-		"GIT_COMMITTER_NAME=go-test",
-	}
-	err = cmd.Run()
-	if err != nil {
-		t.Errorf("should not fail: %s", err)
-	}
+	err = ioutil.WriteFile(path.Join(dir, "different_file"), []byte{}, 0644)
+	require.NoError(t, err)
+
+	err = exec.Command("git", "-C", dir, "add", "different_file").Run()
+	require.NoError(t, err)
+
+	commit("branch commit")
+}
+
+func checkout(t *testing.T, source ConfigSource, versions ConfigVersions, channel string) string {
+	version, err := versions.Version(channel)
+	require.NoError(t, err)
+
+	checkout, err := source.Get(version)
+	require.NoError(t, err)
+
+	return checkout.Path
+}
+
+func requireFile(t *testing.T, dir string, file string) {
+	_, err := os.Stat(path.Join(dir, file))
+	require.NoError(t, err)
+}
+
+func requireNoFile(t *testing.T, dir string, file string) {
+	_, err := os.Stat(path.Join(dir, file))
+	require.NotNil(t, err)
+	require.True(t, os.IsNotExist(err), "unexpected error: %v", err)
 }
 
 func TestGitGet(t *testing.T) {
 	workdir := "workdir_test"
 	tmpRepo := "tmp_test_repo.git"
-	channel := "master"
 	createGitRepo(t, tmpRepo)
 	defer os.RemoveAll(tmpRepo)
 
 	c, err := NewGit(workdir, tmpRepo, "")
 	require.NoError(t, err)
+	defer os.RemoveAll(workdir)
 
 	versions, err := c.Update()
 	require.NoError(t, err)
 
-	version, err := versions.Version(channel)
+	// check master channel
+	master := checkout(t, c, versions, "master")
+	requireFile(t, master, "init_file")
+	requireNoFile(t, master, "different_file")
+
+	// check another channel
+	channel2 := checkout(t, c, versions, "channel2")
+	requireFile(t, channel2, "init_file")
+	requireFile(t, channel2, "different_file")
+
+	// check sha
+	out, err := exec.Command("git", "-C", tmpRepo, "rev-parse", "master").Output()
 	require.NoError(t, err)
 
-	_, err = c.Get(version)
-	require.NoError(t, err)
-
-	// cleanup repo
-	err = os.RemoveAll(workdir)
-	require.NoError(t, err)
+	sha := checkout(t, c, versions, strings.TrimSpace(string(out)))
+	requireFile(t, sha, "init_file")
+	requireNoFile(t, sha, "different_file")
 }
 
 func TestGetRepoName(t *testing.T) {

--- a/controller/cluster_list_test.go
+++ b/controller/cluster_list_test.go
@@ -19,7 +19,7 @@ var mockStatus = &api.ClusterStatus{
 }
 
 var devRevision = channel.ConfigVersion("<dev-channel>")
-var defaultChannels = channel.NewStaticVersions(map[string]channel.ConfigVersion{
+var defaultChannels = channel.NewGitVersions(map[string]channel.ConfigVersion{
 	"dev": devRevision,
 })
 
@@ -275,7 +275,7 @@ func TestClusterEnvOrder(t *testing.T) {
 	status := &api.ClusterStatus{
 		CurrentVersion: "abc123#test",
 	}
-	channels := channel.NewStaticVersions(map[string]channel.ConfigVersion{"dev": "def456"})
+	channels := channel.NewGitVersions(map[string]channel.ConfigVersion{"dev": "def456"})
 
 	test1 := &api.Cluster{
 		ID: "aws:123456789011:eu-central-1:test1",

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -94,7 +94,7 @@ type mockChannelSource struct {
 
 func MockChannelSource(configVersions map[string]channel.ConfigVersion, failGet bool) channel.ConfigSource {
 	return &mockChannelSource{
-		configVersions: channel.NewStaticVersions(configVersions),
+		configVersions: channel.NewGitVersions(configVersions),
 		failGet:        failGet,
 	}
 }


### PR DESCRIPTION
- Add support for SHA checkouts for git config source (these are used in tests)
- Add tests for both checkout modes