### PR TITLE
Move secret decryption to provisioner

### DIFF
--- a/cmd/clm/main.go
+++ b/cmd/clm/main.go
@@ -70,7 +70,7 @@ func main() {
 
 	rootLogger := log.StandardLogger().WithFields(map[string]interface{}{})
 
-	p := provisioner.NewClusterpyProvisioner(clusterTokenSource, cfg.AssumedRole, awsConfig, &provisioner.Options{
+	p := provisioner.NewClusterpyProvisioner(clusterTokenSource, secretDecrypter, cfg.AssumedRole, awsConfig, &provisioner.Options{
 		DryRun:         cfg.DryRun,
 		ApplyOnly:      cfg.ApplyOnly,
 		UpdateStrategy: cfg.UpdateStrategy,
@@ -98,7 +98,6 @@ func main() {
 			AccountFilter:     cfg.AccountFilter,
 			Interval:          cfg.Interval,
 			DryRun:            cfg.DryRun,
-			SecretDecrypter:   secretDecrypter,
 			ConcurrentUpdates: cfg.ConcurrentUpdates,
 			EnvironmentOrder:  cfg.EnvironmentOrder,
 		}


### PR DESCRIPTION
This allows config defaults (which are currently handled by provisioner) to be correctly decrypted.