### PR TITLE
Check if the pod was already moved before evicting

### DIFF
--- a/pkg/updatestrategy/node_pool_manager.go
+++ b/pkg/updatestrategy/node_pool_manager.go
@@ -389,6 +389,19 @@ var evictPod = func(client kubernetes.Interface, logger *log.Entry, pod *v1.Pod)
 		"node": pod.Spec.NodeName,
 	})
 
+	updated, err := client.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	if updated.Spec.NodeName != pod.Spec.NodeName {
+		// Already evicted
+		return nil
+	}
+
 	eviction := &policy.Eviction{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pod.Name,
@@ -399,7 +412,7 @@ var evictPod = func(client kubernetes.Interface, logger *log.Entry, pod *v1.Pod)
 		},
 	}
 
-	err := client.CoreV1().Pods(pod.Namespace).Evict(eviction)
+	err = client.CoreV1().Pods(pod.Namespace).Evict(eviction)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It's possible that someone else might move the pod while we're evicting it. Since statefulset pods have the same name, CLM will try to evict it again even if it's not running on the node we're trying to drain. Re-check on every attempt to reduce the race window. Fix #54.