### PR TITLE
CLC update strategy

### DIFF
--- a/pkg/updatestrategy/clc_update.go
+++ b/pkg/updatestrategy/clc_update.go
@@ -1,0 +1,107 @@
+package updatestrategy
+
+import (
+	"context"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
+)
+
+const (
+	pollingInterval = 10 * time.Second
+)
+
+type CLCUpdateStrategy struct {
+	nodePoolManager NodePoolManager
+	logger          *log.Entry
+}
+
+// NewCLCUpdateStrategy initializes a new CLCUpdateStrategy.
+func NewCLCUpdateStrategy(logger *log.Entry, nodePoolManager NodePoolManager) *CLCUpdateStrategy {
+	return &CLCUpdateStrategy{
+		nodePoolManager: nodePoolManager,
+		logger:          logger.WithField("strategy", "clc"),
+	}
+}
+
+func (c *CLCUpdateStrategy) Update(ctx context.Context, nodePoolDesc *api.NodePool) error {
+	c.logger.Infof("Initializing update of node pool '%s'", nodePoolDesc.Name)
+
+	err := c.doUpdate(ctx, nodePoolDesc)
+	if err != nil {
+		if ctx.Err() != nil {
+			err := c.rollbackUpdate(nodePoolDesc)
+			if err != nil {
+				log.Errorf("Error while aborting the update for node pool '%s': %v", nodePoolDesc.Name, err)
+			}
+		}
+		return err
+	}
+
+	c.logger.Infof("Node pool '%s' successfully updated", nodePoolDesc.Name)
+	return nil
+}
+
+func (c *CLCUpdateStrategy) rollbackUpdate(nodePoolDesc *api.NodePool) error {
+	nodePool, err := c.nodePoolManager.GetPool(nodePoolDesc)
+	if err != nil {
+		return err
+	}
+
+	for _, node := range nodePool.Nodes {
+		if node.Generation != nodePool.Generation {
+			err := c.nodePoolManager.AbortNodeDecommissioning(node)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *CLCUpdateStrategy) doUpdate(ctx context.Context, nodePoolDesc *api.NodePool) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		nodePool, err := c.nodePoolManager.GetPool(nodePoolDesc)
+		if err != nil {
+			return err
+		}
+
+		oldNodes, err := c.markOldNodes(nodePool)
+		if err != nil {
+			return err
+		}
+
+		if oldNodes == 0 {
+			return nil
+		}
+
+		c.logger.Infof("Waiting for decommissioning of old nodes (%d left)", oldNodes)
+
+		// wait for CLC to finish rolling the nodes
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollingInterval):
+		}
+	}
+}
+
+func (c *CLCUpdateStrategy) markOldNodes(nodePool *NodePool) (int, error) {
+	marked := 0
+	for _, node := range nodePool.Nodes {
+		if node.Generation != nodePool.Generation {
+			err := c.nodePoolManager.MarkNodeForDecommission(node)
+			marked++
+			if err != nil {
+				return 0, err
+			}
+		}
+	}
+	return marked, nil
+}

--- a/pkg/updatestrategy/clc_update.go
+++ b/pkg/updatestrategy/clc_update.go
@@ -8,20 +8,18 @@ import (
 	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
 )
 
-const (
-	pollingInterval = 10 * time.Second
-)
-
 type CLCUpdateStrategy struct {
 	nodePoolManager NodePoolManager
 	logger          *log.Entry
+	pollingInterval time.Duration
 }
 
 // NewCLCUpdateStrategy initializes a new CLCUpdateStrategy.
-func NewCLCUpdateStrategy(logger *log.Entry, nodePoolManager NodePoolManager) *CLCUpdateStrategy {
+func NewCLCUpdateStrategy(logger *log.Entry, nodePoolManager NodePoolManager, pollingInterval time.Duration) *CLCUpdateStrategy {
 	return &CLCUpdateStrategy{
 		nodePoolManager: nodePoolManager,
 		logger:          logger.WithField("strategy", "clc"),
+		pollingInterval: pollingInterval,
 	}
 }
 
@@ -87,7 +85,7 @@ func (c *CLCUpdateStrategy) doUpdate(ctx context.Context, nodePoolDesc *api.Node
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(pollingInterval):
+		case <-time.After(c.pollingInterval):
 		}
 	}
 }

--- a/pkg/updatestrategy/clc_update_test.go
+++ b/pkg/updatestrategy/clc_update_test.go
@@ -1,0 +1,230 @@
+package updatestrategy
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type nodeState int
+
+const (
+	nodeStateReady nodeState = iota
+	nodeStateDecommissionPending
+	nodeStateDecommissioning
+	nodeStateTerminated
+)
+
+type mockNodeCLC struct {
+	name       string
+	generation int
+	state      nodeState
+}
+
+type mockNodePoolManagerCLC struct {
+	generation            int
+	nodes                 []*mockNodeCLC
+	abortAfterTerminating string
+	abortFunc             func()
+}
+
+func (m *mockNodePoolManagerCLC) advance() {
+	for _, node := range m.nodes {
+		switch node.state {
+		case nodeStateDecommissionPending:
+			log.Infof("decommissioning node %s", node.name)
+			node.state = nodeStateDecommissioning
+			return
+		case nodeStateDecommissioning:
+			log.Infof("decommissioned node %s", node.name)
+			node.state = nodeStateTerminated
+			if node.name == m.abortAfterTerminating {
+				m.abortFunc()
+			}
+			return
+		case nodeStateTerminated:
+			if node.name == m.abortAfterTerminating {
+				return
+			}
+		}
+	}
+}
+
+func (m *mockNodePoolManagerCLC) GetPool(nodePool *api.NodePool) (*NodePool, error) {
+	m.advance()
+
+	result := &NodePool{
+		Min:        0,
+		Desired:    0,
+		Current:    0,
+		Max:        10,
+		Generation: m.generation,
+	}
+
+	for _, node := range m.nodes {
+		if node.state != nodeStateTerminated {
+			var lifecycleStatus string
+			switch node.state {
+			case nodeStateReady:
+				lifecycleStatus = "ready"
+			case nodeStateDecommissionPending:
+				lifecycleStatus = "decommission-pending"
+			case nodeStateDecommissioning:
+				lifecycleStatus = "decommissioning"
+			default:
+				panic("invalid lifecycle status")
+			}
+
+			result.Nodes = append(result.Nodes, &Node{
+				Name:       node.name,
+				Labels:     map[string]string{"lifecycle-status": lifecycleStatus},
+				Generation: node.generation,
+			})
+		}
+	}
+
+	return result, nil
+}
+
+func (m *mockNodePoolManagerCLC) findNode(nodeName string) (*mockNodeCLC, error) {
+	for _, n := range m.nodes {
+		if n.name == nodeName {
+			return n, nil
+		}
+	}
+	return nil, fmt.Errorf("unknown node: %s", nodeName)
+}
+
+func (m *mockNodePoolManagerCLC) MarkNodeForDecommission(node *Node) error {
+	n, err := m.findNode(node.Name)
+	if err != nil {
+		return err
+	}
+
+	if n.generation == m.generation {
+		return fmt.Errorf("decommission attempted on an up-to-date node %s", node.Name)
+	}
+
+	if n.state == nodeStateReady {
+		n.state = nodeStateDecommissionPending
+	}
+	return nil
+}
+
+func (m *mockNodePoolManagerCLC) AbortNodeDecommissioning(node *Node) error {
+	n, err := m.findNode(node.Name)
+	if err != nil {
+		return err
+	}
+
+	if n.state == nodeStateDecommissionPending {
+		n.state = nodeStateReady
+	}
+	return nil
+}
+
+func (m *mockNodePoolManagerCLC) ScalePool(ctx context.Context, nodePool *api.NodePool, replicas int) error {
+	panic("should not be called")
+}
+
+func (m *mockNodePoolManagerCLC) TerminateNode(ctx context.Context, node *Node, decrementDesired bool) error {
+	panic("should not be called")
+}
+
+func (m *mockNodePoolManagerCLC) CordonNode(node *Node) error {
+	panic("should not be called")
+}
+
+func TestCLCUpdateStrategy(t *testing.T) {
+	for _, tc := range []struct {
+		name                  string
+		nodePoolGeneration    int
+		nodes                 []*mockNodeCLC
+		abortAfterTerminating string
+		expectTerminated      []string
+		expectNotTerminated   []string
+	}{
+		{
+			name:               "old nodes are decommissioned, new nodes are left intact",
+			nodePoolGeneration: 3,
+			nodes: []*mockNodeCLC{
+				{name: "node-1", generation: 1},
+				{name: "node-2", generation: 3},
+				{name: "node-3", generation: 3},
+				{name: "node-4", generation: 2},
+				{name: "node-5", generation: 10},
+			},
+			expectTerminated:    []string{"node-1", "node-4", "node-5"},
+			expectNotTerminated: []string{"node-2", "node-3"},
+		},
+		{
+			name:               "works fine if there are no old nodes",
+			nodePoolGeneration: 3,
+			nodes: []*mockNodeCLC{
+				{name: "node-1", generation: 3},
+				{name: "node-2", generation: 3},
+			},
+			expectNotTerminated: []string{"node-1", "node-2"},
+		},
+		{
+			name:               "correctly aborts",
+			nodePoolGeneration: 3,
+			nodes: []*mockNodeCLC{
+				{name: "node-1", generation: 1},
+				{name: "node-2", generation: 3},
+				{name: "node-3", generation: 2},
+				{name: "node-4", generation: 4},
+				{name: "node-5", generation: 3},
+				{name: "node-6", generation: 10},
+			},
+			abortAfterTerminating: "node-3",
+			expectTerminated:      []string{"node-1", "node-3"},
+			expectNotTerminated:   []string{"node-2", "node-4", "node-5", "node-6"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := log.WithField("test", true)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			nodePoolManager := &mockNodePoolManagerCLC{
+				generation: tc.nodePoolGeneration,
+				nodes:      tc.nodes,
+				abortAfterTerminating: tc.abortAfterTerminating,
+				abortFunc:             cancel,
+			}
+			strategy := NewCLCUpdateStrategy(logger, nodePoolManager, 50*time.Millisecond)
+			nodePool := &api.NodePool{
+				DiscountStrategy: "none",
+				InstanceType:     "m4.large",
+				Name:             "test-node-pool",
+				Profile:          "test-profile",
+				MinSize:          0,
+				MaxSize:          10,
+			}
+
+			err := strategy.Update(ctx, nodePool)
+			if tc.abortAfterTerminating == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualValues(t, context.Canceled, err)
+			}
+
+			for _, nodeName := range tc.expectTerminated {
+				node, err := nodePoolManager.findNode(nodeName)
+				require.NoError(t, err)
+				require.Equal(t, nodeStateTerminated, node.state, "expected node %s to be terminated", nodeName)
+			}
+			for _, nodeName := range tc.expectNotTerminated {
+				node, err := nodePoolManager.findNode(nodeName)
+				require.NoError(t, err)
+				require.Equal(t, nodeStateReady, node.state, "expected node %s to be ready", nodeName)
+			}
+		})
+	}
+}

--- a/pkg/updatestrategy/clc_update_test.go
+++ b/pkg/updatestrategy/clc_update_test.go
@@ -6,11 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
-	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
-
 	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
 )
 
 type nodeState int

--- a/pkg/updatestrategy/rolling_update_test.go
+++ b/pkg/updatestrategy/rolling_update_test.go
@@ -51,6 +51,10 @@ func (m *mockNodePoolManager) MarkNodeForDecommission(node *Node) error {
 	return nil
 }
 
+func (m *mockNodePoolManager) AbortNodeDecommissioning(node *Node) error {
+	return nil
+}
+
 func (m *mockNodePoolManager) ScalePool(ctx context.Context, nodePool *api.NodePool, replicas int) error {
 	if replicas > m.nodePool.Current {
 		delta := replicas - m.nodePool.Current

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -59,6 +59,7 @@ const (
 	updateStrategyRolling          = "rolling"
 	updateStrategyCLC              = "clc"
 	defaultMaxRetryTime            = 5 * time.Minute
+	clcPollingInterval             = 10 * time.Second
 )
 
 type clusterpyProvisioner struct {
@@ -657,7 +658,7 @@ func (p *clusterpyProvisioner) prepareProvision(logger *log.Entry, cluster *api.
 	case updateStrategyRolling:
 		updater = updatestrategy.NewRollingUpdateStrategy(logger, poolManager, 3)
 	case updateStrategyCLC:
-		updater = updatestrategy.NewCLCUpdateStrategy(logger, poolManager)
+		updater = updatestrategy.NewCLCUpdateStrategy(logger, poolManager, clcPollingInterval)
 	default:
 		return nil, nil, nil, fmt.Errorf("unknown update strategy: %s", p.updateStrategy)
 	}

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -53,11 +53,11 @@ const (
 	resourceLifecycleOwned         = "owned"
 	subnetsConfigItemKey           = "subnets"
 	vpcIDConfigItemKey             = "vpc_id"
-	vpcIPv4CIDRBlockConfigItemKey  = "vpc_ipv4_cidr"
 	subnetAllAZName                = "*"
 	maxApplyRetries                = 10
 	configKeyUpdateStrategy        = "update_strategy"
 	updateStrategyRolling          = "rolling"
+	updateStrategyCLC              = "clc"
 	defaultMaxRetryTime            = 5 * time.Minute
 )
 
@@ -621,45 +621,48 @@ func (p *clusterpyProvisioner) prepareProvision(logger *log.Entry, cluster *api.
 		PollInterval:                   p.updateStrategy.PollInterval,
 	}
 
+	client, err := kubernetes.NewKubeClientWithTokenSource(cluster.APIServerURL, p.tokenSource)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// setup updater
+
 	// allow clusters to override their drain settings
-	handleDurationItem(cluster.ConfigItems, "drain_grace_period", func(v time.Duration) { drainConfig.ForceEvictionGracePeriod = v })
-	handleDurationItem(cluster.ConfigItems, "drain_min_pod_lifetime", func(v time.Duration) { drainConfig.MinPodLifetime = v })
-	handleDurationItem(cluster.ConfigItems, "drain_min_healthy_sibling_lifetime", func(v time.Duration) { drainConfig.MinHealthyPDBSiblingLifetime = v })
-	handleDurationItem(cluster.ConfigItems, "drain_min_unhealthy_sibling_lifetime", func(v time.Duration) { drainConfig.MinUnhealthyPDBSiblingLifetime = v })
-	handleDurationItem(cluster.ConfigItems, "drain_force_evict_interval", func(v time.Duration) { drainConfig.ForceEvictionInterval = v })
-	handleDurationItem(cluster.ConfigItems, "drain_poll_interval", func(v time.Duration) { drainConfig.PollInterval = v })
+	for _, setting := range []struct {
+		key string
+		fn  func(duration time.Duration)
+	}{
+		{"drain_grace_period", func(v time.Duration) { drainConfig.ForceEvictionGracePeriod = v }},
+		{"drain_min_pod_lifetime", func(v time.Duration) { drainConfig.MinPodLifetime = v }},
+		{"drain_min_healthy_sibling_lifetime", func(v time.Duration) { drainConfig.MinHealthyPDBSiblingLifetime = v }},
+		{"drain_min_unhealthy_sibling_lifetime", func(v time.Duration) { drainConfig.MinUnhealthyPDBSiblingLifetime = v }},
+		{"drain_force_evict_interval", func(v time.Duration) { drainConfig.ForceEvictionInterval = v }},
+		{"drain_poll_interval", func(v time.Duration) { drainConfig.PollInterval = v }},
+	} {
+		if value, ok := cluster.ConfigItems[setting.key]; ok {
+			parsed, err := time.ParseDuration(value)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("invalid value for %s: %v", setting.key, err)
+			}
+			setting.fn(parsed)
+		}
+	}
+
+	poolBackend := updatestrategy.NewASGNodePoolsBackend(cluster.ID, sess)
+	poolManager := updatestrategy.NewKubernetesNodePoolManager(logger, client, poolBackend, drainConfig)
 
 	var updater updatestrategy.UpdateStrategy
-	var poolManager updatestrategy.NodePoolManager
 	switch updateStrategy {
 	case updateStrategyRolling:
-		client, err := kubernetes.NewKubeClientWithTokenSource(cluster.APIServerURL, p.tokenSource)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-
-		// setup updater
-		poolBackend := updatestrategy.NewASGNodePoolsBackend(cluster.ID, sess)
-
-		poolManager = updatestrategy.NewKubernetesNodePoolManager(logger, client, poolBackend, drainConfig)
-
 		updater = updatestrategy.NewRollingUpdateStrategy(logger, poolManager, 3)
+	case updateStrategyCLC:
+		updater = updatestrategy.NewCLCUpdateStrategy(logger, poolManager)
 	default:
 		return nil, nil, nil, fmt.Errorf("unknown update strategy: %s", p.updateStrategy)
 	}
 
 	return adapter, updater, poolManager, nil
-}
-
-func handleDurationItem(configItems map[string]string, key string, set func(duration time.Duration)) error {
-	if value, ok := configItems[key]; ok {
-		parsed, err := time.ParseDuration(value)
-		if err != nil {
-			return fmt.Errorf("invalid value for %s: %v", key, err)
-		}
-		set(parsed)
-	}
-	return nil
 }
 
 // tagSubnets tags all subnets in the default VPC with the kubernetes cluster


### PR DESCRIPTION
MVP for Cluster Lifecycle Controller integration. If update strategy is set to `clc`, only update the launch configuration & launch templates, mark the outdated nodes with `decommission-pending` and wait for CLC to remove them.

Note that CLM also does the draining when decommissioning node pools or scaling down; this PR only touches the node update code. Once we're comfortable with using CLC, I'd rather drop the old code completely and refactor the whole `node_pool_manager`/`update_strategy` mess.