### PR TITLE
Wait for instance to be terminated in AWS

### DIFF
--- a/pkg/updatestrategy/aws_asg.go
+++ b/pkg/updatestrategy/aws_asg.go
@@ -17,7 +17,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/elb/elbiface"
 	"github.com/cenkalti/backoff"
-	log "github.com/sirupsen/logrus"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
 )
 
@@ -336,12 +335,11 @@ func (n *ASGNodePoolsBackend) Terminate(node *Node, decrementDesired bool) error
 
 		switch state {
 		case ec2.InstanceStateNameShuttingDown, ec2.InstanceStateNameStopping:
-			log.Info("shutting down")
 			return errors.New("instance shutting down")
 		case ec2.InstanceStateNameTerminated, ec2.InstanceStateNameStopped:
 			return nil
 		default:
-			return nil
+			return fmt.Errorf("unexpected instance state '%s'", state)
 		}
 	}
 

--- a/pkg/updatestrategy/aws_asg_test.go
+++ b/pkg/updatestrategy/aws_asg_test.go
@@ -440,6 +440,16 @@ func TestTerminate(t *testing.T) {
 					},
 				},
 			},
+			descStatus: &ec2.DescribeInstanceStatusOutput{
+				InstanceStatuses: []*ec2.InstanceStatus{
+					{
+						InstanceState: &ec2.InstanceState{
+							Code: aws.Int64(48), // terminated
+							Name: aws.String("terminated"),
+						},
+					},
+				},
+			},
 		},
 	}
 	err := backend.Terminate(&Node{}, true)
@@ -460,8 +470,8 @@ func TestTerminate(t *testing.T) {
 			InstanceStatuses: []*ec2.InstanceStatus{
 				{
 					InstanceState: &ec2.InstanceState{
-						Code: aws.Int64(32),
-						Name: aws.String("shutting-down"),
+						Code: aws.Int64(48), // terminated
+						Name: aws.String("terminated"),
 					},
 				},
 			},

--- a/pkg/updatestrategy/node_pool_manager.go
+++ b/pkg/updatestrategy/node_pool_manager.go
@@ -204,14 +204,7 @@ func (m *KubernetesNodePoolManager) TerminateNode(ctx context.Context, node *Nod
 		return err
 	}
 
-	err = m.backend.Terminate(node, decrementDesired)
-	if err != nil {
-		return err
-	}
-
-	// remove the node resource from Kubernetes. This ensures that the same
-	// empty node is not drained multiple times.
-	return m.kube.CoreV1().Nodes().Delete(node.Name, nil)
+	return m.backend.Terminate(node, decrementDesired)
 }
 
 // ScalePool scales a nodePool to the specified number of replicas.


### PR DESCRIPTION
Deleting the Kubernetes node object when terminating a node had the bad side effect that flannel on other nodes would remove the routes before the node was actually gone. Instead of deleting the node object we wait for the instance to be terminated according to AWS this way we don't drain the same node multiple times (which was the reason for deleting the node object manually in the first place).