### PR TITLE
Mark nodes in orphan node pools

### DIFF
--- a/pkg/updatestrategy/node_pool_manager_test.go
+++ b/pkg/updatestrategy/node_pool_manager_test.go
@@ -125,7 +125,7 @@ func TestLabelNodes(t *testing.T) {
 		kube: setupMockKubernetes(t, []*v1.Node{node}, nil),
 	}
 
-	err := mgr.LabelNode(&Node{Name: node.Name}, "foo", "bar")
+	err := mgr.labelNode(&Node{Name: node.Name}, "foo", "bar")
 	assert.NoError(t, err)
 }
 
@@ -141,7 +141,7 @@ func TestTaintNode(t *testing.T) {
 	}
 
 	// we can add a new taint
-	err := mgr.TaintNode(&Node{Name: node.Name}, "foo", "bar", v1.TaintEffectNoSchedule)
+	err := mgr.taintNode(&Node{Name: node.Name}, "foo", "bar", v1.TaintEffectNoSchedule)
 	assert.NoError(t, err)
 
 	updated, err := mgr.kube.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
@@ -155,7 +155,7 @@ func TestTaintNode(t *testing.T) {
 		updated.Spec.Taints)
 
 	// we can add another taint
-	err = mgr.TaintNode(&Node{Name: node.Name, Taints: updated.Spec.Taints}, "bar", "quux", v1.TaintEffectNoExecute)
+	err = mgr.taintNode(&Node{Name: node.Name, Taints: updated.Spec.Taints}, "bar", "quux", v1.TaintEffectNoExecute)
 	assert.NoError(t, err)
 
 	updated, err = mgr.kube.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
@@ -170,7 +170,7 @@ func TestTaintNode(t *testing.T) {
 		updated.Spec.Taints)
 
 	// we can replace an existing taint
-	err = mgr.TaintNode(&Node{Name: node.Name, Taints: updated.Spec.Taints}, "bar", "foo", v1.TaintEffectNoSchedule)
+	err = mgr.taintNode(&Node{Name: node.Name, Taints: updated.Spec.Taints}, "bar", "foo", v1.TaintEffectNoSchedule)
 	assert.NoError(t, err)
 
 	updated, err = mgr.kube.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
@@ -185,7 +185,7 @@ func TestTaintNode(t *testing.T) {
 		updated.Spec.Taints)
 
 	// no-op updates should work
-	err = mgr.TaintNode(&Node{Name: node.Name, Taints: updated.Spec.Taints}, "bar", "foo", v1.TaintEffectNoSchedule)
+	err = mgr.taintNode(&Node{Name: node.Name, Taints: updated.Spec.Taints}, "bar", "foo", v1.TaintEffectNoSchedule)
 	assert.NoError(t, err)
 
 	updated, err = mgr.kube.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})

--- a/pkg/updatestrategy/rolling_update_test.go
+++ b/pkg/updatestrategy/rolling_update_test.go
@@ -8,7 +8,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
-	"k8s.io/client-go/pkg/api/v1"
 )
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
@@ -48,11 +47,7 @@ func (m *mockNodePoolManager) GetPool(nodePool *api.NodePool) (*NodePool, error)
 	return m.nodePool, nil
 }
 
-func (m *mockNodePoolManager) LabelNode(node *Node, labelKey, labelValue string) error {
-	return nil
-}
-
-func (m *mockNodePoolManager) TaintNode(node *Node, taintKey, taintValue string, effect v1.TaintEffect) error {
+func (m *mockNodePoolManager) MarkNodeForDecommission(node *Node) error {
 	return nil
 }
 


### PR DESCRIPTION
 * `NodePoolManager`: remove `LabelNode`/`TaintNode`
 * `NodePoolManager`: add `MarkNodeForDecommission`, set `lifecycle-status=draining` internally in `drain()`
 * `ScalePool()`: allow resizing to either 0 or size which is gte the current size. The current downscaling logic isn't robust enough (e.g. it doesn't attempt to balance failure domains), so let's only cover the case where a pool disappears completely. Additionally, mark the nodes for decommissioning before downscaling.
 * Log when we actually start terminating a node