### PR TITLE
Persistent draining

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,7 @@ const (
 	defaultDrainMinHealthySiblingLifetime   = "1h"
 	defaultDrainMinUnhealthySiblingLifetime = "6h"
 	defaultDrainForceEvictInterval          = "5m"
+	defaultDrainPollInterval                = "30s"
 	defaultUpdateStrategy                   = "rolling"
 )
 
@@ -108,6 +109,7 @@ func (cfg *LifecycleManagerConfig) ParseFlags() string {
 	kingpin.Flag("drain-min-healthy-sibling-lifetime", "Minimum lifetime of healthy pods in the same PDB as the one considered for forced termination.").Default(defaultDrainMinHealthySiblingLifetime).DurationVar(&cfg.UpdateStrategy.MinHealthyPDBSiblingLifetime)
 	kingpin.Flag("drain-min-unhealthy-sibling-lifetime", "Minimum lifetime of unhealthy pods in the same PDB as the one considered for forced termination.").Default(defaultDrainMinUnhealthySiblingLifetime).DurationVar(&cfg.UpdateStrategy.MinUnhealthyPDBSiblingLifetime)
 	kingpin.Flag("drain-force-evict-interval", "Interval between forced terminations of pods on the same node.").Default(defaultDrainForceEvictInterval).DurationVar(&cfg.UpdateStrategy.ForceEvictionInterval)
+	kingpin.Flag("drain-poll-interval", "Interval between drain attempts.").Default(defaultDrainPollInterval).DurationVar(&cfg.UpdateStrategy.PollInterval)
 	kingpin.Flag("update-strategy", "Update strategy to use when updating node pools.").Default(defaultUpdateStrategy).EnumVar(&cfg.UpdateStrategy.Strategy, "rolling")
 	kingpin.Flag("remove-volumes", "Remove EBS volumes when decommissioning.").BoolVar(&cfg.RemoveVolumes)
 	kingpin.Flag("environment-order", "Roll out channel updates to the environments in a specific order.").StringsVar(&cfg.EnvironmentOrder)

--- a/config/config.go
+++ b/config/config.go
@@ -6,21 +6,26 @@ import (
 	"path"
 	"time"
 
+	"github.com/zalando-incubator/cluster-lifecycle-manager/pkg/updatestrategy"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 const (
-	defaultInterval              = "10m"
-	defaultListener              = ":9090"
-	defaultCredentialsDir        = "/meta/credentials"
-	defaultRegistryTokenName     = "cluster-registry-rw"
-	defaultClusterTokenName      = "cluster-rw"
-	defaultRegistry              = "file://clusters.yaml"
-	defaultConcurrentUpdates     = "1"
-	defaultAwsMaxRetries         = "50"
-	defaultAwsMaxRetryInterval   = "10s"
-	defaultUpdateMaxEvictTimeout = "10m"
-	defaultUpdateStrategy        = "rolling"
+	defaultInterval                         = "10m"
+	defaultListener                         = ":9090"
+	defaultCredentialsDir                   = "/meta/credentials"
+	defaultRegistryTokenName                = "cluster-registry-rw"
+	defaultClusterTokenName                 = "cluster-rw"
+	defaultRegistry                         = "file://clusters.yaml"
+	defaultConcurrentUpdates                = "1"
+	defaultAwsMaxRetries                    = "50"
+	defaultAwsMaxRetryInterval              = "10s"
+	defaultDrainGracePeriod                 = "6h"
+	defaultDrainMinPodLifetime              = "72h"
+	defaultDrainMinHealthySiblingLifetime   = "1h"
+	defaultDrainMinUnhealthySiblingLifetime = "6h"
+	defaultDrainForceEvictInterval          = "5m"
+	defaultUpdateStrategy                   = "rolling"
 )
 
 var defaultWorkdir = path.Join(os.TempDir(), "clm-workdir")
@@ -57,8 +62,8 @@ type LifecycleManagerConfig struct {
 // timeout. The default strategy can be overwritten with a config item per
 // cluster.
 type UpdateStrategy struct {
-	Strategy        string
-	MaxEvictTimeout time.Duration
+	updatestrategy.DrainConfig
+	Strategy string
 }
 
 // New returns the app wide configuration file
@@ -98,9 +103,13 @@ func (cfg *LifecycleManagerConfig) ParseFlags() string {
 	kingpin.Flag("apply-only", "Enable apply only mode which will only apply CloudFormation stacks and manifests, but not do any rolling of nodes.").BoolVar(&cfg.ApplyOnly)
 	kingpin.Flag("aws-max-retries", "Maximum number of retries for AWS SDK requests.").Default(defaultAwsMaxRetries).IntVar(&cfg.AwsMaxRetries)
 	kingpin.Flag("aws-max-retry-interval", "Maximum interval between retries for AWS SDK requests.").Default(defaultAwsMaxRetryInterval).DurationVar(&cfg.AwsMaxRetryInterval)
-	kingpin.Flag("update-max-evict-timeout", "Maximum timeout for evicting pods during update.").Default(defaultUpdateMaxEvictTimeout).DurationVar(&cfg.UpdateStrategy.MaxEvictTimeout)
+	kingpin.Flag("drain-grace-period", "Interval between drain start and the first forced termination.").Default(defaultDrainGracePeriod).DurationVar(&cfg.UpdateStrategy.ForceEvictionGracePeriod)
+	kingpin.Flag("drain-min-pod-lifetime", " Minimum lifetime of a pod that allows forced termination when draining.").Default(defaultDrainMinPodLifetime).DurationVar(&cfg.UpdateStrategy.MinPodLifetime)
+	kingpin.Flag("drain-min-healthy-sibling-lifetime", "Minimum lifetime of healthy pods in the same PDB as the one considered for forced termination.").Default(defaultDrainMinHealthySiblingLifetime).DurationVar(&cfg.UpdateStrategy.MinHealthyPDBSiblingLifetime)
+	kingpin.Flag("drain-min-unhealthy-sibling-lifetime", "Minimum lifetime of unhealthy pods in the same PDB as the one considered for forced termination.").Default(defaultDrainMinUnhealthySiblingLifetime).DurationVar(&cfg.UpdateStrategy.MinUnhealthyPDBSiblingLifetime)
+	kingpin.Flag("drain-force-evict-interval", "Interval between forced terminations of pods on the same node.").Default(defaultDrainForceEvictInterval).DurationVar(&cfg.UpdateStrategy.ForceEvictionInterval)
 	kingpin.Flag("update-strategy", "Update strategy to use when updating node pools.").Default(defaultUpdateStrategy).EnumVar(&cfg.UpdateStrategy.Strategy, "rolling")
-	kingpin.Flag("remove-volumes", "Remove EBS volumes when decommissioning").BoolVar(&cfg.RemoveVolumes)
-	kingpin.Flag("environment-order", "Roll out channel updates to the environments in a specific order").StringsVar(&cfg.EnvironmentOrder)
+	kingpin.Flag("remove-volumes", "Remove EBS volumes when decommissioning.").BoolVar(&cfg.RemoveVolumes)
+	kingpin.Flag("environment-order", "Roll out channel updates to the environments in a specific order.").StringsVar(&cfg.EnvironmentOrder)
 	return kingpin.Parse()
 }

--- a/pkg/updatestrategy/drain.go
+++ b/pkg/updatestrategy/drain.go
@@ -439,6 +439,11 @@ func (m *KubernetesNodePoolManager) isEvictablePod(pod v1.Pod) bool {
 		return false
 	}
 
+	if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
+		logger.Debug("Pod terminated")
+		return false
+	}
+
 	for _, owner := range pod.GetOwnerReferences() {
 		if owner.Kind == "DaemonSet" {
 			logger.Debug("DaemonSet Pod not evictable")

--- a/pkg/updatestrategy/drain.go
+++ b/pkg/updatestrategy/drain.go
@@ -31,7 +31,7 @@ func timestampAnnotation(logger *log.Entry, node *Node, annotation string, fallb
 
 	value, err := time.Parse(time.RFC3339, ts)
 	if err != nil {
-		logger.Warnf("invalid value for %s: %v", annotation, err)
+		logger.Warnf("invalid value for %s (will use %s): %v", annotation, fallback, err)
 		return fallback
 	}
 
@@ -191,19 +191,19 @@ func (m *KubernetesNodePoolManager) evictOrForceTerminatePod(ctx context.Context
 func (m *KubernetesNodePoolManager) forceTerminationAllowed(pod v1.Pod, now, drainStart, lastForcedTermination time.Time) (bool, error) {
 	// too early to start force terminating
 	if now.Before(drainStart.Add(m.drainConfig.ForceEvictionGracePeriod)) {
-		m.podLogger(pod).Debugf("Won't force terminate (node in grace period)")
+		m.podLogger(pod).Debug("Won't force terminate (node in grace period)")
 		return false, nil
 	}
 
 	// we've recently force killed a pod
 	if now.Before(lastForcedTermination.Add(m.drainConfig.ForceEvictionInterval)) {
-		m.podLogger(pod).Debugf("Won't force terminate (recently force terminated a pod)")
+		m.podLogger(pod).Debug("Won't force terminate (recently force terminated a pod)")
 		return false, nil
 	}
 
 	// pod too young
 	if now.Before(pod.GetCreationTimestamp().Add(m.drainConfig.MinPodLifetime)) {
-		m.podLogger(pod).Debugf("Won't force terminate (pod too young)")
+		m.podLogger(pod).Debug("Won't force terminate (pod too young)")
 		return false, nil
 	}
 

--- a/pkg/updatestrategy/drain.go
+++ b/pkg/updatestrategy/drain.go
@@ -1,0 +1,440 @@
+package updatestrategy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"sync/atomic"
+
+	"github.com/cenkalti/backoff"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+	policy "k8s.io/client-go/pkg/apis/policy/v1beta1"
+)
+
+const (
+	drainStartAnnotation      = "cluster-lifecycle-manager.zalando.org/drain-start"
+	lastForcedDrainAnnotation = "cluster-lifecycle-manager.zalando.org/last-forced-drain"
+)
+
+func timestampAnnotation(logger *log.Entry, node *Node, annotation string, fallback time.Time) time.Time {
+	ts, ok := node.Annotations[annotation]
+	if !ok {
+		return fallback
+	}
+
+	value, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		logger.Warnf("invalid value for %s: %v", annotation, err)
+		return fallback
+	}
+
+	return value
+}
+
+// drain tries to cleanly evict all of the pods on a node, and then forcibly terminates the remaining ones.
+func (m *KubernetesNodePoolManager) drain(ctx context.Context, node *Node) error {
+	m.logger.WithField("node", node.Name).Info("Draining node")
+
+	err := m.labelNode(node, lifecycleStatusLabel, lifecycleStatusDraining)
+	if err != nil {
+		return err
+	}
+
+	drainStart := timestampAnnotation(m.logger, node, drainStartAnnotation, time.Now())
+	err = m.annotateNode(node, drainStartAnnotation, drainStart.Format(time.RFC3339))
+	if err != nil {
+		return err
+	}
+
+	lastForcedTermination := timestampAnnotation(m.logger, node, lastForcedDrainAnnotation, time.Unix(0, 0))
+
+	// fast eviction (in parallel) as long as we can evict something without violating PDBs
+	for {
+		pods, err := m.evictablePods(node.Name)
+		if err != nil {
+			return err
+		}
+
+		if len(pods) == 0 {
+			break
+		}
+
+		evicted, err := m.evictParallel(ctx, pods)
+		if err == nil {
+			err = ctx.Err()
+		}
+		if err != nil {
+			return err
+		}
+		if !evicted {
+			break
+		}
+	}
+
+	// slow eviction, one by one
+	for {
+		pods, err := m.evictablePods(node.Name)
+		if err != nil {
+			return err
+		}
+
+		if len(pods) == 0 {
+			break
+		}
+
+		forceEvicted, err := m.evictSomething(ctx, pods, drainStart, lastForcedTermination)
+		if err != nil {
+			return err
+		}
+
+		if forceEvicted {
+			lastForcedTermination = time.Now()
+			err := m.annotateNode(node, drainStartAnnotation, lastForcedTermination.Format(time.RFC3339))
+			if err != nil {
+				return err
+			}
+		}
+
+		err = ctx.Err()
+		if err != nil {
+			return err
+		}
+
+		time.Sleep(10 * time.Second)
+	}
+
+	return nil
+}
+
+func (m *KubernetesNodePoolManager) evictParallel(ctx context.Context, pods []v1.Pod) (bool, error) {
+	var evicted int64
+	var group errgroup.Group
+
+	for _, pod := range pods {
+		pod := pod
+		group.Go(func() error {
+			err := evictPod(m.kube, m.logger, pod)
+			if err != nil {
+				if isPDBViolation(err) {
+					m.pdbViolated(pod)
+					return nil
+				}
+				return err
+			}
+
+			atomic.AddInt64(&evicted, 1)
+			return nil
+		})
+	}
+
+	err := group.Wait()
+	return atomic.LoadInt64(&evicted) > 0, err
+}
+
+func (m *KubernetesNodePoolManager) podLogger(pod v1.Pod) *log.Entry {
+	return m.logger.WithFields(log.Fields{
+		"ns":   pod.Namespace,
+		"pod":  pod.Name,
+		"node": pod.Spec.NodeName,
+	})
+}
+
+func (m *KubernetesNodePoolManager) pdbViolated(pod v1.Pod) {
+	m.podLogger(pod).Info("Pod Disruption Budget violated")
+}
+
+func (m *KubernetesNodePoolManager) evictSomething(ctx context.Context, pods []v1.Pod, drainStart, lastForcedTermination time.Time) (bool, error) {
+	for _, pod := range pods {
+		err := ctx.Err()
+		if err != nil {
+			return false, err
+		}
+
+		// try evicting normally
+		err = evictPod(m.kube, m.logger, pod)
+		if err == nil {
+			return false, nil
+		}
+		if !isPDBViolation(err) {
+			return false, err
+		}
+
+		// PDB violation, check if we can force terminate the pod
+		m.pdbViolated(pod)
+
+		forceTerminate, err := m.forceTerminationAllowed(pod, drainStart, lastForcedTermination)
+		if forceTerminate {
+			err = m.deletePod(pod)
+			if err != nil {
+				return false, err
+			}
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (m *KubernetesNodePoolManager) forceTerminationAllowed(pod v1.Pod, drainStart, lastForcedTermination time.Time) (bool, error) {
+	now := time.Now()
+
+	// too early to start force terminating
+	if drainStart.Add(m.drainConfig.ForceEvictionGracePeriod).After(now) {
+		return false, nil
+	}
+
+	// we've recently force killed a pod
+	if lastForcedTermination.Add(m.drainConfig.ForceEvictionInterval).After(now) {
+		return false, nil
+	}
+
+	// pod too young
+	if pod.GetCreationTimestamp().Add(m.drainConfig.MinPodLifetime).After(now) {
+		return false, nil
+	}
+
+	// find all other pods matched by the same PDBs
+	allPods, err := m.getPodsByNamespace(pod.GetNamespace())
+	if err != nil {
+		return false, err
+	}
+	allPdbs, err := m.getPDBsbyNamespace(pod.GetNamespace())
+	if err != nil {
+		return false, err
+	}
+	siblingPods := findSiblingPods(m.logger, pod, allPods, allPdbs)
+
+	// check if PDB siblings are old enough
+	siblingsOldEnough := true
+	for _, siblingPod := range siblingPods {
+		waitTime := m.drainConfig.MinUnhealthyPDBSiblingLifetime
+		if podReady(siblingPod) {
+			waitTime = m.drainConfig.MinHealthyPDBSiblingLifetime
+		}
+		if siblingPod.GetCreationTimestamp().Add(waitTime).After(now) {
+			siblingsOldEnough = false
+			break
+		}
+	}
+	if !siblingsOldEnough {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (m *KubernetesNodePoolManager) deletePod(pod v1.Pod) error {
+	logger := m.podLogger(pod)
+
+	err := m.kube.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{
+		GracePeriodSeconds: pod.Spec.TerminationGracePeriodSeconds,
+	})
+	if err != nil {
+		logger.Errorf("Failed to delete pod: %v", err)
+		return err
+	}
+
+	// wait for pod to be terminated and gone from the node.
+	err = waitForPodTermination(m.kube, pod)
+	if err != nil {
+		logger.Warnf("Pod not terminated within grace period: %s", err)
+	}
+
+	logger.Info("Pod deleted")
+	return nil
+}
+
+func podReady(pod v1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == v1.PodReady {
+			return condition.Status == v1.ConditionTrue
+		}
+	}
+	return false
+}
+
+func findSiblingPods(logger *log.Entry, pod v1.Pod, allPods *v1.PodList, allPdbs *policy.PodDisruptionBudgetList) []v1.Pod {
+	var siblingSelectors []labels.Selector
+	for _, pdb := range allPdbs.Items {
+		selector, err := metav1.LabelSelectorAsSelector(pdb.Spec.Selector)
+		if err != nil {
+			logger.Debugf("pdb %s/%s has an invalid selector, skipping", pod.GetNamespace(), pdb.GetName())
+			continue
+		}
+		if selector.Matches(labels.Set(pod.Labels)) {
+			siblingSelectors = append(siblingSelectors, selector)
+		}
+	}
+
+	var result []v1.Pod
+	for _, candidate := range allPods.Items {
+		if candidate.GetName() == pod.GetName() {
+			continue
+		}
+
+		for _, selector := range siblingSelectors {
+			if selector.Matches(labels.Set(candidate.Labels)) {
+				result = append(result, candidate)
+				break
+			}
+		}
+	}
+
+	return result
+}
+
+func isPDBViolation(err error) bool {
+	return apiErrors.IsTooManyRequests(err) || strings.Contains(err.Error(), multiplePDBsErrMsg)
+}
+
+// evictPod tries to evict a pod from a node.
+// Note: this is defined as a variable so it can be easily mocked in tests.
+var evictPod = func(client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
+	localLogger := logger.WithFields(log.Fields{
+		"ns":   pod.Namespace,
+		"pod":  pod.Name,
+		"node": pod.Spec.NodeName,
+	})
+
+	updated, err := client.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	if updated.Status.Phase == v1.PodSucceeded || updated.Status.Phase == v1.PodFailed {
+		// Completed, just ignore
+		return nil
+	}
+
+	if updated.Spec.NodeName != pod.Spec.NodeName {
+		// Already evicted
+		return nil
+	}
+
+	eviction := &policy.Eviction{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+		},
+		DeleteOptions: &metav1.DeleteOptions{
+			GracePeriodSeconds: pod.Spec.TerminationGracePeriodSeconds,
+		},
+	}
+
+	err = client.CoreV1().Pods(pod.Namespace).Evict(eviction)
+	if err != nil {
+		return err
+	}
+	localLogger.Info("Evicting pod")
+
+	// wait for the pod to be actually evicted and gone from the node.
+	// It has TerminationGracePeriodSeconds time to clean up.
+	start := time.Now().UTC()
+	err = waitForPodTermination(client, pod)
+	if err != nil {
+		localLogger.Warnf("Pod not terminated within grace period: %s", err)
+	}
+
+	localLogger.Infof("Pod evicted. (Observed termination period: %s)", time.Now().UTC().Sub(start))
+	return nil
+}
+
+// waitForPodTermination waits for a pod to be terminated by looking up the pod
+// in the API server.
+// It waits for up to TerminationGracePeriodSeconds as specified on the pod +
+// an additional eviction head room.
+// This is to fully respect the termination expectations as described in:
+// https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+func waitForPodTermination(client kubernetes.Interface, pod v1.Pod) error {
+	if pod.Spec.TerminationGracePeriodSeconds == nil {
+		// if no grace period is defined, we don't wait.
+		return nil
+	}
+
+	waitForTermination := func() error {
+		newpod, err := client.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
+		if err != nil {
+			if apiErrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		// statefulset pods have the same name after restart, check the uid as well
+		if newpod.GetObjectMeta().GetUID() == pod.GetObjectMeta().GetUID() {
+			return fmt.Errorf("pod not terminated")
+		}
+
+		return nil
+	}
+
+	gracePeriod := time.Duration(*pod.Spec.TerminationGracePeriodSeconds)*time.Second + podEvictionHeadroom
+
+	backoffCfg := backoff.NewExponentialBackOff()
+	backoffCfg.MaxElapsedTime = gracePeriod
+	return backoff.Retry(waitForTermination, backoffCfg)
+}
+
+// evictablePods returns all evictable pods currently scheduled to a node, regardless of their status.
+func (m *KubernetesNodePoolManager) evictablePods(nodeName string) ([]v1.Pod, error) {
+	opts := metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
+	}
+
+	podList, err := m.kube.CoreV1().Pods(v1.NamespaceAll).List(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []v1.Pod
+	for _, pod := range podList.Items {
+		if m.isEvictablePod(pod) {
+			result = append(result, pod)
+		}
+	}
+
+	return result, nil
+}
+
+func (m *KubernetesNodePoolManager) getPodsByNamespace(namespace string) (*v1.PodList, error) {
+	return m.kube.CoreV1().Pods(namespace).List(metav1.ListOptions{})
+}
+
+func (m *KubernetesNodePoolManager) getPDBsbyNamespace(namespace string) (*policy.PodDisruptionBudgetList, error) {
+	return m.kube.PolicyV1beta1().PodDisruptionBudgets(namespace).List(metav1.ListOptions{})
+}
+
+// isEvictablePod detects whether it makes sense to evict a pod.
+// Non-evictable pods are pods managed by DaemonSets and mirror pods.
+func (m *KubernetesNodePoolManager) isEvictablePod(pod v1.Pod) bool {
+	logger := m.logger.WithFields(log.Fields{
+		"ns":   pod.Namespace,
+		"pod":  pod.Name,
+		"node": pod.Spec.NodeName,
+	})
+
+	if _, ok := pod.Annotations[mirrorPodAnnotation]; ok {
+		logger.Debug("Mirror Pod not evictable")
+		return false
+	}
+
+	for _, owner := range pod.GetOwnerReferences() {
+		if owner.Kind == "DaemonSet" {
+			logger.Debug("DaemonSet Pod not evictable")
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/updatestrategy/drain.go
+++ b/pkg/updatestrategy/drain.go
@@ -290,6 +290,9 @@ var deletePod = func(client kubernetes.Interface, logger *log.Entry, pod v1.Pod)
 		GracePeriodSeconds: pod.Spec.TerminationGracePeriodSeconds,
 	})
 	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			return nil
+		}
 		logger.Errorf("Failed to delete pod: %v", err)
 		return err
 	}
@@ -344,6 +347,9 @@ var evictPod = func(client kubernetes.Interface, logger *log.Entry, pod v1.Pod) 
 
 	err = client.CoreV1().Pods(pod.Namespace).Evict(eviction)
 	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 	localLogger.Info("Evicting pod")

--- a/pkg/updatestrategy/drain_test.go
+++ b/pkg/updatestrategy/drain_test.go
@@ -1,0 +1,280 @@
+package updatestrategy
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+func removePod(client kubernetes.Interface, pod v1.Pod) error {
+	var zero int64
+	client.CoreV1().Pods(pod.GetNamespace()).Delete(pod.GetName(), &metav1.DeleteOptions{GracePeriodSeconds: &zero})
+	return nil
+}
+
+func evictPodFailPDB(client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
+	return &errors.StatusError{
+		ErrStatus: metav1.Status{
+			Code: http.StatusTooManyRequests,
+		},
+	}
+}
+
+func TestTerminateNode(t *testing.T) {
+	nodeName := "test"
+	evictPod = func(client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
+		return removePod(client, pod)
+	}
+
+	pods := []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "a",
+				Namespace: "default",
+			},
+			Spec: v1.PodSpec{
+				NodeName: nodeName,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "b",
+				Namespace: "default",
+				Annotations: map[string]string{
+					mirrorPodAnnotation: "",
+				},
+			},
+			Spec: v1.PodSpec{
+				NodeName: nodeName,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "c",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind: "DaemonSet",
+					},
+				},
+			},
+			Spec: v1.PodSpec{
+				NodeName: nodeName,
+			},
+		},
+	}
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+		},
+	}
+
+	logger := log.WithField("test", true)
+	backend := &mockProviderNodePoolsBackend{
+		nodePool: &NodePool{
+			Min:        1,
+			Max:        1,
+			Current:    1,
+			Desired:    1,
+			Generation: 1,
+			Nodes: []*Node{
+				{ProviderID: "provider-id"},
+			},
+		},
+	}
+	mgr := &KubernetesNodePoolManager{
+		logger:  logger,
+		kube:    setupMockKubernetes(t, []*v1.Node{node}, pods),
+		backend: backend,
+		drainConfig: &DrainConfig{
+			PollInterval: time.Second,
+		},
+	}
+
+	err := mgr.TerminateNode(context.Background(), &Node{Name: node.Name}, false)
+	assert.NoError(t, err)
+
+	// test when evictPod returns 429
+	evictPod = evictPodFailPDB
+
+	mgr.kube = setupMockKubernetes(t, []*v1.Node{node}, pods)
+	err = mgr.TerminateNode(context.Background(), &Node{Name: node.Name}, false)
+	assert.NoError(t, err)
+}
+
+func TestTerminateNodeCancelled(t *testing.T) {
+	nodeName := "test"
+
+	pods := []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "a",
+				Namespace: "default",
+			},
+			Spec: v1.PodSpec{
+				NodeName: nodeName,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "b",
+				Namespace: "default",
+				Annotations: map[string]string{
+					mirrorPodAnnotation: "",
+				},
+			},
+			Spec: v1.PodSpec{
+				NodeName: nodeName,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "c",
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind: "DaemonSet",
+					},
+				},
+			},
+			Spec: v1.PodSpec{
+				NodeName: nodeName,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "d",
+				Namespace: "default",
+			},
+			Spec: v1.PodSpec{
+				NodeName: nodeName,
+			},
+		},
+	}
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+		},
+	}
+
+	logger := log.WithField("test", true)
+	backend := &mockProviderNodePoolsBackend{
+		nodePool: &NodePool{
+			Min:        1,
+			Max:        1,
+			Current:    1,
+			Desired:    1,
+			Generation: 1,
+			Nodes: []*Node{
+				{ProviderID: "provider-id"},
+			},
+		},
+	}
+
+	// immediate cancellation
+	{
+		var evictCount int32
+
+		mgr := &KubernetesNodePoolManager{
+			logger:      logger,
+			kube:        setupMockKubernetes(t, []*v1.Node{node}, pods),
+			backend:     backend,
+			drainConfig: &DrainConfig{},
+		}
+
+		evictPod = func(client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
+			atomic.AddInt32(&evictCount, 1)
+			return nil
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		err := mgr.TerminateNode(ctx, &Node{Name: node.Name}, false)
+		evictCountFinal := atomic.LoadInt32(&evictCount)
+		assert.Zero(t, evictCountFinal)
+		assert.EqualValues(t, err, context.Canceled)
+	}
+
+	// cancel after first pod
+	{
+		var evictCount int32
+		blockEviction := sync.WaitGroup{}
+		blockHelper := sync.WaitGroup{}
+		blockEviction.Add(1)
+		// add two to the wg counter because we have two pods that will be
+		// evicted in parallel.
+		blockHelper.Add(2)
+
+		evictPod = func(client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
+			// unblock so we can be cancelled
+			blockHelper.Done()
+			// wait until we're unblocked
+			blockEviction.Wait()
+			atomic.AddInt32(&evictCount, 1)
+			return removePod(client, pod)
+		}
+
+		mgr := &KubernetesNodePoolManager{
+			logger:      logger,
+			kube:        setupMockKubernetes(t, []*v1.Node{node}, pods),
+			backend:     backend,
+			drainConfig: &DrainConfig{},
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+
+		go func() {
+			// wait until evict() unblocks us
+			blockHelper.Wait()
+			cancel()
+			// unblock evict()
+			blockEviction.Done()
+		}()
+
+		err := mgr.TerminateNode(ctx, &Node{Name: node.Name}, false)
+
+		evictCountFinal := atomic.LoadInt32(&evictCount)
+		assert.Equal(t, int32(2), evictCountFinal)
+		assert.EqualValues(t, err, context.Canceled)
+	}
+
+	// cancel during slow eviction
+	{
+		var deleteCount int32
+		evictPod = evictPodFailPDB
+
+		mgr := &KubernetesNodePoolManager{
+			logger:  logger,
+			kube:    setupMockKubernetes(t, []*v1.Node{node}, pods),
+			backend: backend,
+			drainConfig: &DrainConfig{
+				ForceEvictionInterval: time.Minute,
+				PollInterval:          time.Second,
+			},
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		deletePod = func(client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
+			atomic.AddInt32(&deleteCount, 1)
+			cancel()
+			return nil
+		}
+		err := mgr.TerminateNode(ctx, &Node{Name: node.Name}, false)
+
+		deleteCountFinal := atomic.LoadInt32(&deleteCount)
+		assert.EqualValues(t, int32(1), deleteCountFinal)
+		assert.EqualValues(t, err, context.Canceled)
+	}
+}

--- a/pkg/updatestrategy/node_pool_manager.go
+++ b/pkg/updatestrategy/node_pool_manager.go
@@ -44,6 +44,7 @@ type NodePoolManager interface {
 	CordonNode(node *Node) error
 }
 
+// DrainConfig contains the various settings for the smart node draining algorithm
 type DrainConfig struct {
 	// Start forcefully evicting pods <ForceEvictionGracePeriod> after node drain started
 	ForceEvictionGracePeriod time.Duration
@@ -190,7 +191,7 @@ func (m *KubernetesNodePoolManager) updateNode(node *Node, needsUpdate func(*Nod
 	return backoff.Retry(taintNode, backoffCfg)
 }
 
-// aabelNode annotates a Kubernetes node object in case the annotation is not already
+// annotateNode annotates a Kubernetes node object in case the annotation is not already
 // defined.
 func (m *KubernetesNodePoolManager) annotateNode(node *Node, annotationKey, annotationValue string) error {
 	return m.updateNode(

--- a/pkg/updatestrategy/node_pool_manager.go
+++ b/pkg/updatestrategy/node_pool_manager.go
@@ -4,19 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff"
 	log "github.com/sirupsen/logrus"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
-	"golang.org/x/sync/errgroup"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
-	policy "k8s.io/client-go/pkg/apis/policy/v1beta1"
 )
 
 const (
@@ -47,25 +44,42 @@ type NodePoolManager interface {
 	CordonNode(node *Node) error
 }
 
+type DrainConfig struct {
+	// Start forcefully evicting pods <ForceEvictionGracePeriod> after node drain started
+	ForceEvictionGracePeriod time.Duration
+
+	// Only force evict pods that are at least <MinPodLifetime> old
+	MinPodLifetime time.Duration
+
+	// Wait until all healthy pods in the same PDB are at least <MinHealthyPDBSiblingCreationTime> old
+	MinHealthyPDBSiblingLifetime time.Duration
+
+	// Wait until all unhealthy pods in the same PDB are at least <MinUnhealthyPDBSiblingCreationTime> old
+	MinUnhealthyPDBSiblingLifetime time.Duration
+
+	// Wait at least <ForceEvictionInterval> between force evictions to allow controllers to catch up
+	ForceEvictionInterval time.Duration
+}
+
 // KubernetesNodePoolManager defines a node pool manager which uses the
 // Kubernetes API along with a node pool provider backend to manage node pools.
 type KubernetesNodePoolManager struct {
-	kube            kubernetes.Interface
-	backend         ProviderNodePoolsBackend
-	logger          *log.Entry
-	maxEvictTimeout time.Duration
+	kube        kubernetes.Interface
+	backend     ProviderNodePoolsBackend
+	logger      *log.Entry
+	drainConfig *DrainConfig
 }
 
 // NewKubernetesNodePoolManager initializes a new Kubernetes NodePool manager
 // which can manage single node pools based on the nodes registered in the
 // Kubernetes API and the related NodePoolBackend for those nodes e.g.
 // ASGNodePool.
-func NewKubernetesNodePoolManager(logger *log.Entry, kubeClient kubernetes.Interface, poolBackend ProviderNodePoolsBackend, maxEvictTimeout time.Duration) *KubernetesNodePoolManager {
+func NewKubernetesNodePoolManager(logger *log.Entry, kubeClient kubernetes.Interface, poolBackend ProviderNodePoolsBackend, drainConfig *DrainConfig) *KubernetesNodePoolManager {
 	return &KubernetesNodePoolManager{
-		kube:            kubeClient,
-		backend:         poolBackend,
-		logger:          logger,
-		maxEvictTimeout: maxEvictTimeout,
+		kube:        kubeClient,
+		backend:     poolBackend,
+		logger:      logger,
+		drainConfig: drainConfig,
 	}
 }
 
@@ -337,261 +351,11 @@ func (m *KubernetesNodePoolManager) ScalePool(ctx context.Context, nodePool *api
 	}
 }
 
-// drain tries to evict all of the pods on a node.
-// pods are evicted in parallel.
-func (m *KubernetesNodePoolManager) drain(ctx context.Context, node *Node) error {
-	m.logger.WithField("node", node.Name).Info("Draining node")
-
-	err := m.labelNode(node, lifecycleStatusLabel, lifecycleStatusDraining)
-	if err != nil {
-		return err
-	}
-
-	pods, err := m.getPodsByNode(node.Name)
-	if err != nil {
-		return err
-	}
-
-	var evictionGroup errgroup.Group
-	for _, pod := range pods.Items {
-		pod := pod
-		evictionGroup.Go(func() error {
-			evictPod := func() error {
-				// we check at the start because there's a continue in the loop body
-				err := ctx.Err()
-				if err != nil {
-					return backoff.Permanent(err)
-				}
-
-				// Don't bother with this pod if it's not evictable.
-				if !m.isEvictablePod(pod) {
-					return nil
-				}
-
-				err = evictPod(m.kube, m.logger, &pod)
-				if err != nil {
-					if apiErrors.IsTooManyRequests(err) || isMultiplePDBsErr(err) {
-						m.logger.WithFields(log.Fields{
-							"ns":   pod.Namespace,
-							"pod":  pod.Name,
-							"node": pod.Spec.NodeName,
-						}).Info("Pod Disruption Budget violated")
-					}
-					return err
-				}
-				return nil
-			}
-
-			// We try to evict all pods of a node by calling evict on all of them once. If we encounter an
-			// error we will backoff and try again for as long as `maxEvictTimeout`. If after `maxEvictTimeout`
-			// we still receive an error related to pod disruption budget violations we will continue and
-			// forcefully shutdown the pod in the next step.
-			backoffCfg := backoff.NewExponentialBackOff()
-			backoffCfg.MaxElapsedTime = m.maxEvictTimeout
-			err := backoff.Retry(evictPod, backoffCfg)
-			if err != nil {
-				if !apiErrors.IsTooManyRequests(err) && !isMultiplePDBsErr(err) {
-					m.logger.WithFields(log.Fields{
-						"ns":   pod.Namespace,
-						"pod":  pod.Name,
-						"node": pod.Spec.NodeName,
-					}).Errorf("Failed to evict pod: %v", err)
-					return err
-				}
-			}
-			return nil
-		})
-	}
-
-	err = evictionGroup.Wait()
-	if err != nil {
-		return err
-	}
-
-	// Delete all remaining evictable pods disregarding their pod disruption budgets. It's necessary
-	// in case a pod disruption budget must be violated in order to proceed with a cluster update.
-	pods, err = m.getPodsByNode(node.Name)
-	if err != nil {
-		return err
-	}
-
-	var deleteGroup errgroup.Group
-	for _, pod := range pods.Items {
-		pod := pod
-
-		deleteGroup.Go(func() error {
-			// Don't bother with this pod if it's not evictable.
-			if !m.isEvictablePod(pod) {
-				return nil
-			}
-
-			logger := m.logger.WithFields(log.Fields{
-				"ns":   pod.Namespace,
-				"pod":  pod.Name,
-				"node": pod.Spec.NodeName,
-			})
-
-			err := m.kube.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{
-				GracePeriodSeconds: pod.Spec.TerminationGracePeriodSeconds,
-			})
-			if err != nil {
-				logger.Errorf("Failed to delete pod: %v", err)
-				return err
-			}
-
-			if err = ctx.Err(); err != nil {
-				return err
-			}
-
-			// wait for pod to be terminated and gone from the node.
-			err = waitForPodTermination(m.kube, pod)
-			if err != nil {
-				logger.Warnf("Pod not terminated within grace period: %s", err)
-			}
-
-			logger.Info("Pod deleted")
-			return nil
-		})
-	}
-
-	return deleteGroup.Wait()
-}
-
-// isMultiplePDBsErr returns true if the error is caused by multiple PDBs
-// defined for a single pod.
-func isMultiplePDBsErr(err error) bool {
-	return strings.Contains(err.Error(), multiplePDBsErrMsg)
-}
-
-// evictPod tries to evict a pod from a node.
-// Note: this is defined as a variable so it can be easily mocked in tests.
-var evictPod = func(client kubernetes.Interface, logger *log.Entry, pod *v1.Pod) error {
-	localLogger := logger.WithFields(log.Fields{
-		"ns":   pod.Namespace,
-		"pod":  pod.Name,
-		"node": pod.Spec.NodeName,
-	})
-
-	updated, err := client.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
-	if err != nil {
-		if apiErrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-
-	if updated.Status.Phase == v1.PodSucceeded || updated.Status.Phase == v1.PodFailed {
-		// Completed, just ignore
-		return nil
-	}
-
-	if updated.Spec.NodeName != pod.Spec.NodeName {
-		// Already evicted
-		return nil
-	}
-
-	eviction := &policy.Eviction{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      pod.Name,
-			Namespace: pod.Namespace,
-		},
-		DeleteOptions: &metav1.DeleteOptions{
-			GracePeriodSeconds: pod.Spec.TerminationGracePeriodSeconds,
-		},
-	}
-
-	err = client.CoreV1().Pods(pod.Namespace).Evict(eviction)
-	if err != nil {
-		return err
-	}
-	localLogger.Info("Evicting pod")
-
-	// wait for the pod to be actually evicted and gone from the node.
-	// It has TerminationGracePeriodSeconds time to clean up.
-	start := time.Now().UTC()
-	err = waitForPodTermination(client, *pod)
-	if err != nil {
-		localLogger.Warnf("Pod not terminated within grace period: %s", err)
-	}
-
-	localLogger.Infof("Pod evicted. (Observed termination period: %s)", time.Now().UTC().Sub(start))
-	return nil
-}
-
-// waitForPodTermination waits for a pod to be terminated by looking up the pod
-// in the API server.
-// It waits for up to TerminationGracePeriodSeconds as specified on the pod +
-// an additional eviction head room.
-// This is to fully respect the termination expectations as described in:
-// https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
-func waitForPodTermination(client kubernetes.Interface, pod v1.Pod) error {
-	if pod.Spec.TerminationGracePeriodSeconds == nil {
-		// if no grace period is defined, we don't wait.
-		return nil
-	}
-
-	waitForTermination := func() error {
-		newpod, err := client.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
-		if err != nil {
-			if apiErrors.IsNotFound(err) {
-				return nil
-			}
-			return err
-		}
-
-		// statefulset pods have the same name after restart, check the uid as well
-		if newpod.GetObjectMeta().GetUID() == pod.GetObjectMeta().GetUID() {
-			return fmt.Errorf("pod not terminated")
-		}
-
-		return nil
-	}
-
-	gracePeriod := time.Duration(*pod.Spec.TerminationGracePeriodSeconds)*time.Second + podEvictionHeadroom
-
-	backoffCfg := backoff.NewExponentialBackOff()
-	backoffCfg.MaxElapsedTime = gracePeriod
-	return backoff.Retry(waitForTermination, backoffCfg)
-}
-
 // CordonNode marks a node unschedulable.
 func (m *KubernetesNodePoolManager) CordonNode(node *Node) error {
 	unschedulable := []byte(`{"spec": {"unschedulable": true}}`)
 	_, err := m.kube.CoreV1().Nodes().Patch(node.Name, types.StrategicMergePatchType, unschedulable)
 	return err
-}
-
-// getPodsByNode returns all pods currently scheduled to a node, regardless of their status.
-func (m *KubernetesNodePoolManager) getPodsByNode(nodeName string) (*v1.PodList, error) {
-	opts := metav1.ListOptions{
-		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
-	}
-
-	return m.kube.CoreV1().Pods(v1.NamespaceAll).List(opts)
-}
-
-// isEvictablePod detects whether it makes sense to evict a pod.
-// Non-evictable pods are pods managed by DaemonSets and mirror pods.
-func (m *KubernetesNodePoolManager) isEvictablePod(pod v1.Pod) bool {
-	logger := m.logger.WithFields(log.Fields{
-		"ns":   pod.Namespace,
-		"pod":  pod.Name,
-		"node": pod.Spec.NodeName,
-	})
-
-	if _, ok := pod.Annotations[mirrorPodAnnotation]; ok {
-		logger.Debug("Mirror Pod not evictable")
-		return false
-	}
-
-	for _, owner := range pod.GetOwnerReferences() {
-		if owner.Kind == "DaemonSet" {
-			logger.Debug("DaemonSet Pod not evictable")
-			return false
-		}
-	}
-
-	return true
 }
 
 // WaitForDesiredNodes waits for the current number of nodes to match the

--- a/pkg/updatestrategy/node_pool_manager.go
+++ b/pkg/updatestrategy/node_pool_manager.go
@@ -59,6 +59,9 @@ type DrainConfig struct {
 
 	// Wait at least <ForceEvictionInterval> between force evictions to allow controllers to catch up
 	ForceEvictionInterval time.Duration
+
+	// Wait for <PollInterval> between force eviction attempts
+	PollInterval time.Duration
 }
 
 // KubernetesNodePoolManager defines a node pool manager which uses the

--- a/pkg/updatestrategy/node_pool_manager.go
+++ b/pkg/updatestrategy/node_pool_manager.go
@@ -172,8 +172,7 @@ func (m *KubernetesNodePoolManager) updateNode(node *Node, needsUpdate func(*Nod
 		}
 
 		if patch(updatedNode) {
-			_, err := m.kube.CoreV1().Nodes().Update(updatedNode)
-			if err != nil {
+			if _, err := m.kube.CoreV1().Nodes().Update(updatedNode); err != nil {
 				// automatically retry if there was a conflicting update.
 				serr, ok := err.(*apiErrors.StatusError)
 				if ok && serr.Status().Reason == metav1.StatusReasonConflict {

--- a/pkg/updatestrategy/node_pool_manager_test.go
+++ b/pkg/updatestrategy/node_pool_manager_test.go
@@ -127,6 +127,43 @@ func TestLabelNodes(t *testing.T) {
 
 	err := mgr.labelNode(&Node{Name: node.Name}, "foo", "bar")
 	assert.NoError(t, err)
+
+	updated, err := mgr.kube.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.EqualValues(t, updated.Labels, map[string]string{"foo": "bar"})
+
+	err = mgr.labelNode(&Node{Name: node.Name}, "foo", "baz")
+	assert.NoError(t, err)
+
+	updated2, err := mgr.kube.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.EqualValues(t, updated2.Labels, map[string]string{"foo": "baz"})
+}
+
+func TestAnnotateNodes(t *testing.T) {
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+	}
+
+	mgr := &KubernetesNodePoolManager{
+		kube: setupMockKubernetes(t, []*v1.Node{node}, nil),
+	}
+
+	err := mgr.annotateNode(&Node{Name: node.Name}, "foo", "bar")
+	assert.NoError(t, err)
+
+	updated, err := mgr.kube.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.EqualValues(t, updated.Annotations, map[string]string{"foo": "bar"})
+
+	err = mgr.annotateNode(&Node{Name: node.Name}, "foo", "baz")
+	assert.NoError(t, err)
+
+	updated2, err := mgr.kube.CoreV1().Nodes().Get(node.Name, metav1.GetOptions{})
+	assert.NoError(t, err)
+	assert.EqualValues(t, updated2.Annotations, map[string]string{"foo": "baz"})
 }
 
 func TestTaintNode(t *testing.T) {

--- a/pkg/updatestrategy/node_pool_manager_test.go
+++ b/pkg/updatestrategy/node_pool_manager_test.go
@@ -2,16 +2,12 @@ package updatestrategy
 
 import (
 	"context"
-	"net/http"
-	"sync"
-	"sync/atomic"
 	"testing"
 
 	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -252,7 +248,7 @@ func TestCordonNode(t *testing.T) {
 }
 
 func TestScalePool(tt *testing.T) {
-	evictPod = func(client kubernetes.Interface, logger *log.Entry, pod *v1.Pod) error {
+	evictPod = func(client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
 		return nil
 	}
 
@@ -358,223 +354,5 @@ func TestScalePool(tt *testing.T) {
 			}
 			assert.NoError(t, mgr.ScalePool(context.Background(), &api.NodePool{Name: "test"}, tc.replicas))
 		})
-	}
-}
-
-func TestTerminateNode(t *testing.T) {
-	nodeName := "test"
-	evictPod = func(client kubernetes.Interface, logger *log.Entry, pod *v1.Pod) error {
-		return nil
-	}
-
-	pods := []*v1.Pod{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "a",
-				Namespace: "default",
-			},
-			Spec: v1.PodSpec{
-				NodeName: nodeName,
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "b",
-				Namespace: "default",
-				Annotations: map[string]string{
-					mirrorPodAnnotation: "",
-				},
-			},
-			Spec: v1.PodSpec{
-				NodeName: nodeName,
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "c",
-				Namespace: "default",
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						Kind: "DaemonSet",
-					},
-				},
-			},
-			Spec: v1.PodSpec{
-				NodeName: nodeName,
-			},
-		},
-	}
-
-	node := &v1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: nodeName,
-		},
-	}
-
-	logger := log.WithField("test", true)
-	backend := &mockProviderNodePoolsBackend{
-		nodePool: &NodePool{
-			Min:        1,
-			Max:        1,
-			Current:    1,
-			Desired:    1,
-			Generation: 1,
-			Nodes: []*Node{
-				{ProviderID: "provider-id"},
-			},
-		},
-	}
-	mgr := &KubernetesNodePoolManager{
-		logger:      logger,
-		kube:        setupMockKubernetes(t, []*v1.Node{node}, pods),
-		backend:     backend,
-		drainConfig: &DrainConfig{},
-	}
-
-	err := mgr.TerminateNode(context.Background(), &Node{Name: node.Name}, false)
-	assert.NoError(t, err)
-
-	// test when evictPod returns 429
-	evictPod = func(client kubernetes.Interface, logger *log.Entry, pod *v1.Pod) error {
-		return &errors.StatusError{
-			ErrStatus: metav1.Status{
-				Code: http.StatusTooManyRequests,
-			},
-		}
-	}
-
-	mgr.kube = setupMockKubernetes(t, []*v1.Node{node}, pods)
-	err = mgr.TerminateNode(context.Background(), &Node{Name: node.Name}, false)
-	assert.NoError(t, err)
-}
-
-func TestTerminateNodeCancelled(t *testing.T) {
-	nodeName := "test"
-
-	var evictCount int32
-	blockEviction := sync.WaitGroup{}
-	blockHelper := sync.WaitGroup{}
-	blockEviction.Add(1)
-	// add two to the wg counter because we have two pods that will be
-	// evicted in parallel.
-	blockHelper.Add(2)
-
-	evictPod = func(client kubernetes.Interface, logger *log.Entry, pod *v1.Pod) error {
-		// unblock so we can be cancelled
-		blockHelper.Done()
-		// wait until we're unblocked
-		blockEviction.Wait()
-		atomic.AddInt32(&evictCount, 1)
-		return nil
-	}
-
-	pods := []*v1.Pod{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "a",
-				Namespace: "default",
-			},
-			Spec: v1.PodSpec{
-				NodeName: nodeName,
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "b",
-				Namespace: "default",
-				Annotations: map[string]string{
-					mirrorPodAnnotation: "",
-				},
-			},
-			Spec: v1.PodSpec{
-				NodeName: nodeName,
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "c",
-				Namespace: "default",
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						Kind: "DaemonSet",
-					},
-				},
-			},
-			Spec: v1.PodSpec{
-				NodeName: nodeName,
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "d",
-				Namespace: "default",
-			},
-			Spec: v1.PodSpec{
-				NodeName: nodeName,
-			},
-		},
-	}
-
-	node := &v1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: nodeName,
-		},
-	}
-
-	logger := log.WithField("test", true)
-	backend := &mockProviderNodePoolsBackend{
-		nodePool: &NodePool{
-			Min:        1,
-			Max:        1,
-			Current:    1,
-			Desired:    1,
-			Generation: 1,
-			Nodes: []*Node{
-				{ProviderID: "provider-id"},
-			},
-		},
-	}
-
-	// immediate cancellation
-	{
-		mgr := &KubernetesNodePoolManager{
-			logger:      logger,
-			kube:        setupMockKubernetes(t, []*v1.Node{node}, pods),
-			backend:     backend,
-			drainConfig: &DrainConfig{},
-		}
-
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		err := mgr.TerminateNode(ctx, &Node{Name: node.Name}, false)
-		evictCountFinal := atomic.LoadInt32(&evictCount)
-		assert.Zero(t, evictCountFinal)
-		assert.Error(t, err)
-	}
-
-	// cancel after first pod
-	{
-		mgr := &KubernetesNodePoolManager{
-			logger:      logger,
-			kube:        setupMockKubernetes(t, []*v1.Node{node}, pods),
-			backend:     backend,
-			drainConfig: &DrainConfig{},
-		}
-
-		ctx, cancel := context.WithCancel(context.Background())
-
-		go func() {
-			// wait until evict() unblocks us
-			blockHelper.Wait()
-			cancel()
-			// unblock evict()
-			blockEviction.Done()
-		}()
-
-		err := mgr.TerminateNode(ctx, &Node{Name: node.Name}, false)
-
-		evictCountFinal := atomic.LoadInt32(&evictCount)
-		assert.Equal(t, int32(2), evictCountFinal)
-		assert.Error(t, err)
 	}
 }

--- a/pkg/updatestrategy/node_pool_manager_test.go
+++ b/pkg/updatestrategy/node_pool_manager_test.go
@@ -6,7 +6,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
 
@@ -95,7 +94,7 @@ func TestGetPool(t *testing.T) {
 		logger,
 		setupMockKubernetes(t, []*v1.Node{node}, nil),
 		backend,
-		0,
+		&DrainConfig{},
 	)
 
 	// test getting nodes successfully
@@ -426,10 +425,10 @@ func TestTerminateNode(t *testing.T) {
 		},
 	}
 	mgr := &KubernetesNodePoolManager{
-		logger:          logger,
-		kube:            setupMockKubernetes(t, []*v1.Node{node}, pods),
-		backend:         backend,
-		maxEvictTimeout: 1 * time.Nanosecond,
+		logger:      logger,
+		kube:        setupMockKubernetes(t, []*v1.Node{node}, pods),
+		backend:     backend,
+		drainConfig: &DrainConfig{},
 	}
 
 	err := mgr.TerminateNode(context.Background(), &Node{Name: node.Name}, false)
@@ -539,10 +538,10 @@ func TestTerminateNodeCancelled(t *testing.T) {
 	// immediate cancellation
 	{
 		mgr := &KubernetesNodePoolManager{
-			logger:          logger,
-			kube:            setupMockKubernetes(t, []*v1.Node{node}, pods),
-			backend:         backend,
-			maxEvictTimeout: 1 * time.Nanosecond,
+			logger:      logger,
+			kube:        setupMockKubernetes(t, []*v1.Node{node}, pods),
+			backend:     backend,
+			drainConfig: &DrainConfig{},
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -556,10 +555,10 @@ func TestTerminateNodeCancelled(t *testing.T) {
 	// cancel after first pod
 	{
 		mgr := &KubernetesNodePoolManager{
-			logger:          logger,
-			kube:            setupMockKubernetes(t, []*v1.Node{node}, pods),
-			backend:         backend,
-			maxEvictTimeout: 1 * time.Nanosecond,
+			logger:      logger,
+			kube:        setupMockKubernetes(t, []*v1.Node{node}, pods),
+			backend:     backend,
+			drainConfig: &DrainConfig{},
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/updatestrategy/updatestrategy.go
+++ b/pkg/updatestrategy/updatestrategy.go
@@ -47,6 +47,7 @@ func (n *NodePool) ReadyNodes() []*Node {
 // node pool backend along with the corresponding Kubernetes node object.
 type Node struct {
 	Name            string
+	Annotations     map[string]string
 	Labels          map[string]string
 	Taints          []v1.Taint
 	Cordoned        bool

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -55,7 +55,6 @@ const (
 	subnetAllAZName                = "*"
 	maxApplyRetries                = 10
 	configKeyUpdateStrategy        = "update_strategy"
-	configKeyNodeMaxEvictTimeout   = "node_max_evict_timeout"
 	updateStrategyRolling          = "rolling"
 	defaultMaxRetryTime            = 5 * time.Minute
 )
@@ -581,17 +580,20 @@ func (p *clusterpyProvisioner) prepareProvision(logger *log.Entry, cluster *api.
 		updateStrategy = p.updateStrategy.Strategy
 	}
 
-	// allow clusters to override their max evict timeout
-	// use global max evict timeout if cluster doesn't define one.
-	maxEvictTimeout := p.updateStrategy.MaxEvictTimeout
-
-	maxEvictTimeoutStr, ok := cluster.ConfigItems[configKeyNodeMaxEvictTimeout]
-	if ok {
-		maxEvictTimeout, err = time.ParseDuration(maxEvictTimeoutStr)
-		if err != nil {
-			return nil, nil, nil, err
-		}
+	drainConfig := &updatestrategy.DrainConfig{
+		ForceEvictionGracePeriod:       p.updateStrategy.ForceEvictionGracePeriod,
+		MinPodLifetime:                 p.updateStrategy.MinPodLifetime,
+		MinHealthyPDBSiblingLifetime:   p.updateStrategy.MinHealthyPDBSiblingLifetime,
+		MinUnhealthyPDBSiblingLifetime: p.updateStrategy.MinUnhealthyPDBSiblingLifetime,
+		ForceEvictionInterval:          p.updateStrategy.ForceEvictionInterval,
 	}
+
+	// allow clusters to override their drain settings
+	handleDurationItem(cluster.ConfigItems, "drain_grace_period", func(v time.Duration) { drainConfig.ForceEvictionGracePeriod = v })
+	handleDurationItem(cluster.ConfigItems, "drain_min_pod_lifetime", func(v time.Duration) { drainConfig.MinPodLifetime = v })
+	handleDurationItem(cluster.ConfigItems, "drain_min_healthy_sibling_lifetime", func(v time.Duration) { drainConfig.MinHealthyPDBSiblingLifetime = v })
+	handleDurationItem(cluster.ConfigItems, "drain_min_unhealthy_sibling_lifetime", func(v time.Duration) { drainConfig.MinUnhealthyPDBSiblingLifetime = v })
+	handleDurationItem(cluster.ConfigItems, "drain_force_evict_interval", func(v time.Duration) { drainConfig.ForceEvictionInterval = v })
 
 	var updater updatestrategy.UpdateStrategy
 	var poolManager updatestrategy.NodePoolManager
@@ -605,7 +607,7 @@ func (p *clusterpyProvisioner) prepareProvision(logger *log.Entry, cluster *api.
 		// setup updater
 		poolBackend := updatestrategy.NewASGNodePoolsBackend(cluster.ID, sess)
 
-		poolManager = updatestrategy.NewKubernetesNodePoolManager(logger, client, poolBackend, maxEvictTimeout)
+		poolManager = updatestrategy.NewKubernetesNodePoolManager(logger, client, poolBackend, drainConfig)
 
 		updater = updatestrategy.NewRollingUpdateStrategy(logger, poolManager, 3)
 	default:
@@ -613,6 +615,18 @@ func (p *clusterpyProvisioner) prepareProvision(logger *log.Entry, cluster *api.
 	}
 
 	return adapter, updater, poolManager, nil
+}
+
+func handleDurationItem(configItems map[string]string, key string, set func(duration time.Duration)) error {
+	value, ok := configItems[key]
+	if ok {
+		parsed, err := time.ParseDuration(value)
+		if err != nil {
+			return fmt.Errorf("invalid value for %s: %v", key, err)
+		}
+		set(parsed)
+	}
+	return nil
 }
 
 // tagSubnets tags all subnets in the default VPC with the kubernetes cluster

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -620,8 +620,7 @@ func (p *clusterpyProvisioner) prepareProvision(logger *log.Entry, cluster *api.
 }
 
 func handleDurationItem(configItems map[string]string, key string, set func(duration time.Duration)) error {
-	value, ok := configItems[key]
-	if ok {
+	if value, ok := configItems[key]; ok {
 		parsed, err := time.ParseDuration(value)
 		if err != nil {
 			return fmt.Errorf("invalid value for %s: %v", key, err)

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -586,6 +586,7 @@ func (p *clusterpyProvisioner) prepareProvision(logger *log.Entry, cluster *api.
 		MinHealthyPDBSiblingLifetime:   p.updateStrategy.MinHealthyPDBSiblingLifetime,
 		MinUnhealthyPDBSiblingLifetime: p.updateStrategy.MinUnhealthyPDBSiblingLifetime,
 		ForceEvictionInterval:          p.updateStrategy.ForceEvictionInterval,
+		PollInterval:                   p.updateStrategy.PollInterval,
 	}
 
 	// allow clusters to override their drain settings
@@ -594,6 +595,7 @@ func (p *clusterpyProvisioner) prepareProvision(logger *log.Entry, cluster *api.
 	handleDurationItem(cluster.ConfigItems, "drain_min_healthy_sibling_lifetime", func(v time.Duration) { drainConfig.MinHealthyPDBSiblingLifetime = v })
 	handleDurationItem(cluster.ConfigItems, "drain_min_unhealthy_sibling_lifetime", func(v time.Duration) { drainConfig.MinUnhealthyPDBSiblingLifetime = v })
 	handleDurationItem(cluster.ConfigItems, "drain_force_evict_interval", func(v time.Duration) { drainConfig.ForceEvictionInterval = v })
+	handleDurationItem(cluster.ConfigItems, "drain_poll_interval", func(v time.Duration) { drainConfig.PollInterval = v })
 
 	var updater updatestrategy.UpdateStrategy
 	var poolManager updatestrategy.NodePoolManager


### PR DESCRIPTION
Implement the new node draining algorithm that's persistent, can proceed if CLM is restarted or fails and deals with bad PDBs much better.

The new algorithm works like this:
 1. Mark the node in the usual way, persist the timestamp in an annotation on the node object.
 2. Try evicting all pods on the node in parallel using the eviction API. Continue trying until none of the pods can be evicted because of PDB issues.
 3. Every N seconds (10 for now) update the list of evictable pods and try to evict normally first. If that still doesn't succeed, terminate it forcefully if all the following conditions are met:
      * `-drain-grace-period` has passed since we started draining
      * pod was created at least `-drain-min-pod-lifetime` ago
      * pods in the same PDB were created at least `-drain-min-healthy-sibling-lifetime` ago (if they're healthy) or `-drain-min-unhealthy-sibling-lifetime` (if they're not)
      * last forced termination on the node happened at least `-drain-force-evict-interval` ago
  4. If there was a forced termination, persist the timestamp in an annotation on the node object.