### PR TITLE
Read configuration defaults from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,34 @@ the `name` will be used. If none of them are defined, it's an error.
 
 `kind` must be one of the kinds defined in `kubectl get`.
 
+## Configuration defaults
+
+CLM will look for a `config-defaults.yaml` file in the cluster configuration
+directory. If the file exists, it will be evaluated as a Go template with all
+the usual CLM variables and functions available, and the resulting output will
+be parsed as a simple key-value map. CLM will use the contents of the file to
+populate the cluster's configuration items, taking care not to overwrite the
+existing ones.
+
+For example, you can use the defaults file to have different settings for
+production and test clusters, while keeping the manifests readable:
+
+* **config-defaults.yaml**:
+    ```yaml
+    {{ if eq .Environment "production"}}
+    autoscaling_buffer_pods: "3"
+    {{else}}
+    autoscaling_buffer_pods: "0"
+    {{end}}
+    ```
+
+* **manifests/example/example.yaml**:
+    ```yaml
+    …
+    spec:
+      replicas: {{.ConfigItems.autoscaling_buffer_pods}}
+    …
+    ```
 
 ## Non-disruptive rolling updates
 

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -44,6 +44,7 @@ const (
 	providerID                          = "zalando-aws"
 	manifestsPath                       = "cluster/manifests"
 	deletionsFile                       = "deletions.yaml"
+	defaultsFile                        = "cluster/config-defaults.yaml"
 	defaultNamespace                    = "default"
 	kubectlNotFound                     = "(NotFound)"
 	tagNameKubernetesClusterPrefix      = "kubernetes.io/cluster/"
@@ -98,7 +99,7 @@ func (p *clusterpyProvisioner) Supports(cluster *api.Cluster) bool {
 }
 
 func (p *clusterpyProvisioner) updateDefaults(cluster *api.Cluster, channelConfig *channel.Config) error {
-	defaultsFile := path.Join(channelConfig.Path, "cluster", "config-defaults.yaml")
+	defaultsFile := path.Join(channelConfig.Path, defaultsFile)
 
 	withoutConfigItems := *cluster
 	withoutConfigItems.ConfigItems = make(map[string]string)
@@ -118,8 +119,8 @@ func (p *clusterpyProvisioner) updateDefaults(cluster *api.Cluster, channelConfi
 	}
 
 	for k, v := range defaults {
-		_, exists := cluster.ConfigItems[k]
-		if !exists {
+		_, ok := cluster.ConfigItems[k]
+		if !ok {
 			cluster.ConfigItems[k] = v
 		}
 	}


### PR DESCRIPTION
Check if `cluster/config-defaults.yaml` exists as the first step during provisioning. If it's there, evaluate it as a Go template with a cluster definition stripped of config items, parse it as a YAML file that's expected to be a simple string->string map, and set all missing config items to the values from the parsed map.

This has multiple benefits:
 - the defaults are in one place, even if they're used in multiple templates (could even use this for e.g. specifying hyperkube image)
 - the template is a bit cleaner because we don't have the same stupid `if index ...` everywhere