### PR TITLE
Add a separate concurrency limit for forks

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -811,9 +811,12 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:39ebcc2b11457b703ae9ee2e8cca0f68df21969c6102cb3b705f76cca0ea0239"
+  digest = "1:c313aef534e493304f3666fbd24dca5932ebf776a82b7a40f961c9355794a1b1"
   name = "golang.org/x/sync"
-  packages = ["errgroup"]
+  packages = [
+    "errgroup",
+    "semaphore",
+  ]
   pruneopts = "UT"
   revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
 
@@ -1161,6 +1164,7 @@
     "golang.org/x/net/context",
     "golang.org/x/oauth2",
     "golang.org/x/sync/errgroup",
+    "golang.org/x/sync/semaphore",
     "gopkg.in/alecthomas/kingpin.v2",
     "gopkg.in/yaml.v2",
     "k8s.io/api/core/v1",

--- a/channel/config_source.go
+++ b/channel/config_source.go
@@ -1,6 +1,8 @@
 package channel
 
 import (
+	"context"
+
 	log "github.com/sirupsen/logrus"
 )
 
@@ -11,10 +13,10 @@ type ConfigVersion string
 type ConfigSource interface {
 	// Update synchronizes the local copy of the configuration with the remote one
 	// and returns the available channel versions.
-	Update(logger *log.Entry) (ConfigVersions, error)
+	Update(ctx context.Context, logger *log.Entry) (ConfigVersions, error)
 
 	// Get returns a Config related to the specified version from the local copy.
-	Get(logger *log.Entry, version ConfigVersion) (*Config, error)
+	Get(ctx context.Context, logger *log.Entry, version ConfigVersion) (*Config, error)
 
 	// Delete deletes the config.
 	Delete(logger *log.Entry, config *Config) error

--- a/channel/directory.go
+++ b/channel/directory.go
@@ -1,6 +1,8 @@
 package channel
 
 import (
+	"context"
+
 	log "github.com/sirupsen/logrus"
 )
 
@@ -16,13 +18,13 @@ func NewDirectory(location string) ConfigSource {
 	return &Directory{location: location}
 }
 
-func (d *Directory) Update(logger *log.Entry) (ConfigVersions, error) {
+func (d *Directory) Update(ctx context.Context, logger *log.Entry) (ConfigVersions, error) {
 	result := &directoryVersions{}
 	return result, nil
 }
 
 // Get returns the contents from the directory.
-func (d *Directory) Get(logger *log.Entry, version ConfigVersion) (*Config, error) {
+func (d *Directory) Get(ctx context.Context, logger *log.Entry, version ConfigVersion) (*Config, error) {
 	return &Config{
 		Path: d.location,
 	}, nil

--- a/channel/directory_test.go
+++ b/channel/directory_test.go
@@ -1,6 +1,7 @@
 package channel
 
 import (
+	"context"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -13,11 +14,11 @@ func TestDirectoryChannel(t *testing.T) {
 	logger := log.StandardLogger().WithFields(map[string]interface{}{})
 
 	d := NewDirectory(location)
-	channels, err := d.Update(logger)
+	channels, err := d.Update(context.Background(), logger)
 	require.NoError(t, err)
 	require.Empty(t, channels)
 
-	cc, err := d.Get(logger, "channel")
+	cc, err := d.Get(context.Background(), logger, "channel")
 	require.NoError(t, err)
 
 	if cc.Path != location {

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ const (
 	defaultClusterTokenName                 = "cluster-rw"
 	defaultRegistry                         = "file://clusters.yaml"
 	defaultConcurrentUpdates                = "1"
+	defaultConcurrentExternalProcesses      = "10"
 	defaultAwsMaxRetries                    = "50"
 	defaultAwsMaxRetryInterval              = "10s"
 	defaultDrainGracePeriod                 = "6h"
@@ -33,29 +34,30 @@ var defaultWorkdir = path.Join(os.TempDir(), "clm-workdir")
 
 // LifecycleManagerConfig stores the configuration for app
 type LifecycleManagerConfig struct {
-	Registry            string
-	AccountFilter       IncludeExcludeFilter
-	Token               string
-	RegistryTokenName   string
-	ClusterTokenName    string
-	AssumedRole         string
-	Interval            time.Duration
-	Debug               bool
-	DumpRequest         bool
-	DryRun              bool
-	ConcurrentUpdates   uint
-	Listen              string
-	Workdir             string
-	Directory           string
-	GitRepositoryURL    string
-	SSHPrivateKeyFile   string
-	CredentialsDir      string
-	EnvironmentOrder    []string
-	ApplyOnly           bool
-	AwsMaxRetries       int
-	AwsMaxRetryInterval time.Duration
-	UpdateStrategy      UpdateStrategy
-	RemoveVolumes       bool
+	Registry                    string
+	AccountFilter               IncludeExcludeFilter
+	Token                       string
+	RegistryTokenName           string
+	ClusterTokenName            string
+	AssumedRole                 string
+	Interval                    time.Duration
+	Debug                       bool
+	DumpRequest                 bool
+	DryRun                      bool
+	ConcurrentUpdates           uint
+	Listen                      string
+	Workdir                     string
+	Directory                   string
+	GitRepositoryURL            string
+	SSHPrivateKeyFile           string
+	CredentialsDir              string
+	EnvironmentOrder            []string
+	ConcurrentExternalProcesses uint
+	ApplyOnly                   bool
+	AwsMaxRetries               int
+	AwsMaxRetryInterval         time.Duration
+	UpdateStrategy              UpdateStrategy
+	RemoveVolumes               bool
 }
 
 // UpdateStrategy defines the default update strategy configured for the
@@ -113,5 +115,6 @@ func (cfg *LifecycleManagerConfig) ParseFlags() string {
 	kingpin.Flag("update-strategy", "Update strategy to use when updating node pools.").Default(defaultUpdateStrategy).EnumVar(&cfg.UpdateStrategy.Strategy, "rolling")
 	kingpin.Flag("remove-volumes", "Remove EBS volumes when decommissioning.").BoolVar(&cfg.RemoveVolumes)
 	kingpin.Flag("environment-order", "Roll out channel updates to the environments in a specific order.").StringsVar(&cfg.EnvironmentOrder)
+	kingpin.Flag("concurrent-external-processes", "Number of external processes allowed to run in parallel").Default(defaultConcurrentExternalProcesses).UintVar(&cfg.ConcurrentExternalProcesses)
 	return kingpin.Parse()
 }

--- a/pkg/util/command/command.go
+++ b/pkg/util/command/command.go
@@ -2,12 +2,25 @@ package command
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"os/exec"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
 )
+
+// ExecManager limits the number of external commands that are running at the same time
+type ExecManager struct {
+	sema *semaphore.Weighted
+}
+
+func NewExecManager(maxConcurrency uint) *ExecManager {
+	return &ExecManager{
+		sema: semaphore.NewWeighted(int64(maxConcurrency)),
+	}
+}
 
 func outputLines(output string) []string {
 	return strings.Split(strings.TrimRight(output, "\n"), "\n")
@@ -15,7 +28,13 @@ func outputLines(output string) []string {
 
 // RunSilently runs an exec.Cmd, capturing its output and additionally logging it
 // only if the command fails (or if debug logging is enabled)
-func RunSilently(logger *log.Entry, cmd *exec.Cmd) (string, error) {
+func (m *ExecManager) RunSilently(ctx context.Context, logger *log.Entry, cmd *exec.Cmd) (string, error) {
+	err := m.sema.Acquire(ctx, 1)
+	if err != nil {
+		return "", err
+	}
+	defer m.sema.Release(1)
+
 	rawOut, err := cmd.CombinedOutput()
 	out := string(rawOut)
 	if err != nil {
@@ -32,12 +51,18 @@ func RunSilently(logger *log.Entry, cmd *exec.Cmd) (string, error) {
 
 // Run runs an exec.Cmd, capturing its output and additionally redirecting
 // it to a logger
-func Run(logger *log.Entry, cmd *exec.Cmd) (string, error) {
+func (m *ExecManager) Run(ctx context.Context, logger *log.Entry, cmd *exec.Cmd) (string, error) {
+	err := m.sema.Acquire(ctx, 1)
+	if err != nil {
+		return "", err
+	}
+	defer m.sema.Release(1)
+
 	var output bytes.Buffer
 
 	cmd.Stdout = io.MultiWriter(&output, logger.WriterLevel(log.InfoLevel))
 	cmd.Stderr = io.MultiWriter(&output, logger.WriterLevel(log.ErrorLevel))
 
-	err := cmd.Run()
+	err = cmd.Run()
 	return output.String(), err
 }


### PR DESCRIPTION
Add a new argument, `--concurrent-external-processes`, which limit the number of external processes (like `senza` or `kubectl`) we run at the same time.
Fix #98.