### PR TITLE
Improve CLM logging

### DIFF
--- a/channel/config_source.go
+++ b/channel/config_source.go
@@ -1,5 +1,9 @@
 package channel
 
+import (
+	log "github.com/sirupsen/logrus"
+)
+
 type ConfigVersion string
 
 // ConfigSource is an interface for getting the cluster configuration for a
@@ -7,13 +11,13 @@ type ConfigVersion string
 type ConfigSource interface {
 	// Update synchronizes the local copy of the configuration with the remote one
 	// and returns the available channel versions.
-	Update() (ConfigVersions, error)
+	Update(logger *log.Entry) (ConfigVersions, error)
 
 	// Get returns a Config related to the specified version from the local copy.
-	Get(version ConfigVersion) (*Config, error)
+	Get(logger *log.Entry, version ConfigVersion) (*Config, error)
 
 	// Delete deletes the config.
-	Delete(config *Config) error
+	Delete(logger *log.Entry, config *Config) error
 }
 
 // ConfigVersions is a snapshot of the versions at the time of an update

--- a/channel/directory.go
+++ b/channel/directory.go
@@ -1,5 +1,9 @@
 package channel
 
+import (
+	log "github.com/sirupsen/logrus"
+)
+
 // Directory defines a channel source where everything is stored in a directory.
 type Directory struct {
 	location string
@@ -12,20 +16,20 @@ func NewDirectory(location string) ConfigSource {
 	return &Directory{location: location}
 }
 
-func (d *Directory) Update() (ConfigVersions, error) {
+func (d *Directory) Update(logger *log.Entry) (ConfigVersions, error) {
 	result := &directoryVersions{}
 	return result, nil
 }
 
 // Get returns the contents from the directory.
-func (d *Directory) Get(version ConfigVersion) (*Config, error) {
+func (d *Directory) Get(logger *log.Entry, version ConfigVersion) (*Config, error) {
 	return &Config{
 		Path: d.location,
 	}, nil
 }
 
 // Delete is a no-op for the directory channelSource.
-func (d *Directory) Delete(config *Config) error {
+func (d *Directory) Delete(logger *log.Entry, config *Config) error {
 	return nil
 }
 

--- a/channel/directory_test.go
+++ b/channel/directory_test.go
@@ -3,18 +3,21 @@ package channel
 import (
 	"testing"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
 func TestDirectoryChannel(t *testing.T) {
 	location := "/test-dir"
 
+	logger := log.StandardLogger().WithFields(map[string]interface{}{})
+
 	d := NewDirectory(location)
-	channels, err := d.Update()
+	channels, err := d.Update(logger)
 	require.NoError(t, err)
 	require.NotEmpty(t, channels)
 
-	cc, err := d.Get("channel")
+	cc, err := d.Get(logger, "channel")
 	require.NoError(t, err)
 
 	if cc.Path != location {

--- a/controller/cluster_list.go
+++ b/controller/cluster_list.go
@@ -123,7 +123,7 @@ func (clusterList *ClusterList) updateClusters(channels channel.ConfigVersions, 
 		}
 
 		if !clusterList.accountFilter.Allowed(cluster.InfrastructureAccount) {
-			log.Infof("Skipping %s cluster, infrastructure account does not match provided filter.", cluster.ID)
+			log.Debug("Skipping %s cluster, infrastructure account does not match provided filter.", cluster.ID)
 			continue
 		}
 

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -130,8 +130,7 @@ func (p *clusterpyProvisioner) updateDefaults(cluster *api.Cluster, channelConfi
 
 // Provision provisions/updates a cluster on AWS. Provision is an idempotent
 // operation for the same input.
-func (p *clusterpyProvisioner) Provision(ctx context.Context, cluster *api.Cluster, channelConfig *channel.Config) error {
-	logger := log.WithField("cluster", cluster.Alias)
+func (p *clusterpyProvisioner) Provision(ctx context.Context, logger *log.Entry, cluster *api.Cluster, channelConfig *channel.Config) error {
 	awsAdapter, updater, nodePoolManager, err := p.prepareProvision(logger, cluster, channelConfig)
 	if err != nil {
 		return err
@@ -379,8 +378,7 @@ func nodePoolFeatureEnabled(cluster *api.Cluster) bool {
 }
 
 // Decommission decommissions a cluster provisioned in AWS.
-func (p *clusterpyProvisioner) Decommission(cluster *api.Cluster, channelConfig *channel.Config) error {
-	logger := log.WithField("cluster", cluster.Alias)
+func (p *clusterpyProvisioner) Decommission(logger *log.Entry, cluster *api.Cluster, channelConfig *channel.Config) error {
 	awsAdapter, _, _, err := p.prepareProvision(logger, cluster, channelConfig)
 	if err != nil {
 		return err

--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -7,6 +7,8 @@ import (
 	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/channel"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/config"
+
+	log "github.com/sirupsen/logrus"
 )
 
 var (
@@ -27,6 +29,6 @@ type Options struct {
 // clusters.
 type Provisioner interface {
 	Supports(cluster *api.Cluster) bool
-	Provision(ctx context.Context, cluster *api.Cluster, channelConfig *channel.Config) error
-	Decommission(cluster *api.Cluster, channelConfig *channel.Config) error
+	Provision(ctx context.Context, logger *log.Entry, cluster *api.Cluster, channelConfig *channel.Config) error
+	Decommission(logger *log.Entry, cluster *api.Cluster, channelConfig *channel.Config) error
 }

--- a/provisioner/stdout.go
+++ b/provisioner/stdout.go
@@ -21,15 +21,15 @@ func (p *stdoutProvisioner) Supports(cluster *api.Cluster) bool {
 }
 
 // Provision mocks provisioning a cluster.
-func (p *stdoutProvisioner) Provision(ctx context.Context, cluster *api.Cluster, channelConfig *channel.Config) error {
-	log.Infof("stdout: Provisioning cluster %s.", cluster.ID)
+func (p *stdoutProvisioner) Provision(ctx context.Context, logger *log.Entry, cluster *api.Cluster, channelConfig *channel.Config) error {
+	logger.Infof("stdout: Provisioning cluster %s.", cluster.ID)
 
 	return nil
 }
 
 // Decommission mocks decommissioning a cluster.
-func (p *stdoutProvisioner) Decommission(cluster *api.Cluster, channelConfig *channel.Config) error {
-	log.Infof("stdout: Decommissioning cluster %s.", cluster.ID)
+func (p *stdoutProvisioner) Decommission(logger *log.Entry, cluster *api.Cluster, channelConfig *channel.Config) error {
+	logger.Infof("stdout: Decommissioning cluster %s.", cluster.ID)
 
 	return nil
 }


### PR DESCRIPTION
* Move the useless and repetitive logs (e.g. cluster filter) to Debug
* Log command output (e.g. git) only on error, or if debug logging is enabled.
* Refactor the code to explicitly pass the logger around instead of reconstructing it everywhere. This means we can add fields in the controller and they would actually be preserved in all log statements.