### PR TITLE
Extract templating

### DIFF
--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -1,20 +1,15 @@
 package provisioner
 
 import (
-	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
 	"path"
-	"path/filepath"
 	"sort"
 	"strings"
-	"text/template"
 	"time"
 	"unicode"
 
@@ -68,12 +63,6 @@ type clusterpyProvisioner struct {
 	applyOnly      bool
 	updateStrategy config.UpdateStrategy
 	removeVolumes  bool
-}
-
-type applyContext struct {
-	manifestData          map[string]string
-	baseDir               string
-	computingManifestHash bool
 }
 
 // NewClusterpyProvisioner returns a new ClusterPy provisioner by passing its location and and IAM role to use.
@@ -881,13 +870,6 @@ func parseDeletions(manifestsPath string) (*deletions, error) {
 	return &deletions, nil
 }
 
-func newApplyContext(baseDir string) *applyContext {
-	return &applyContext{
-		baseDir:      baseDir,
-		manifestData: make(map[string]string),
-	}
-}
-
 // apply calls kubectl apply for all the manifests in manifestsPath.
 func (p *clusterpyProvisioner) apply(logger *log.Entry, cluster *api.Cluster, manifestsPath string) error {
 	logger.Debugf("Checking for deletions.yaml")
@@ -995,87 +977,6 @@ func (p *clusterpyProvisioner) apply(logger *log.Entry, cluster *api.Cluster, ma
 	}
 
 	return nil
-}
-
-// getAWSAccountID is an utility function for the gotemplate that will remove
-// the prefix "aws" from the infrastructure ID.
-// TODO: get the real AWS account ID from the `external_id` field of the
-// infrastructure account in the cluster registry.
-func getAWSAccountID(ia string) string {
-	return strings.Split(ia, ":")[1]
-}
-
-// base64Encode base64 encodes a string.
-func base64Encode(value string) string {
-	return base64.StdEncoding.EncodeToString([]byte(value))
-}
-
-func (context *applyContext) resetComputingManifestHash() {
-	context.computingManifestHash = false
-}
-
-// manifestHash is a function for the templates that will return a hash of an interpolated sibling template
-// file. returns an error if computing manifestHash calls manifestHash again, if interpolation of that template
-// returns an error, or if the path is outside of the manifests folder.
-func manifestHash(context *applyContext, file string, template string, cluster *api.Cluster) (string, error) {
-	if context.computingManifestHash {
-		return "", fmt.Errorf("manifestHash is not reentrant")
-	}
-	context.computingManifestHash = true
-	defer context.resetComputingManifestHash()
-
-	templateFile, err := filepath.Abs(path.Clean(path.Join(path.Dir(file), template)))
-	if err != nil {
-		return "", err
-	}
-
-	if !strings.HasPrefix(templateFile, context.baseDir) {
-		return "", fmt.Errorf("invalid template path: %s", templateFile)
-	}
-
-	templateData, ok := context.manifestData[templateFile]
-	if !ok {
-		applied, err := applyTemplate(context, templateFile, cluster)
-		if err != nil {
-			return "", err
-		}
-		templateData = applied
-	}
-
-	return fmt.Sprintf("%x", sha256.Sum256([]byte(templateData))), nil
-}
-
-// applyTemplate takes a fileName of a template and the model to apply to it.
-// returns the transformed template or an error if not successful
-func applyTemplate(context *applyContext, file string, cluster *api.Cluster) (string, error) {
-	funcMap := template.FuncMap{
-		"getAWSAccountID": getAWSAccountID,
-		"base64":          base64Encode,
-		"manifestHash":    func(template string) (string, error) { return manifestHash(context, file, template, cluster) },
-	}
-
-	f, err := os.Open(file)
-	if err != nil {
-		return "", err
-	}
-	content, err := ioutil.ReadFile(f.Name())
-	if err != nil {
-		return "", err
-	}
-	t, err := template.New(f.Name()).Option("missingkey=error").Funcs(funcMap).Parse(string(content))
-	if err != nil {
-		return "", err
-	}
-	var out bytes.Buffer
-	err = t.Execute(&out, cluster)
-	if err != nil {
-		return "", err
-	}
-
-	templateData := out.String()
-	context.manifestData[file] = templateData
-
-	return templateData, nil
 }
 
 func stripWhitespace(content string) string {

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -93,7 +93,7 @@ func (p *clusterpyProvisioner) updateDefaults(cluster *api.Cluster, channelConfi
 	withoutConfigItems := *cluster
 	withoutConfigItems.ConfigItems = make(map[string]string)
 
-	result, err := applyTemplate(newApplyContext(channelConfig.Path), defaultsFile, &withoutConfigItems)
+	result, err := renderTemplate(newTemplateContext(channelConfig.Path), defaultsFile, &withoutConfigItems)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -901,7 +901,7 @@ func (p *clusterpyProvisioner) apply(logger *log.Entry, cluster *api.Cluster, ma
 		return errors.Wrapf(err, "no valid token")
 	}
 
-	applyContext := newApplyContext(manifestsPath)
+	applyContext := newTemplateContext(manifestsPath)
 
 	for _, c := range components {
 		// skip deletions.yaml if found
@@ -927,7 +927,7 @@ func (p *clusterpyProvisioner) apply(logger *log.Entry, cluster *api.Cluster, ma
 			allowFailure := f.Name() == "credentials.yaml"
 
 			file := path.Join(componentFolder, f.Name())
-			manifest, err := applyTemplate(applyContext, file, cluster)
+			manifest, err := renderTemplate(applyContext, file, cluster)
 			if err != nil {
 				logger.Errorf("Error applying template %v", err)
 			}

--- a/provisioner/kubesystem_test.go
+++ b/provisioner/kubesystem_test.go
@@ -67,13 +67,13 @@ func TestApplyTemplate(t *testing.T) {
 
 	cdir, err := os.Getwd()
 	require.NoError(t, err)
-	context := newApplyContext(cdir)
+	context := newTemplateContext(cdir)
 
 	region := "eu-central"
 	localID := "kube-aws-test-rdifazio55"
 	cluster := &api.Cluster{Region: region, LocalID: localID}
 
-	s, err := applyTemplate(context, "test_template", cluster)
+	s, err := renderTemplate(context, "test_template", cluster)
 	if err == nil {
 		t.Errorf("should fail, mate hosted zone configitems are not passed!")
 	}
@@ -81,7 +81,7 @@ func TestApplyTemplate(t *testing.T) {
 	cluster.ConfigItems = map[string]string{
 		"mate_hosted_zone": "hosted-zone",
 	}
-	s, err = applyTemplate(context, "test_template", cluster)
+	s, err = renderTemplate(context, "test_template", cluster)
 	if err != nil {
 		t.Errorf("should not fail %v", err)
 	}
@@ -128,7 +128,7 @@ func TestApplyTemplateBase64Fun(t *testing.T) {
 
 	cdir, err := os.Getwd()
 	require.NoError(t, err)
-	context := newApplyContext(cdir)
+	context := newTemplateContext(cdir)
 
 	value := "value"
 
@@ -136,7 +136,7 @@ func TestApplyTemplateBase64Fun(t *testing.T) {
 	cluster.ConfigItems = map[string]string{
 		"my_value": value,
 	}
-	s, err := applyTemplate(context, "test_template", cluster)
+	s, err := renderTemplate(context, "test_template", cluster)
 	if err != nil {
 		t.Errorf("should not fail %v", err)
 	}

--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -92,7 +92,7 @@ func (p *AWSNodePoolProvisioner) generateNodePoolStackTemplate(nodePool *api.Nod
 	}
 
 	stackFilePath := path.Join(nodePoolProfilesPath, stackFileName)
-	return applyTemplate(newApplyContext(nodePoolProfilesPath), stackFilePath, params)
+	return renderTemplate(newTemplateContext(nodePoolProfilesPath), stackFilePath, params)
 }
 
 // Provision provisions node pools of the cluster.
@@ -248,7 +248,7 @@ func (p *AWSNodePoolProvisioner) Reconcile(ctx context.Context) error {
 // and uploading the User Data to S3. A EC2 UserData ready base64 string will
 // be returned.
 func (p *AWSNodePoolProvisioner) prepareUserData(basedir, clcPath string, config interface{}) (string, error) {
-	rendered, err := applyTemplate(newApplyContext(basedir), clcPath, config)
+	rendered, err := renderTemplate(newTemplateContext(basedir), clcPath, config)
 	if err != nil {
 		return "", err
 	}

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -16,6 +16,7 @@ type applyContext struct {
 	manifestData          map[string]string
 	baseDir               string
 	computingManifestHash bool
+	readTemplate          func(string) ([]byte, error)
 }
 
 func newApplyContext(baseDir string) *applyContext {

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -1,0 +1,106 @@
+package provisioner
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+type applyContext struct {
+	manifestData          map[string]string
+	baseDir               string
+	computingManifestHash bool
+}
+
+func newApplyContext(baseDir string) *applyContext {
+	return &applyContext{
+		baseDir:      baseDir,
+		manifestData: make(map[string]string),
+	}
+}
+
+// applyTemplate takes a fileName of a template and the model to apply to it.
+// returns the transformed template or an error if not successful
+func applyTemplate(context *applyContext, filePath string, data interface{}) (string, error) {
+	funcMap := template.FuncMap{
+		"getAWSAccountID": getAWSAccountID,
+		"base64":          base64Encode,
+		"manifestHash":    func(template string) (string, error) { return manifestHash(context, filePath, template, data) },
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	content, err := ioutil.ReadFile(f.Name())
+	if err != nil {
+		return "", err
+	}
+	t, err := template.New(f.Name()).Option("missingkey=error").Funcs(funcMap).Parse(string(content))
+	if err != nil {
+		return "", err
+	}
+	var out bytes.Buffer
+	err = t.Execute(&out, data)
+	if err != nil {
+		return "", err
+	}
+
+	templateData := out.String()
+	context.manifestData[filePath] = templateData
+
+	return templateData, nil
+}
+
+// manifestHash is a function for the templates that will return a hash of an interpolated sibling template
+// file. returns an error if computing manifestHash calls manifestHash again, if interpolation of that template
+// returns an error, or if the path is outside of the manifests folder.
+func manifestHash(context *applyContext, file string, template string, data interface{}) (string, error) {
+	if context.computingManifestHash {
+		return "", fmt.Errorf("manifestHash is not reentrant")
+	}
+	context.computingManifestHash = true
+	defer func() {
+		context.computingManifestHash = false
+	}()
+
+	templateFile, err := filepath.Abs(path.Clean(path.Join(path.Dir(file), template)))
+	if err != nil {
+		return "", err
+	}
+
+	if !strings.HasPrefix(templateFile, context.baseDir) {
+		return "", fmt.Errorf("invalid template path: %s", templateFile)
+	}
+
+	templateData, ok := context.manifestData[templateFile]
+	if !ok {
+		applied, err := applyTemplate(context, templateFile, data)
+		if err != nil {
+			return "", err
+		}
+		templateData = applied
+	}
+
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(templateData))), nil
+}
+
+// getAWSAccountID is an utility function for the gotemplate that will remove
+// the prefix "aws" from the infrastructure ID.
+// TODO: get the real AWS account ID from the `external_id` field of the
+// infrastructure account in the cluster registry.
+func getAWSAccountID(ia string) string {
+	return strings.Split(ia, ":")[1]
+}
+
+// base64Encode base64 encodes a string.
+func base64Encode(value string) string {
+	return base64.StdEncoding.EncodeToString([]byte(value))
+}

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -35,15 +34,11 @@ func applyTemplate(context *applyContext, filePath string, data interface{}) (st
 		"manifestHash":    func(template string) (string, error) { return manifestHash(context, filePath, template, data) },
 	}
 
-	f, err := os.Open(filePath)
+	content, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		return "", err
 	}
-	content, err := ioutil.ReadFile(f.Name())
-	if err != nil {
-		return "", err
-	}
-	t, err := template.New(f.Name()).Option("missingkey=error").Funcs(funcMap).Parse(string(content))
+	t, err := template.New(filePath).Option("missingkey=error").Funcs(funcMap).Parse(string(content))
 	if err != nil {
 		return "", err
 	}

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -1,0 +1,89 @@
+package provisioner
+
+import (
+	"github.com/stretchr/testify/require"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+func ApplyTemplate(t *testing.T, templates map[string]string, templateName string, data interface{}) (string, error) {
+	basedir, err := ioutil.TempDir(os.TempDir(), t.Name())
+	require.NoError(t, err, "unable to create temp dir")
+
+	defer os.RemoveAll(basedir)
+
+	for name, content := range templates {
+		fullPath := path.Join(basedir, name)
+		parentDir := path.Dir(fullPath)
+		err := os.MkdirAll(parentDir, 0755)
+		require.NoError(t, err, "error while creating %s", parentDir)
+		err = ioutil.WriteFile(fullPath, []byte(content), 0644)
+		require.NoError(t, err, "error while writing %s", fullPath)
+	}
+
+	context := newApplyContext(basedir)
+	return applyTemplate(context, path.Join(basedir, templateName), data)
+}
+
+func TestTemplating(t *testing.T) {
+	result, err := ApplyTemplate(
+		t,
+		map[string]string{"dir/foo.yaml": "foo {{ . }}"},
+		"dir/foo.yaml",
+		"1")
+
+	require.NoError(t, err)
+	require.EqualValues(t, "foo 1", result)
+}
+
+func TestBase64(t *testing.T) {
+	result, err := ApplyTemplate(
+		t,
+		map[string]string{"dir/foo.yaml": "{{ . | base64 }}"},
+		"dir/foo.yaml",
+		"abc123")
+
+	require.NoError(t, err)
+	require.EqualValues(t, "YWJjMTIz", result)
+}
+
+func TestManifestHash(t *testing.T) {
+	result, err := ApplyTemplate(
+		t,
+		map[string]string{
+			"dir/config.yaml": "foo {{ . }}",
+			"dir/foo.yaml":    `{{ manifestHash "config.yaml" }}`,
+		},
+		"dir/foo.yaml",
+		"abc123")
+
+	require.NoError(t, err)
+	require.EqualValues(t, "82b883f3662dfed3357ba6c497a77684b1d84468c6aa49bf89c4f209889ddc77", result)
+}
+
+func TestManifestHashMissingFile(t *testing.T) {
+	_, err := ApplyTemplate(
+		t,
+		map[string]string{
+			"dir/foo.yaml": `{{ manifestHash "missing.yaml" }}`,
+		},
+		"dir/foo.yaml",
+		"abc123")
+
+	require.Error(t, err)
+}
+
+func TestManifestHashRecursiveInclude(t *testing.T) {
+	_, err := ApplyTemplate(
+		t,
+		map[string]string{
+			"dir/config.yaml": `{{ manifestHash "foo.yaml" }}`,
+			"dir/foo.yaml":    `{{ manifestHash "config.yaml" }}`,
+		},
+		"dir/foo.yaml",
+		"abc123")
+
+	require.Error(t, err)
+}

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func ApplyTemplate(t *testing.T, templates map[string]string, templateName string, data interface{}) (string, error) {
+func render(t *testing.T, templates map[string]string, templateName string, data interface{}) (string, error) {
 	basedir, err := ioutil.TempDir(os.TempDir(), t.Name())
 	require.NoError(t, err, "unable to create temp dir")
 
@@ -23,12 +23,12 @@ func ApplyTemplate(t *testing.T, templates map[string]string, templateName strin
 		require.NoError(t, err, "error while writing %s", fullPath)
 	}
 
-	context := newApplyContext(basedir)
-	return applyTemplate(context, path.Join(basedir, templateName), data)
+	context := newTemplateContext(basedir)
+	return renderTemplate(context, path.Join(basedir, templateName), data)
 }
 
 func TestTemplating(t *testing.T) {
-	result, err := ApplyTemplate(
+	result, err := render(
 		t,
 		map[string]string{"dir/foo.yaml": "foo {{ . }}"},
 		"dir/foo.yaml",
@@ -39,7 +39,7 @@ func TestTemplating(t *testing.T) {
 }
 
 func TestBase64(t *testing.T) {
-	result, err := ApplyTemplate(
+	result, err := render(
 		t,
 		map[string]string{"dir/foo.yaml": "{{ . | base64 }}"},
 		"dir/foo.yaml",
@@ -50,7 +50,7 @@ func TestBase64(t *testing.T) {
 }
 
 func TestManifestHash(t *testing.T) {
-	result, err := ApplyTemplate(
+	result, err := render(
 		t,
 		map[string]string{
 			"dir/config.yaml": "foo {{ . }}",
@@ -64,7 +64,7 @@ func TestManifestHash(t *testing.T) {
 }
 
 func TestManifestHashMissingFile(t *testing.T) {
-	_, err := ApplyTemplate(
+	_, err := render(
 		t,
 		map[string]string{
 			"dir/foo.yaml": `{{ manifestHash "missing.yaml" }}`,
@@ -76,7 +76,7 @@ func TestManifestHashMissingFile(t *testing.T) {
 }
 
 func TestManifestHashRecursiveInclude(t *testing.T) {
-	_, err := ApplyTemplate(
+	_, err := render(
 		t,
 		map[string]string{
 			"dir/config.yaml": `{{ manifestHash "foo.yaml" }}`,


### PR DESCRIPTION
- Use the same templating code for manifests and node pool data
- Add basic tests
- Remove a useless os.Open