### PR TITLE
Don't wait for Spot pool nodes

### DIFF
--- a/api/node_pool.go
+++ b/api/node_pool.go
@@ -2,6 +2,11 @@ package api
 
 import "strings"
 
+const (
+	DiscountStrategyNone = "none"
+	DiscountStrategySpot = "spot_max_price"
+)
+
 // NodePool describes a node pool in a kubernetes cluster.
 type NodePool struct {
 	DiscountStrategy string            `json:"discount_strategy" yaml:"discount_strategy"`

--- a/pkg/updatestrategy/node_pool_manager.go
+++ b/pkg/updatestrategy/node_pool_manager.go
@@ -575,6 +575,11 @@ func WaitForDesiredNodes(ctx context.Context, logger *log.Entry, n NodePoolManag
 			break
 		}
 
+		// Don't wait for Spot nodes, just proceed with whatever we want to do
+		if nodePoolDesc.DiscountStrategy == api.DiscountStrategySpot {
+			break
+		}
+
 		logger.WithFields(log.Fields{"node-pool": nodePoolDesc.Name}).
 			Infof("Waiting for ready and desired number of nodes to match: %d/%d", readyNodes, nodePool.Desired)
 

--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -35,18 +35,16 @@ import (
 )
 
 const (
-	waitTime                     = 15 * time.Second
-	stackMaxSize                 = 51200
-	cloudformationValidationErr  = "ValidationError"
-	cloudformationNoUpdateMsg    = "No updates are to be performed."
-	clmCFBucketPattern           = "cluster-lifecycle-manager-%s-%s"
-	lifecycleStatusReady         = "ready"
-	etcdInstanceTypeKey          = "etcd_instance_type"
-	etcdInstanceCountKey         = "etcd_instance_count"
-	etcdS3BackupBucketKey        = "etcd_s3_backup_bucket"
-	discountStrategyNone         = "none"
-	discountStrategySpotMaxPrice = "spot_max_price"
-	ignitionBaseTemplate         = `{
+	waitTime                    = 15 * time.Second
+	stackMaxSize                = 51200
+	cloudformationValidationErr = "ValidationError"
+	cloudformationNoUpdateMsg   = "No updates are to be performed."
+	clmCFBucketPattern          = "cluster-lifecycle-manager-%s-%s"
+	lifecycleStatusReady        = "ready"
+	etcdInstanceTypeKey         = "etcd_instance_type"
+	etcdInstanceCountKey        = "etcd_instance_count"
+	etcdS3BackupBucketKey       = "etcd_s3_backup_bucket"
+	ignitionBaseTemplate        = `{
   "ignition": {
     "version": "2.1.0",
     "config": {

--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -153,9 +153,9 @@ func (p *AWSNodePoolProvisioner) provisionNodePool(nodePool *api.NodePool, value
 	values["spot_price"] = ""
 
 	switch nodePool.DiscountStrategy {
-	case discountStrategyNone:
+	case api.DiscountStrategyNone:
 		break
-	case discountStrategySpotMaxPrice:
+	case api.DiscountStrategySpot:
 		instanceInfo, err := awsExt.InstanceInfo(nodePool.InstanceType)
 		if err != nil {
 			return err


### PR DESCRIPTION
Spot nodes can be terminated at any time, so we don't need to wait for replacement node to come up during the upgrade. This also allows CLM to proceed when AWS doesn't have capacity instead of getting stuck forever.