### PR TITLE
Use a $100/hr spot price cap if no pricing info is available

### DIFF
--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -163,7 +163,8 @@ func (p *AWSNodePoolProvisioner) provisionNodePool(nodePool *api.NodePool, value
 	case api.DiscountStrategySpot:
 		onDemandPrice, ok := instanceInfo.Pricing[p.Cluster.Region]
 		if !ok {
-			return fmt.Errorf("no price data for region %s, instance type %s", p.Cluster.Region, nodePool.InstanceType)
+			p.logger.Warnf("No price data for region %s, instance type %s", p.Cluster.Region, nodePool.InstanceType)
+			onDemandPrice = "100.0"
 		}
 
 		values["spot_price"] = onDemandPrice


### PR DESCRIPTION
This allows us to proceed even if we don't have pricing info and *should* be reasonably harmless. We'll move to launch templates soon anyway, so this is just a temporary hack.