### PR TITLE
util/command: Run->RunSilently, add Run

### DIFF
--- a/channel/git.go
+++ b/channel/git.go
@@ -120,19 +120,18 @@ func (g *Git) Update(logger *log.Entry) (ConfigVersions, error) {
 		return nil, err
 	}
 
-	return g.availableChannels()
+	return g.availableChannels(logger)
 }
 
-func (g *Git) availableChannels() (ConfigVersions, error) {
+func (g *Git) availableChannels(logger *log.Entry) (ConfigVersions, error) {
 	cmd := exec.Command("git", "--git-dir", g.repoDir, "show-ref", "--heads")
-	cmd.Stderr = nil
-	out, err := cmd.Output()
+	out, err := command.RunSilently(logger, cmd)
 	if err != nil {
 		return nil, err
 	}
 
 	result := make(map[string]ConfigVersion)
-	for _, line := range strings.Split(string(out), "\n") {
+	for _, line := range strings.Split(out, "\n") {
 		if line != "" {
 			chunks := strings.Split(line, " ")
 			if len(chunks) != 2 {
@@ -178,5 +177,6 @@ func (g *Git) cmd(logger *log.Entry, args ...string) error {
 		cmd.Env = []string{fmt.Sprintf("GIT_SSH_COMMAND=ssh -i %s -o 'StrictHostKeyChecking no'", g.sshPrivateKeyFile)}
 	}
 
-	return command.Run(logger, cmd)
+	_, err := command.RunSilently(logger, cmd)
+	return err
 }

--- a/channel/git_test.go
+++ b/channel/git_test.go
@@ -30,7 +30,7 @@ func createGitRepo(t *testing.T, logger *log.Entry, dir string) {
 			"GIT_COMMITTER_NAME=go-test",
 		}
 		log.Printf("test")
-		err := command.Run(logger, cmd)
+		_, err := command.RunSilently(logger, cmd)
 		require.NoError(t, err)
 	}
 

--- a/pkg/util/command/command.go
+++ b/pkg/util/command/command.go
@@ -1,27 +1,43 @@
 package command
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 
+	"bytes"
 	log "github.com/sirupsen/logrus"
+	"io"
 )
 
-func outputLines(raw []byte) []string {
-	return strings.Split(strings.TrimRight(string(raw), "\n"), "\n")
+func outputLines(output string) []string {
+	return strings.Split(strings.TrimRight(output, "\n"), "\n")
 }
 
-// Run configures stdout and stderr of a command to use the logger interface
-// and adds stderr as context if the command exits with status code > 0.
-func Run(logger *log.Entry, cmd *exec.Cmd) error {
-	out, err := cmd.CombinedOutput()
+// RunSilently runs an exec.Cmd, capturing its output and additionally logging it
+// only if the command fails (or if debug logging is enabled)
+func RunSilently(logger *log.Entry, cmd *exec.Cmd) (string, error) {
+	rawOut, err := cmd.CombinedOutput()
+	out := string(rawOut)
 	if err != nil {
-		return fmt.Errorf("%s: %s", err, string(out))
+		for _, line := range outputLines(out) {
+			logger.Errorln(line)
+		}
 	} else if logger.Logger.Level >= log.DebugLevel {
 		for _, line := range outputLines(out) {
 			logger.Debugln(line)
 		}
 	}
-	return err
+	return string(out), err
+}
+
+// Run runs an exec.Cmd, capturing its output and additionally redirecting
+// it to a logger
+func Run(logger *log.Entry, cmd *exec.Cmd) (string, error) {
+	var output bytes.Buffer
+
+	cmd.Stdout = io.MultiWriter(&output, logger.WriterLevel(log.InfoLevel))
+	cmd.Stderr = io.MultiWriter(&output, logger.WriterLevel(log.ErrorLevel))
+
+	err := cmd.Run()
+	return output.String(), err
 }

--- a/pkg/util/command/command.go
+++ b/pkg/util/command/command.go
@@ -1,12 +1,12 @@
 package command
 
 import (
+	"bytes"
+	"io"
 	"os/exec"
 	"strings"
 
-	"bytes"
 	log "github.com/sirupsen/logrus"
-	"io"
 )
 
 func outputLines(output string) []string {

--- a/pkg/util/command/command_test.go
+++ b/pkg/util/command/command_test.go
@@ -27,26 +27,47 @@ func newTestLogger(level log.Level) *testLogger {
 	}
 }
 
-func TestSuccessfulRun(t *testing.T) {
+func TestRunSilentlySuccessful(t *testing.T) {
 	cmd := exec.Command("go", "version")
 	logger := newTestLogger(log.InfoLevel)
-	err := Run(logger.entry, cmd)
+	out, err := RunSilently(logger.entry, cmd)
 	require.NoError(t, err)
+	require.Contains(t, out, "go version")
 	require.Empty(t, logger.buf.String())
 }
 
-func TestSuccessfulRunDebug(t *testing.T) {
+func TestRunSilentlyDebug(t *testing.T) {
 	cmd := exec.Command("go", "version")
 	logger := newTestLogger(log.DebugLevel)
-	err := Run(logger.entry, cmd)
+	out, err := RunSilently(logger.entry, cmd)
 	require.NoError(t, err)
+	require.Contains(t, out, "go version")
 	require.NotEmpty(t, logger.buf.String())
 }
 
-func TestFailingRun(t *testing.T) {
+func TestRunSilentlyFailing(t *testing.T) {
 	cmd := exec.Command("go", "dsjghsdgkjshgkjsdhfjkshfkjsdf")
 	logger := newTestLogger(log.InfoLevel)
-	err := Run(logger.entry, cmd)
+	out, err := RunSilently(logger.entry, cmd)
 	require.Error(t, err)
-	require.Empty(t, logger.buf.String())
+	require.Contains(t, out, "unknown subcommand")
+	require.NotEmpty(t, logger.buf.String())
+}
+
+func TestRunSuccessful(t *testing.T) {
+	cmd := exec.Command("go", "dsjghsdgkjshgkjsdhfjkshfkjsdf")
+	logger := newTestLogger(log.InfoLevel)
+	out, err := Run(logger.entry, cmd)
+	require.Error(t, err)
+	require.Contains(t, out, "unknown subcommand")
+	require.NotEmpty(t, logger.buf.String())
+}
+
+func TestRunFailing(t *testing.T) {
+	cmd := exec.Command("go", "version")
+	logger := newTestLogger(log.InfoLevel)
+	out, err := Run(logger.entry, cmd)
+	require.NoError(t, err)
+	require.Contains(t, out, "go version")
+	require.NotEmpty(t, logger.buf.String())
 }


### PR DESCRIPTION
* Rename `Run` -> `RunSilently`
* `RunSilently`: don't print anything unless there's an error
* Add `Run`, which always prints the output (useful for e.g. kubectl)
* Return the combined output from both functions