### PR TITLE
Allow updates if we don't depend on any clusters

### DIFF
--- a/controller/channel_versions.go
+++ b/controller/channel_versions.go
@@ -25,7 +25,8 @@ func (cv usedVersions) addCluster(clusterInfo *ClusterInfo) {
 	}
 }
 
-// fullyUpdated returns true if all clusters with the provided environment and channel use the provided version
+// fullyUpdated returns true if all clusters with the provided environment and channel use the provided version, or
+// if there's no matching clusters
 func (cv usedVersions) fullyUpdated(environment, channel string, version channel.ConfigVersion) bool {
 	key := versionKey{environment: environment, channel: channel}
 	if versions, ok := cv[key]; ok {

--- a/controller/channel_versions.go
+++ b/controller/channel_versions.go
@@ -36,6 +36,6 @@ func (cv usedVersions) fullyUpdated(environment, channel string, version channel
 		_, used := versions[version]
 		return used
 	} else {
-		return false
+		return true
 	}
 }

--- a/controller/cluster_list_test.go
+++ b/controller/cluster_list_test.go
@@ -332,6 +332,9 @@ func TestClusterEnvOrder(t *testing.T) {
 	// ignore prod: some test clusters have invalid statuses
 	assert.NotContains(t, pendingUpdates(test1, test3, prod), prod.ID)
 
+	// allow prod: no clusters in test environment
+	assert.Contains(t, pendingUpdates(staging, prod), prod.ID)
+
 	// other environments should work fine
 	assert.Contains(t, pendingUpdates(test1, test3, staging), staging.ID)
 }


### PR DESCRIPTION
We have one channel that only has a production cluster, and currently it's blocked.