### PR TITLE
Run tests with -race on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ install:
 script:
   - make build.docker
   - roveralls
-  - goveralls -v -coverprofile=roveralls.coverprofile -service=travis-ci
+  - goveralls -v -coverprofile=roveralls.coverprofile -service=travis-ci -race


### PR DESCRIPTION
We don't run CDP builds for external contributors, and `-race` could catch some errors.