### PR TITLE
scaleOutAndWaitForNodesToBeReady: ignore spot pools

### DIFF
--- a/pkg/updatestrategy/rolling_update.go
+++ b/pkg/updatestrategy/rolling_update.go
@@ -258,6 +258,11 @@ func (r *RollingUpdateStrategy) scaleOutAndWaitForNodesToBeReady(ctx context.Con
 			return nil, err
 		}
 
+		// We don't need surge nodes in Spot
+		if nodePoolDesc.DiscountStrategy == api.DiscountStrategySpot {
+			return nodePool, nil
+		}
+
 		// in case there are less than surge desired nodes we don't
 		// want to increase the pool size with surge, but instead with
 		// at most desired.


### PR DESCRIPTION
In #72, `WaitForDesiredNodes` was updated to return immediately for Spot pools. This, however, causes `scaleOutAndWaitForNodesToBeReady` to quickly scale-up to the max. Fix by short-circuiting as well.