### PR TITLE
Remove legacy node pool support (Legacy pools step 3/4)

### DIFF
--- a/pkg/updatestrategy/aws_asg.go
+++ b/pkg/updatestrategy/aws_asg.go
@@ -374,10 +374,6 @@ func (n *ASGNodePoolsBackend) getNodePoolASGs(nodePool *api.NodePool) ([]*autosc
 		return nil, err
 	}
 
-	if len(asgs) == 0 {
-		return nil, fmt.Errorf("failed to find any ASGs for node pool '%s'", nodePool.Name)
-	}
-
 	return asgs, nil
 }
 

--- a/pkg/updatestrategy/aws_asg.go
+++ b/pkg/updatestrategy/aws_asg.go
@@ -374,6 +374,10 @@ func (n *ASGNodePoolsBackend) getNodePoolASGs(nodePool *api.NodePool) ([]*autosc
 		return nil, err
 	}
 
+	if len(asgs) == 0 {
+		return nil, fmt.Errorf("failed to find any ASGs for node pool '%s'", nodePool.Name)
+	}
+
 	return asgs, nil
 }
 

--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -209,17 +209,7 @@ func (a *awsAdapter) CreateOrUpdateClusterStack(parentCtx context.Context, stack
 		version,
 		"KmsKey=*",
 		fmt.Sprintf("StackName=%s", name),
-		fmt.Sprintf("UserDataMaster=%s", ""),
-		fmt.Sprintf("UserDataWorker=%s", ""),
-		fmt.Sprintf("MasterNodePoolName=%s", ""),
-		fmt.Sprintf("WorkerNodePoolName=%s", ""),
-		fmt.Sprintf("MasterNodes=%d", 0),
-		fmt.Sprintf("WorkerNodes=%d", 0),
-		fmt.Sprintf("MinimumWorkerNodes=%d", 0),
-		fmt.Sprintf("MaximumWorkerNodes=%d", 0),
 		fmt.Sprintf("HostedZone=%s", hostedZone),
-		fmt.Sprintf("MasterInstanceType=%s", "m5.large"),
-		fmt.Sprintf("InstanceType=%s", "m5.large"),
 		fmt.Sprintf("ClusterID=%s", cluster.ID),
 	}
 

--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -208,6 +208,17 @@ func (a *awsAdapter) CreateOrUpdateClusterStack(parentCtx context.Context, stack
 		fmt.Sprintf("StackName=%s", name),
 		fmt.Sprintf("HostedZone=%s", hostedZone),
 		fmt.Sprintf("ClusterID=%s", cluster.ID),
+		// TOOD: unused, remove me
+		fmt.Sprintf("UserDataMaster=%s", ""),
+		fmt.Sprintf("UserDataWorker=%s", ""),
+		fmt.Sprintf("MasterNodePoolName=%s", ""),
+		fmt.Sprintf("WorkerNodePoolName=%s", ""),
+		fmt.Sprintf("MasterNodes=%d", 0),
+		fmt.Sprintf("WorkerNodes=%d", 0),
+		fmt.Sprintf("MinimumWorkerNodes=%d", 0),
+		fmt.Sprintf("MaximumWorkerNodes=%d", 0),
+		fmt.Sprintf("MasterInstanceType=%s", "m3.medium"),
+		fmt.Sprintf("InstanceType=%s", "m3.medium"),
 	}
 
 	if bucket, ok := cluster.ConfigItems[etcdS3BackupBucketKey]; ok {

--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -208,17 +208,6 @@ func (a *awsAdapter) CreateOrUpdateClusterStack(parentCtx context.Context, stack
 		fmt.Sprintf("StackName=%s", name),
 		fmt.Sprintf("HostedZone=%s", hostedZone),
 		fmt.Sprintf("ClusterID=%s", cluster.ID),
-		// TOOD: unused, remove me
-		fmt.Sprintf("UserDataMaster=%s", ""),
-		fmt.Sprintf("UserDataWorker=%s", ""),
-		fmt.Sprintf("MasterNodePoolName=%s", ""),
-		fmt.Sprintf("WorkerNodePoolName=%s", ""),
-		fmt.Sprintf("MasterNodes=%d", 0),
-		fmt.Sprintf("WorkerNodes=%d", 0),
-		fmt.Sprintf("MinimumWorkerNodes=%d", 0),
-		fmt.Sprintf("MaximumWorkerNodes=%d", 0),
-		fmt.Sprintf("MasterInstanceType=%s", "m3.medium"),
-		fmt.Sprintf("InstanceType=%s", "m3.medium"),
 	}
 
 	if bucket, ok := cluster.ConfigItems[etcdS3BackupBucketKey]; ok {
@@ -238,12 +227,53 @@ func (a *awsAdapter) CreateOrUpdateClusterStack(parentCtx context.Context, stack
 
 	cmd.Env = enVars
 
-	output, err := cmd.Output()
+	var output []byte
+
+	output, err = cmd.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			return fmt.Errorf("%v: %s", err, string(exitErr.Stderr))
+			// TODO: remove me once https://github.com/zalando-incubator/kubernetes-on-aws/pull/1091
+			// was rolled out to all clusters.
+			if strings.Contains(string(exitErr.Stderr), "Error: Missing parameter") {
+				args = append(args,
+					fmt.Sprintf("UserDataMaster=%s", ""),
+					fmt.Sprintf("UserDataWorker=%s", ""),
+					fmt.Sprintf("MasterNodePoolName=%s", ""),
+					fmt.Sprintf("WorkerNodePoolName=%s", ""),
+					fmt.Sprintf("MasterNodes=%d", 0),
+					fmt.Sprintf("WorkerNodes=%d", 0),
+					fmt.Sprintf("MinimumWorkerNodes=%d", 0),
+					fmt.Sprintf("MaximumWorkerNodes=%d", 0),
+					fmt.Sprintf("MasterInstanceType=%s", "m3.medium"),
+					fmt.Sprintf("InstanceType=%s", "m3.medium"),
+				)
+
+				cmd := exec.Command("senza", args...)
+
+				if a.dryRun {
+					cmd.Args = append(cmd.Args, "--dry-run")
+				}
+
+				enVars, err := a.getEnvVars()
+				if err != nil {
+					return err
+				}
+
+				cmd.Env = enVars
+
+				output, err = cmd.Output()
+				if err != nil {
+					if exitErr, ok := err.(*exec.ExitError); ok {
+						return fmt.Errorf("%v: %s", err, string(exitErr.Stderr))
+					}
+					return err
+				}
+			} else {
+				return fmt.Errorf("%v: %s", err, string(exitErr.Stderr))
+			}
+		} else {
+			return err
 		}
-		return err
 	}
 
 	err = a.applyClusterStack(stackName, output, cluster, s3BucketName)

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -268,19 +268,6 @@ func (p *clusterpyProvisioner) Provision(ctx context.Context, logger *log.Entry,
 		}
 	}
 
-	// If the node pool feature is enabled and we have at least 2
-	// non-legacy node pools, then scale down any empty legacy node pools.
-	// TODO(tech-depth): remove this block when all legacy node pools has
-	// been decommissioned
-	nonLegacyNodePools := len(getNonLegacyNodePools(cluster))
-	legacyNodePools := len(cluster.NodePools) - nonLegacyNodePools
-	if nodePoolFeatureEnabled(cluster) && nonLegacyNodePools >= 2 && legacyNodePools == 0 {
-		_, _, err := getLegacyNodePools(cluster)
-		if err != nil {
-			return err
-		}
-	}
-
 	// TODO(tech-depth): remove if-guard when feature is enabled by default
 	if nodePoolFeatureEnabled(cluster) {
 		// clean up removed node pools

--- a/provisioner/hack.go
+++ b/provisioner/hack.go
@@ -6,36 +6,6 @@ import (
 	"strings"
 )
 
-// parseWebhookID parses the webhookID from a clusterID.
-// This is a hack for the special case of clusterID with localID
-// 'kube-aws-test'.
-func parseWebhookID(clusterID string) (string, error) {
-	account, region, localID, err := parseClusterID(clusterID)
-	if err != nil {
-		return "", err
-	}
-
-	name, _, err := splitStackName(localID)
-	if err != nil {
-		return "", err
-	}
-
-	if name == "kube-aws-test" {
-		return fmt.Sprintf("%s:%s:%s", account, region, name), nil
-	}
-
-	return clusterID, nil
-}
-
-// parseClusterID parses a clusterID into account, region and localID.
-func parseClusterID(clusterID string) (string, string, string, error) {
-	split := strings.Split(clusterID, ":")
-	if len(split) != 4 {
-		return "", "", "", fmt.Errorf("invalid clusterID %s", clusterID)
-	}
-	return split[0] + ":" + split[1], split[2], split[3], nil
-}
-
 // splitStackName takes a stackName and returns the corresponding Senza stack
 // and version values.
 func splitStackName(stackName string) (string, string, error) {


### PR DESCRIPTION
Step 3/4 to remove legacy node pools:
* make CLM tolerate missing legacy node pool stack and userdata files (https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/49)
* update stack to remove legacy resources and set "empty" default values for to-be-removed stack parameters (https://github.com/zalando-incubator/kubernetes-on-aws/pull/1091)
* stop specifying stack parameters in CLM. Default stack values from step 2 will take over. (https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/46) <==
* finally remove unused stack parameters from stack config (https://github.com/zalando-incubator/kubernetes-on-aws/pull/1121)

https://github.com/zalando-incubator/kubernetes-on-aws/pull/1091 must be rolled out to all channels before merging this:
- [x] dev
- [x] alpha
- [x] beta (https://github.com/zalando-incubator/kubernetes-on-aws/pull/1132)
- [x] search-alpha (https://github.com/zalando-incubator/kubernetes-on-aws/pull/1133) (merged but not yet rolled out to search-test)

Details:
* Remove `getLegacyNodePools` and associated code
* Remove `nodePoolFeatureEnabled ` and assume `true` and remove and associated code

Purpose of this PR:
* stop setting all obsolete stack parameters and remove all obsolete code because of this. The removed parameters are still defined in the senza stack but all have defaults.