### PR TITLE
Close the context once we're done

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -101,6 +101,7 @@ func (c *Controller) processWorkerLoop(ctx context.Context, workerNum uint) {
 			if nextCluster != nil {
 				c.processCluster(updateCtx, workerNum, nextCluster)
 			}
+			cancelFunc()
 		case <-ctx.Done():
 			return
 		}


### PR DESCRIPTION
The context was leaking since it was only closed if the update was aborted.