### PR TITLE
Ignore terminated pods when evicting

### DIFF
--- a/pkg/updatestrategy/node_pool_manager.go
+++ b/pkg/updatestrategy/node_pool_manager.go
@@ -483,6 +483,11 @@ func (m *KubernetesNodePoolManager) isEvictablePod(pod v1.Pod) bool {
 		return false
 	}
 
+	if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
+		logger.Debug("Terminated pod (%s) not evictable", pod.Status.Phase)
+		return false
+	}
+
 	for _, owner := range pod.GetOwnerReferences() {
 		if owner.Kind == "DaemonSet" {
 			logger.Debug("DaemonSet Pod not evictable")


### PR DESCRIPTION
PDBs are checked before the pod phase, so a broken PDB can prevent us from evicting terminated pods as well, even though it makes no sense. Just ignore them instead.