### PR TITLE
Minor bugfixes

### DIFF
--- a/pkg/updatestrategy/node_pool_manager.go
+++ b/pkg/updatestrategy/node_pool_manager.go
@@ -484,7 +484,7 @@ func (m *KubernetesNodePoolManager) isEvictablePod(pod v1.Pod) bool {
 	}
 
 	if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
-		logger.Debug("Terminated pod (%s) not evictable", pod.Status.Phase)
+		logger.Debugf("Terminated pod (%s) not evictable", pod.Status.Phase)
 		return false
 	}
 

--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -197,7 +197,7 @@ func (p *AWSNodePoolProvisioner) provisionNodePool(nodePool *api.NodePool, value
 		},
 		{
 			Key:   aws.String(nodePoolProfileTagKey),
-			Value: aws.String(nodePool.Name),
+			Value: aws.String(nodePool.Profile),
 		},
 	}
 


### PR DESCRIPTION
* Set `node-pool/profile` tag to the actual profile name, not node pool name
* Correctly print the notice about terminated pods