### PR TITLE
Remove Outputs field from Cluster struct (was a hack)

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -26,7 +26,6 @@ type Cluster struct {
 	Provider              string            `json:"provider"               yaml:"provider"`
 	Region                string            `json:"region"                 yaml:"region"`
 	Status                *ClusterStatus    `json:"status"                 yaml:"status"`
-	Outputs               map[string]string `json:"outputs"                yaml:"outputs"`
 	Owner                 string            `json:"owner"                  yaml:"owner"`
 }
 

--- a/api/cluster_test.go
+++ b/api/cluster_test.go
@@ -68,7 +68,6 @@ func sampleCluster() *Cluster {
 			"product_x_key": "abcde",
 			"product_y_key": "12345",
 		},
-		Outputs: map[string]string{},
 		NodePools: []*NodePool{
 			{
 				Name:             "master-default",
@@ -101,7 +100,7 @@ func TestVersion(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, field := range fields {
-		if field == "Alias" || field == "NodePools" || field == "Outputs" || field == "Owner" || field == "Status" {
+		if field == "Alias" || field == "NodePools" || field == "Owner" || field == "Status" {
 			continue
 		}
 

--- a/provisioner/aws_test.go
+++ b/provisioner/aws_test.go
@@ -136,7 +136,7 @@ func testWaitForStackWithComplete(t *testing.T) {
 	awsMock := newAWSAdapterWithStubs(cloudformation.StackStatusCreateComplete, "123")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	_, err := awsMock.waitForStack(ctx, 100*time.Millisecond, "foobar")
+	err := awsMock.waitForStack(ctx, 100*time.Millisecond, "foobar")
 	if err != nil {
 		t.Error(err)
 	}
@@ -160,7 +160,7 @@ func testWaitForStackWithTimeout(t *testing.T) {
 			}
 		}
 	}()
-	_, err := awsMock.waitForStack(ctx, 100*time.Millisecond, "foobar")
+	err := awsMock.waitForStack(ctx, 100*time.Millisecond, "foobar")
 	if err != errTimeoutExceeded {
 		t.Errorf("should return timeout exceeded, got: %v", err)
 	}
@@ -190,7 +190,7 @@ func testWaitForStackWithRollback(t *testing.T) {
 		}
 	}()
 
-	_, err := awsMock.waitForStack(ctx, 100*time.Millisecond, "foobar")
+	err := awsMock.waitForStack(ctx, 100*time.Millisecond, "foobar")
 	if err != errRollbackComplete {
 		t.Errorf("should return rollback complete, got: %v", err)
 	}

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -144,11 +144,10 @@ func (p *clusterpyProvisioner) Provision(cluster *api.Cluster, channelConfig *ch
 		}
 	}
 
-	out, err := awsAdapter.CreateOrUpdateClusterStack(cluster.LocalID, stackDefinitionPath, cluster)
+	err = awsAdapter.CreateOrUpdateClusterStack(cluster.LocalID, stackDefinitionPath, cluster)
 	if err != nil {
 		return err
 	}
-	cluster.Outputs = out
 
 	cfgBaseDir := path.Join(channelConfig.Path, "cluster", "node-pools")
 

--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -200,7 +200,7 @@ func (p *AWSNodePoolProvisioner) provisionNodePool(nodePool *api.NodePool, value
 
 	ctx, cancel := context.WithTimeout(context.Background(), maxWaitTimeout)
 	defer cancel()
-	_, err = p.awsAdapter.waitForStack(ctx, waitTime, stackName)
+	err = p.awsAdapter.waitForStack(ctx, waitTime, stackName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Removes a hack that was put in place when cloudformation didn't support
static naming of ASG lifecycle hooks. Now we don't need it anymore.

The need for this was removed with: https://github.com/zalando-incubator/kubernetes-on-aws/pull/991