### PR TITLE
Downgrade container-linux-config-transpiler

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -121,7 +121,7 @@
   version = "v2.0.0"
 
 [[projects]]
-  digest = "1:beedaa1ce9cb1ddb4dc511a68d9d128773e6ada0a1bd8b9bc4b7d7026617b535"
+  digest = "1:15173ac9caac43ba3a8990716158f5fd08174293e259d0a9e67f6fc98cc39d35"
   name = "github.com/coreos/container-linux-config-transpiler"
   packages = [
     "config",
@@ -133,8 +133,8 @@
     "internal/util",
   ]
   pruneopts = "UT"
-  revision = "e2f6c9440215117e896cd70a0d489dc070080d37"
-  version = "v0.9.0"
+  revision = "b76ab0b2d66ff1ac6902f4fe118a02c1bed6e5ce"
+  version = "v0.6.1"
 
 [[projects]]
   digest = "1:0ef770954bca104ee99b3b6b7f9b240605ac03517d9f98cbc1893daa03f3c038"
@@ -153,12 +153,12 @@
   version = "v17"
 
 [[projects]]
-  digest = "1:a3b92afd962a230ba5406be2bbca2df5089cdc3a5820cba0764d54e7e1c9da21"
+  digest = "1:4170b2fbe85d262f50f5fe3c19246b7dafb3b3453aad53255019bbfe827c16b1"
   name = "github.com/coreos/ignition"
   packages = [
     "config/shared/errors",
     "config/shared/validations",
-    "config/v2_2/types",
+    "config/v2_1/types",
     "config/validate",
     "config/validate/astjson",
     "config/validate/astnode",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,7 +9,7 @@ required = [
 
 [[constraint]]
   name = "github.com/coreos/container-linux-config-transpiler"
-  version = "0.9.0"
+  version = "0.6.1"
 
 [[override]]
   name = "github.com/ajeddeloh/yaml"


### PR DESCRIPTION
Upgrading the library in #82 had the side effect of changing the
ignition format causing all nodes to be rolled on next update. Revert
the change to prevent this side effect.