### PR TITLE
T2 unlimited, launch template support

### DIFF
--- a/pkg/updatestrategy/aws_asg.go
+++ b/pkg/updatestrategy/aws_asg.go
@@ -463,6 +463,8 @@ func (n *ASGNodePoolsBackend) getInstancesToUpdate(asg *autoscaling.Group) (map[
 
 	if asg.LaunchTemplate != nil && aws.StringValue(asg.LaunchTemplate.LaunchTemplateName) != "" {
 		version := aws.StringValue(asg.LaunchTemplate.Version)
+
+		// don't allow dynamic versions like $Default/$Latest
 		if version == "" || strings.HasPrefix(version, "$") {
 			return nil, fmt.Errorf("unsupported launch template version for ASG %s: %s", aws.StringValue(asg.AutoScalingGroupName), version)
 		}

--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -149,6 +149,7 @@ func (p *AWSNodePoolProvisioner) Provision(values map[string]interface{}) error 
 
 // provisionNodePool provisions a single node pool.
 func (p *AWSNodePoolProvisioner) provisionNodePool(nodePool *api.NodePool, values map[string]interface{}) error {
+	values["supports_t2_unlimited"] = strings.HasPrefix(nodePool.InstanceType, "t2")
 	values["spot_price"] = ""
 
 	switch nodePool.DiscountStrategy {


### PR DESCRIPTION
* Add support for launch templates. If the ASG uses a launch template, upgrade all nodes that don't use the same launch template version (this covers nodes started from a launch configuration, so upgrades are possible), otherwise use the old logic.
* Add `values.supports_t2_unlimited` that's set iff the instance type is T2.