### PR TITLE
Pool scale-up: increase empty ASGs last

### DIFF
--- a/pkg/updatestrategy/aws_asg.go
+++ b/pkg/updatestrategy/aws_asg.go
@@ -142,10 +142,19 @@ func (n *ASGNodePoolsBackend) Scale(nodePool *api.NodePool, replicas int) error 
 		return nil
 	}
 
-	// add nodes to smallest asgs
+	// add nodes to smallest non-empty asgs
 	if diff > 0 {
 		sort.Slice(asgs, func(i, j int) bool {
-			return aws.Int64Value(asgs[i].DesiredCapacity) < aws.Int64Value(asgs[j].DesiredCapacity)
+			iCap := aws.Int64Value(asgs[i].DesiredCapacity)
+			jCap := aws.Int64Value(asgs[j].DesiredCapacity)
+
+			if iCap == 0 {
+				return false
+			}
+			if jCap == 0 {
+				return true
+			}
+			return iCap < jCap
 		})
 
 	LoopIncrement:


### PR DESCRIPTION
Some of the clusters are essentially impossible to upgrade because they have a split pool of spot nodes with no capacity in one of the zones. When CLM tries to scale this cluster up, it increases the currently empty ASG first and then waits forever. This is overall a shitty situation that needs to be fixed properly, but a quick hacky fix would be to prefer scaling up the ASGs that actually have some instances (or requests).