### PR TITLE
Add support for plain cloudformation instead of senza

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -70,6 +70,8 @@
     "private/protocol/rest",
     "private/protocol/restxml",
     "private/protocol/xml/xmlutil",
+    "service/acm",
+    "service/acm/acmiface",
     "service/autoscaling",
     "service/autoscaling/autoscalingiface",
     "service/cloudformation",
@@ -86,12 +88,6 @@
   ]
   revision = "63f395001dd8f8d48ef82aad68256167e4051652"
   version = "v1.13.33"
-
-[[projects]]
-  name = "github.com/cbroglie/mustache"
-  packages = ["."]
-  revision = "2eb171290cbdc792c57bcd10f5a030b53500b28f"
-  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/cenkalti/backoff"
@@ -474,6 +470,12 @@
   revision = "9a301d65acbb728fcc3ace14f45f511a4cfeea9c"
 
 [[projects]]
+  name = "github.com/zalando-incubator/kube-ingress-aws-controller"
+  packages = ["certs"]
+  revision = "466aab63f48ecfcc907b21ee77dbfb6d3a681fe0"
+  version = "v0.7.3"
+
+[[projects]]
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -727,6 +729,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "603cd54d04e29fd66be8a4bba915bd97bbda36b99ec548bd9814dd68cdba28a0"
+  inputs-digest = "0ad6e7e807f9d9742aa24c302c92f8443a1cccf40f18e8ab507c3cd7797e704e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,10 +8,6 @@ required = [
   version = "~1.13.4"
 
 [[constraint]]
-  name = "github.com/cbroglie/mustache"
-  version = "1.0.0"
-
-[[constraint]]
   name = "github.com/cenkalti/backoff"
   version = "~1.1.0"
 

--- a/provisioner/aws_test.go
+++ b/provisioner/aws_test.go
@@ -259,18 +259,14 @@ func TestCreateOrUpdateClusterStack(t *testing.T) {
 	s3Bucket := "s3-bucket"
 
 	// test creating stack with small stack template
-	err := awsAdapter.applyClusterStack("stack-name", []byte(`{"stack": "template"}`), cluster, s3Bucket)
+	err := awsAdapter.applyClusterStack("stack-name", `{"stack": "template"}`, cluster, s3Bucket)
 	assert.NoError(t, err)
-
-	// test invalid stack template data
-	err = awsAdapter.applyClusterStack("stack-name", []byte(`{"stack": "template"`), cluster, s3Bucket)
-	assert.Error(t, err)
 
 	templateValue := make([]string, stackMaxSize+1)
 	for i := range templateValue {
 		templateValue[i] = "x"
 	}
-	hugeTemplate := []byte(fmt.Sprintf("{\"stack\": \"%s\"}", strings.Join(templateValue, "")))
+	hugeTemplate := fmt.Sprintf("{\"stack\": \"%s\"}", strings.Join(templateValue, ""))
 
 	// test create when template is too big and must be uploaded to s3
 	awsAdapter.s3Uploader = &s3UploaderAPIStub{}
@@ -291,7 +287,7 @@ func TestCreateOrUpdateClusterStack(t *testing.T) {
 			errors.New("base error"),
 		),
 	}
-	err = awsAdapter.applyClusterStack("stack-name", []byte(`{"stack": "template"}`), cluster, s3Bucket)
+	err = awsAdapter.applyClusterStack("stack-name", `{"stack": "template"}`, cluster, s3Bucket)
 	assert.NoError(t, err)
 
 	// test create failing
@@ -299,7 +295,7 @@ func TestCreateOrUpdateClusterStack(t *testing.T) {
 		statusMutex: &sync.Mutex{},
 		createErr:   errors.New("error"),
 	}
-	err = awsAdapter.applyClusterStack("stack-name", []byte(`{"stack": "template"}`), cluster, s3Bucket)
+	err = awsAdapter.applyClusterStack("stack-name", `{"stack": "template"}`, cluster, s3Bucket)
 	assert.Error(t, err)
 
 	// test updating when stack is already up to date
@@ -316,7 +312,7 @@ func TestCreateOrUpdateClusterStack(t *testing.T) {
 			errors.New("base error"),
 		),
 	}
-	err = awsAdapter.applyClusterStack("stack-name", []byte(`{"stack": "template"}`), cluster, s3Bucket)
+	err = awsAdapter.applyClusterStack("stack-name", `{"stack": "template"}`, cluster, s3Bucket)
 	assert.NoError(t, err)
 
 	// test update failing
@@ -329,6 +325,6 @@ func TestCreateOrUpdateClusterStack(t *testing.T) {
 		),
 		updateErr: errors.New("error"),
 	}
-	err = awsAdapter.applyClusterStack("stack-name", []byte(`{"stack": "template"}`), cluster, s3Bucket)
+	err = awsAdapter.applyClusterStack("stack-name", `{"stack": "template"}`, cluster, s3Bucket)
 	assert.Error(t, err)
 }

--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -256,7 +256,7 @@ func (p *AWSNodePoolProvisioner) Reconcile(ctx context.Context) error {
 	return nil
 }
 
-// prepareUserData prepares the user data by rendering the mustache template
+// prepareUserData prepares the user data by rendering the golang template
 // and uploading the User Data to S3. A EC2 UserData ready base64 string will
 // be returned.
 func (p *AWSNodePoolProvisioner) prepareUserData(basedir, clcPath string, config interface{}) (string, error) {


### PR DESCRIPTION
This adds support for defining a `cluster.yaml` file in plain
cloudformation format (with go templating) instead of the senza based
`senza-defintion.yaml`.

Additionally with the go templating it autodiscoveres values like VPC
CIDR block which allows for CIRDs that are different per cluster.