### PR TITLE
Return stderr as part of command err

### DIFF
--- a/pkg/util/command/command.go
+++ b/pkg/util/command/command.go
@@ -1,10 +1,11 @@
 package command
 
 import (
+	"fmt"
 	"os/exec"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
-	"strings"
 )
 
 func outputLines(raw []byte) []string {
@@ -16,9 +17,7 @@ func outputLines(raw []byte) []string {
 func Run(logger *log.Entry, cmd *exec.Cmd) error {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		for _, line := range outputLines(out) {
-			logger.Errorln(line)
-		}
+		return fmt.Errorf("%s: %s", err, string(out))
 	} else if logger.Logger.Level >= log.DebugLevel {
 		for _, line := range outputLines(out) {
 			logger.Debugln(line)

--- a/pkg/util/command/command_test.go
+++ b/pkg/util/command/command_test.go
@@ -48,5 +48,5 @@ func TestFailingRun(t *testing.T) {
 	logger := newTestLogger(log.InfoLevel)
 	err := Run(logger.entry, cmd)
 	require.Error(t, err)
-	require.NotEmpty(t, logger.buf.String())
+	require.Empty(t, logger.buf.String())
 }


### PR DESCRIPTION
In #38 we introduced a bug because `command.Run` no longer returned the stderr string as part of the `error`. This caused a problem in the `deletions.yaml` handling because we rely on the stderr output of `kubectl` to determine if the command just failed because the to-be-deleted resource just wasn't found.

This reverts the behavior.

https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/master/provisioner/clusterpy.go#L820-L825