### PR TITLE
Add autoscalingBufferSettings template function

### DIFF
--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -334,9 +334,9 @@ func (a *awsAdapter) CreateOrUpdateClusterStack(parentCtx context.Context, stack
 		case discountStrategyNone:
 			break
 		case discountStrategySpotMaxPrice:
-			instanceInfo, ok := awsExt.InstanceInfo()[workerPool.InstanceType]
-			if !ok {
-				return fmt.Errorf("unknown instance type %s", workerPool.InstanceType)
+			instanceInfo, err := awsExt.InstanceInfo(workerPool.InstanceType)
+			if err != nil {
+				return err
 			}
 
 			onDemandPrice, ok := instanceInfo.Pricing[cluster.Region]

--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -143,9 +143,9 @@ func (p *AWSNodePoolProvisioner) provisionNodePool(nodePool *api.NodePool, value
 	case discountStrategyNone:
 		break
 	case discountStrategySpotMaxPrice:
-		instanceInfo, ok := awsExt.InstanceInfo()[nodePool.InstanceType]
-		if !ok {
-			return fmt.Errorf("unknown instance type %s", nodePool.InstanceType)
+		instanceInfo, err := awsExt.InstanceInfo(nodePool.InstanceType)
+		if err != nil {
+			return err
 		}
 
 		onDemandPrice, ok := instanceInfo.Pricing[p.Cluster.Region]

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -5,11 +5,24 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
+	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
+	"github.com/zalando-incubator/cluster-lifecycle-manager/pkg/aws"
 	"io/ioutil"
+	"math"
 	"path"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"text/template"
+)
+
+const (
+	autoscalingBufferExplicitCPUConfigItem    = "autoscaling_buffer_cpu"
+	autoscalingBufferExplicitMemoryConfigItem = "autoscaling_buffer_memory"
+	autoscalingBufferCPUScaleConfigItem       = "autoscaling_buffer_cpu_scale"
+	autoscalingBufferMemoryScaleConfigItem    = "autoscaling_buffer_memory_scale"
+	autoscalingBufferPoolsConfigItem          = "autoscaling_buffer_pools"
 )
 
 type templateContext struct {
@@ -19,6 +32,11 @@ type templateContext struct {
 	readTemplate          func(string) ([]byte, error)
 }
 
+type podResources struct {
+	CPU    string
+	Memory string
+}
+
 func newTemplateContext(baseDir string) *templateContext {
 	return &templateContext{
 		baseDir:      baseDir,
@@ -26,13 +44,110 @@ func newTemplateContext(baseDir string) *templateContext {
 	}
 }
 
+func requiredConfigItem(cluster *api.Cluster, configItem string) (string, error) {
+	result, ok := cluster.ConfigItems[configItem]
+	if !ok {
+		return "", fmt.Errorf("missing config item: %s", configItem)
+	}
+	return result, nil
+}
+
+func requiredFloatConfigItem(cluster *api.Cluster, configItem string) (float64, error) {
+	strValue, err := requiredConfigItem(cluster, configItem)
+	if err != nil {
+		return math.NaN(), err
+	}
+	result, err := strconv.ParseFloat(strValue, 64)
+	if err != nil {
+		return math.NaN(), fmt.Errorf("unable to parse %s: %v", configItem, err)
+	}
+	return result, nil
+}
+
+// matchingPools returns all node pools whose names patch poolNameRegex
+func matchingPools(cluster *api.Cluster, poolNameRegex string) ([]*api.NodePool, error) {
+	nameRegex, err := regexp.Compile(poolNameRegex)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []*api.NodePool
+	for _, pool := range cluster.NodePools {
+		if nameRegex.FindStringIndex(pool.Name) != nil {
+			result = append(result, pool)
+		}
+	}
+	return result, nil
+}
+
+// autoscalingBufferSettings returns the CPU and memory resources for the autoscaling buffer pods based on various
+// config items. If autoscaling_buffer_cpu and autoscaling_buffer_memory are set, the values are used directly,
+// otherwise it finds the largest instance type from the node pools matching autoscaling_buffer_pools and scales
+// it using autoscaling_buffer_cpu_scale and autoscaling_buffer_memory_scale
+func autoscalingBufferSettings(cluster *api.Cluster) (*podResources, error) {
+	explicitCPU, haveExplicitCPU := cluster.ConfigItems[autoscalingBufferExplicitCPUConfigItem]
+	explicitMemory, haveExplicitMemory := cluster.ConfigItems[autoscalingBufferExplicitMemoryConfigItem]
+
+	if haveExplicitCPU && haveExplicitMemory {
+		return &podResources{CPU: explicitCPU, Memory: explicitMemory}, nil
+	} else if haveExplicitCPU || haveExplicitMemory {
+		// avoid issues if the user overrides the CPU and then the resulting pod can't fit after node pool change
+		return nil, fmt.Errorf("autoscaling_buffer_cpu/autoscaling_buffer_memory must be used together or not at all")
+	}
+
+	poolNameRegex, err := requiredConfigItem(cluster, autoscalingBufferPoolsConfigItem)
+	if err != nil {
+		return nil, err
+	}
+	cpuScale, err := requiredFloatConfigItem(cluster, autoscalingBufferCPUScaleConfigItem)
+	if err != nil {
+		return nil, err
+	}
+	memoryScale, err := requiredFloatConfigItem(cluster, autoscalingBufferMemoryScaleConfigItem)
+	if err != nil {
+		return nil, err
+	}
+
+	pools, err := matchingPools(cluster, poolNameRegex)
+	if err != nil {
+		return nil, err
+	}
+	if len(pools) == 0 {
+		return nil, fmt.Errorf("no pools matching %s", poolNameRegex)
+	}
+
+	currentLargestInstance := aws.Instance{}
+
+	for _, pool := range pools {
+		instanceInfo, err := aws.InstanceInfo(pool.InstanceType)
+		if err != nil {
+			return nil, err
+		}
+
+		if instanceInfo.VCPU > currentLargestInstance.VCPU && instanceInfo.Memory > currentLargestInstance.Memory {
+			currentLargestInstance = instanceInfo
+		} else if instanceInfo.VCPU <= currentLargestInstance.VCPU && instanceInfo.Memory <= currentLargestInstance.Memory {
+			// do nothing
+		} else {
+			return nil, fmt.Errorf("unable to select autoscaling buffer settings, conflicting instance types %s and %s", currentLargestInstance.InstanceType, instanceInfo.InstanceType)
+		}
+	}
+
+	result := &podResources{
+		CPU:    fmt.Sprintf("%.0fm", math.Floor(float64(currentLargestInstance.VCPU)*cpuScale*1000)),
+		Memory: fmt.Sprintf("%.0fMi", math.Floor(float64(currentLargestInstance.Memory)*memoryScale/1024/1024)),
+	}
+	return result, nil
+}
+
 // renderTemplate takes a fileName of a template and the model to apply to it.
 // returns the transformed template or an error if not successful
 func renderTemplate(context *templateContext, filePath string, data interface{}) (string, error) {
 	funcMap := template.FuncMap{
-		"getAWSAccountID": getAWSAccountID,
-		"base64":          base64Encode,
-		"manifestHash":    func(template string) (string, error) { return manifestHash(context, filePath, template, data) },
+		"getAWSAccountID":           getAWSAccountID,
+		"base64":                    base64Encode,
+		"manifestHash":              func(template string) (string, error) { return manifestHash(context, filePath, template, data) },
+		"autoscalingBufferSettings": autoscalingBufferSettings,
 	}
 
 	content, err := ioutil.ReadFile(filePath)

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -1,12 +1,25 @@
 package provisioner
 
 import (
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
 )
+
+func exampleCluster(pools []*api.NodePool) *api.Cluster {
+	return &api.Cluster{
+		ConfigItems: map[string]string{
+			"autoscaling_buffer_pools":        "worker",
+			"autoscaling_buffer_cpu_scale":    "0.8",
+			"autoscaling_buffer_memory_scale": "0.8",
+		},
+		NodePools: pools,
+	}
+}
 
 func render(t *testing.T, templates map[string]string, templateName string, data interface{}) (string, error) {
 	basedir, err := ioutil.TempDir(os.TempDir(), t.Name())
@@ -86,4 +99,140 @@ func TestManifestHashRecursiveInclude(t *testing.T) {
 		"abc123")
 
 	require.Error(t, err)
+}
+
+func renderAutoscaling(t *testing.T, cluster *api.Cluster) (string, error) {
+	return render(
+		t,
+		map[string]string{
+			"foo.yaml": `{{ with autoscalingBufferSettings . }}{{.CPU}} {{.Memory}}{{end}}`,
+		},
+		"foo.yaml",
+		cluster)
+}
+
+func TestAutoscalingBufferExplicit(t *testing.T) {
+	cluster := exampleCluster([]*api.NodePool{})
+	cluster.ConfigItems["autoscaling_buffer_cpu"] = "111m"
+	cluster.ConfigItems["autoscaling_buffer_memory"] = "1500Mi"
+
+	result, err := renderAutoscaling(t, cluster)
+
+	require.NoError(t, err)
+	require.EqualValues(t, "111m 1500Mi", result)
+}
+
+func TestAutoscalingBufferExplicitOnlyOne(t *testing.T) {
+	cluster := exampleCluster([]*api.NodePool{})
+	cluster.ConfigItems["autoscaling_buffer_cpu"] = "111m"
+
+	_, err := renderAutoscaling(t, cluster)
+	require.Error(t, err)
+
+	delete(cluster.ConfigItems, "autoscaling_buffer_cpu")
+	cluster.ConfigItems["autoscaling_buffer_memory"] = "1500Mi"
+
+	_, err = renderAutoscaling(t, cluster)
+	require.Error(t, err)
+}
+
+func TestAutoscalingBufferPoolBased(t *testing.T) {
+	result, err := render(
+		t,
+		map[string]string{
+			"foo.yaml": `{{ with autoscalingBufferSettings . }}{{.CPU}} {{.Memory}}{{end}}`,
+		},
+		"foo.yaml",
+		exampleCluster([]*api.NodePool{
+			{
+				InstanceType: "m4.xlarge",
+				Name:         "master-default",
+			},
+			{
+				InstanceType: "t2.nano",
+				Name:         "worker-small",
+			},
+			{
+				InstanceType: "m4.large",
+				Name:         "worker-default",
+			},
+		}))
+
+	require.NoError(t, err)
+	require.EqualValues(t, "1600m 6553Mi", result)
+}
+
+func TestAutoscalingBufferPoolBasedNoPools(t *testing.T) {
+	_, err := render(
+		t,
+		map[string]string{
+			"foo.yaml": `{{ with autoscalingBufferSettings . }}{{.CPU}} {{.Memory}}{{end}}`,
+		},
+		"foo.yaml",
+		exampleCluster([]*api.NodePool{
+			{
+				InstanceType: "m4.xlarge",
+				Name:         "master-default",
+			},
+			{
+				InstanceType: "m4.large",
+				Name:         "testing-default",
+			},
+		}))
+
+	require.Error(t, err)
+}
+
+func TestAutoscalingBufferPoolBasedMismatchingType(t *testing.T) {
+	_, err := render(
+		t,
+		map[string]string{
+			"foo.yaml": `{{ with autoscalingBufferSettings . }}{{.CPU}} {{.Memory}}{{end}}`,
+		},
+		"foo.yaml",
+		exampleCluster([]*api.NodePool{
+			{
+				InstanceType: "r4.large",
+				Name:         "worker-one",
+			},
+			{
+				InstanceType: "c4.xlarge",
+				Name:         "worker-two",
+			},
+		}))
+
+	require.Error(t, err)
+}
+
+func TestAutoscalingBufferPoolBasedInvalidSettings(t *testing.T) {
+	configSets := []map[string]string{
+		// missing
+		{"autoscaling_buffer_cpu_scale": "0.8", "autoscaling_buffer_memory_scale": "0.8"},
+		{"autoscaling_buffer_pools": "worker", "autoscaling_buffer_memory_scale": "0.8"},
+		{"autoscaling_buffer_pools": "worker", "autoscaling_buffer_cpu_scale": "0.8"},
+		// invalid
+		{"autoscaling_buffer_pools": "[(", "autoscaling_buffer_cpu_scale": "0.8", "autoscaling_buffer_memory_scale": "0.8"},
+		{"autoscaling_buffer_pools": "worker", "autoscaling_buffer_cpu_scale": "sdfsdfsdf", "autoscaling_buffer_memory_scale": "0.8"},
+		{"autoscaling_buffer_pools": "worker", "autoscaling_buffer_cpu_scale": "0.8", "autoscaling_buffer_memory_scale": "fgdfgdfg"},
+	}
+
+	for _, configItems := range configSets {
+		cluster := exampleCluster([]*api.NodePool{
+			{
+				InstanceType: "m4.large",
+				Name:         "worker",
+			},
+		})
+		cluster.ConfigItems = configItems
+
+		_, err := render(
+			t,
+			map[string]string{
+				"foo.yaml": `{{ with autoscalingBufferSettings . }}{{.CPU}} {{.Memory}}{{end}}`,
+			},
+			"foo.yaml",
+			cluster)
+
+		assert.Error(t, err, "configItems: %s", configItems)
+	}
 }


### PR DESCRIPTION
Given a cluster configuration, it returns the CPU and memory settings for the buffer pods using the following logic:

 - if `autoscaling_buffer_cpu` and `autoscaling_buffer_memory` are set, return their values directly
 - if only one of those is set, fail (this saves us from surprises if the node sizes change in the future)
 - find the largest instance from the pools matching the regex from `autoscaling_buffer_pools` config item, scale their CPU and memory by `autoscaling_buffer_cpu_scale` and `autoscaling_buffer_memory_scale` and return either these values, or  `instance_size - autoscaling_buffer_{cpu|memory}_reserved`, whichever is greater. Fail if the parameters are missing or invalid, or if    we can't determine the largest instance because some pools have more CPU and others more memory.

**Note**: this depends on #36, I'll rebase after it's merged.