### PR TITLE
Do not fail on missing legacy pools (Legacy pools step 1/4)

### DIFF
--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -240,7 +240,7 @@ func (a *awsAdapter) CreateOrUpdateClusterStack(parentCtx context.Context, stack
 
 		// TODO(tech-depth): this is only used for migrating from
 		// legacy node pools to real node pool support.
-		if nodePoolFeatureEnabled(cluster) {
+		if asg != nil && nodePoolFeatureEnabled(cluster) {
 			workerPoolDesired = aws.Int64Value(asg.DesiredCapacity)
 			workerPoolMinSize = aws.Int64Value(asg.MinSize)
 			workerPoolMaxSize = workerPoolDesired
@@ -756,21 +756,8 @@ func userDataConfig(stackName, stackVersion, kubeletSecret string, cluster *api.
 }
 
 // getUserData reads userdata from clc files and uploads the userdata to S3.
-func (a *awsAdapter) getUserData(basePath string, config map[string]string, bucketName string) (string, string, error) {
-	userDataMasterPath := path.Join(basePath, "master.clc.yaml")
-	userDataWorkerPath := path.Join(basePath, "worker.clc.yaml")
-
-	master, err := a.prepareUserData(userDataMasterPath, config, bucketName)
-	if err != nil {
-		return "", "", err
-	}
-
-	worker, err := a.prepareUserData(userDataWorkerPath, config, bucketName)
-	if err != nil {
-		return "", "", err
-	}
-
-	return master, worker, nil
+func (a *awsAdapter) getUserData(_ string, _ map[string]string, _ string) (string, string, error) {
+	return "", "", nil
 }
 
 // prepareUserData prepares the user data by rendering the mustache template

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -275,25 +275,9 @@ func (p *clusterpyProvisioner) Provision(ctx context.Context, logger *log.Entry,
 	nonLegacyNodePools := len(getNonLegacyNodePools(cluster))
 	legacyNodePools := len(cluster.NodePools) - nonLegacyNodePools
 	if nodePoolFeatureEnabled(cluster) && nonLegacyNodePools >= 2 && legacyNodePools == 0 {
-		masterPool, workerPool, err := getLegacyNodePools(cluster)
+		_, _, err := getLegacyNodePools(cluster)
 		if err != nil {
 			return err
-		}
-
-		if masterPool.MaxSize == 0 && masterPool.MinSize == 0 {
-			// gracefully downscale node pool
-			err := nodePoolManager.ScalePool(ctx, masterPool, 0)
-			if err != nil {
-				return err
-			}
-		}
-
-		if workerPool.MaxSize == 0 && workerPool.MinSize == 0 {
-			// gracefully downscale node pool
-			err := nodePoolManager.ScalePool(ctx, workerPool, 0)
-			if err != nil {
-				return err
-			}
 		}
 	}
 


### PR DESCRIPTION
Step 1/4 to remove legacy node pools:
* make CLM tolerate missing legacy userdata files (https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/49) <==
* update stack to remove legacy resources and set "empty" default values for to-be-removed stack parameters (https://github.com/zalando-incubator/kubernetes-on-aws/pull/1091)
* stop specifying stack parameters in CLM. Default stack values from step 2 will take over. (https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/46)
* finally remove unused stack parameters from stack config (https://github.com/zalando-incubator/kubernetes-on-aws/pull/1121)

Purpose of this PR:
* allow to run CLM against current config in `dev` as well as new config in `remove-static-pools`