### PR TITLE
Add support for config items per node pool

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -119,6 +119,23 @@ func (cluster *Cluster) Version(channelVersion channel.ConfigVersion) (*ClusterV
 		if err != nil {
 			return nil, err
 		}
+		// config items are sorted by key to produce a predictable string for
+		// hashing.
+		keys := make([]string, 0, len(nodePool.ConfigItems))
+		for key := range nodePool.ConfigItems {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			_, err = state.WriteString(key)
+			if err != nil {
+				return nil, err
+			}
+			_, err = state.WriteString(nodePool.ConfigItems[key])
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	// sha1 hash the cluster content

--- a/api/cluster_test.go
+++ b/api/cluster_test.go
@@ -72,18 +72,22 @@ func sampleCluster() *Cluster {
 			{
 				Name:             "master-default",
 				Profile:          "master-default",
-				InstanceType:     "m3.medium",
+				InstanceType:     "m4.large",
 				DiscountStrategy: "none",
 				MinSize:          2,
 				MaxSize:          2,
+				ConfigItems:      map[string]string{},
 			},
 			{
 				Name:             "worker-default",
 				Profile:          "worker-default",
-				InstanceType:     "r4.large",
+				InstanceType:     "m5.large",
 				DiscountStrategy: "none",
 				MinSize:          3,
-				MaxSize:          20,
+				MaxSize:          21,
+				ConfigItems: map[string]string{
+					"taints": "my-taint=:NoSchedule",
+				},
 			},
 		},
 	}

--- a/api/node_pool.go
+++ b/api/node_pool.go
@@ -4,12 +4,13 @@ import "strings"
 
 // NodePool describes a node pool in a kubernetes cluster.
 type NodePool struct {
-	DiscountStrategy string `json:"discount_strategy" yaml:"discount_strategy"`
-	InstanceType     string `json:"instance_type"     yaml:"instance_type"`
-	Name             string `json:"name"              yaml:"name"`
-	Profile          string `json:"profile"           yaml:"profile"`
-	MinSize          int64  `json:"min_size"          yaml:"min_size"`
-	MaxSize          int64  `json:"max_size"          yaml:"max_size"`
+	DiscountStrategy string            `json:"discount_strategy" yaml:"discount_strategy"`
+	InstanceType     string            `json:"instance_type"     yaml:"instance_type"`
+	Name             string            `json:"name"              yaml:"name"`
+	Profile          string            `json:"profile"           yaml:"profile"`
+	MinSize          int64             `json:"min_size"          yaml:"min_size"`
+	MaxSize          int64             `json:"max_size"          yaml:"max_size"`
+	ConfigItems      map[string]string `json:"config_items"      yaml:"config_items"`
 }
 
 // NodePools is a slice of *NodePool which implements the sort interface to

--- a/api/node_pool_test.go
+++ b/api/node_pool_test.go
@@ -24,7 +24,10 @@ func TestSortNodePools(t *testing.T) {
 					Profile: "worker-default",
 					Name:    "two",
 					MinSize: 3,
-					MaxSize: 20,
+					MaxSize: 21,
+					ConfigItems: map[string]string{
+						"taints": "my-taint=:NoSchedule",
+					},
 				},
 			}),
 			first: "one",

--- a/docs/cluster-registry.yaml
+++ b/docs/cluster-registry.yaml
@@ -543,39 +543,67 @@ paths:
           schema:
             $ref: '#/definitions/Error'
 
-  '/healthz':
-    get:
-      summary: Health endpoint
-      description: Get health of the application.
+  '/kubernetes-clusters/{cluster_id}/node-pools/{node_pool_name}/config-items/{config_key}':
+    put:
+      summary: Add/update config item
+      description: Add/update a configuration item unique to the node pool.
       tags:
-        - Health
-      operationId: getHealth
-      security: []
+        - NodePoolConfigItems
+      operationId: addOrUpdateNodePoolConfigItem
+      parameters:
+        - $ref: '#/parameters/cluster_id'
+        - $ref: '#/parameters/node_pool_name'
+        - $ref: '#/parameters/config_key'
+        - name: value
+          required: true
+          in: body
+          description: Config value.
+          schema:
+            '$ref': '#/definitions/ConfigValue'
       responses:
         200:
-          description: Application is healthy
+          description: The config items add/update request is accepted.
           schema:
-            $ref: '#/definitions/Health'
-
-        503:
-          description: Application is unhealthy
-
-  '/.well-known/schema-discovery':
-    get:
-      summary: Ignore schema discovery endpoint
-      description: Ignore schema discovery endpoint.
+            '$ref': '#/definitions/ConfigValue'
+        400:
+          description: Invalid request
+          schema:
+            $ref: '#/definitions/Error'
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden
+        500:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    delete:
+      summary: Delete config item
+      description: Deletes config item.
       tags:
-        - SchemaDiscovery
-      operationId: getSchema
-      security: []
+        - NodePoolConfigItems
+      operationId: deleteNodePoolConfigItem
+      parameters:
+        - $ref: '#/parameters/cluster_id'
+        - $ref: '#/parameters/node_pool_name'
+        - $ref: '#/parameters/config_key'
       responses:
-        200:
-          description: Application has no schema discovery
+        204:
+          description: Config item deleted.
+        400:
+          description: Invalid request
           schema:
-            $ref: '#/definitions/Health'
-
-        503:
-          description: Application has no schema discovery
+            $ref: '#/definitions/Error'
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden
+        404:
+          description: Config item not found
+        500:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
 
 
 parameters:
@@ -956,18 +984,25 @@ definitions:
         description: Name of the node pool
       profile:
         type: string
-        example: worker/default
-        description: Profile used for the node pool. Possible values are "worker/default", "worker/database", "worker/gpu", "master". The "master" profile identifies the pool containing the cluster master
+        example: worker-default
+        description: |
+          Profile used for the node pool. Possible values are "worker-default",
+          "worker-database", "worker-gpu", "master". The "master" profile
+          identifies the pool containing the cluster master
       instance_type:
         type: string
-        example: m4.medium
-        description: Type of the instance to use for the nodes in the pool. All the nodes in the pool share the same instance types
+        example: m5.large
+        description: |
+          Type of the instance to use for the nodes in the pool. All the nodes
+          in the pool share the same instance types
       discount_strategy:
         type: string
         example: none
         description: |
-          A discount strategy indicates the type of discount to be associated with the node pool. This might affect the availability of the nodes in the pools in case of preemptible or spot instances.
-          Possible values depend on the provider, the only common one is "none".
+          A discount strategy indicates the type of discount to be associated
+          with the node pool. This might affect the availability of the nodes in
+          the pools in case of preemptible or spot instances.  Possible values
+          depend on the provider, the only common one is "none".
       min_size:
         type: integer
         example: 3
@@ -976,6 +1011,15 @@ definitions:
         type: integer
         example: 20
         description: Maximum size of the node pool
+      config_items:
+        type: object
+        additionalProperties:
+          type: string
+        example:
+          local_storage: "yes"
+        description: |
+          Configuration items unique to the node pool. E.g. custom volume
+          configuration.
     required:
       - name
       - profile
@@ -983,12 +1027,6 @@ definitions:
       - discount_strategy
       - min_size
       - max_size
-
-  Health:
-    type: object
-    properties:
-      health:
-        type: boolean
 
   Error:
     type: object

--- a/registry/http.go
+++ b/registry/http.go
@@ -183,6 +183,7 @@ func convertFromNodePoolModel(nodePool *models.NodePool) *api.NodePool {
 		Profile:          *nodePool.Profile,
 		MinSize:          *nodePool.MinSize,
 		MaxSize:          *nodePool.MaxSize,
+		ConfigItems:      nodePool.ConfigItems,
 	}
 }
 


### PR DESCRIPTION
Adds support for config items per node pool.

(Also added some other cosmetic changes to the swagger definition to align it with our internal cluster-registry definition).