### PR TITLE
Add support for instance_info.InstanceStorageDevices

### DIFF
--- a/pkg/aws/instance_info_test.go
+++ b/pkg/aws/instance_info_test.go
@@ -1,0 +1,41 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstanceInfo(t *testing.T) {
+	for _, tc := range []Instance{
+		{
+			InstanceType: "m4.xlarge",
+			VCPU:         4,
+			Memory:       17179869184,
+		},
+		{
+			InstanceType:           "i3.4xlarge",
+			VCPU:                   16,
+			Memory:                 130996502528,
+			NVMEInstanceStorage:    true,
+			InstanceStorageDevices: []StorageDevice{{Path: "/dev/nvme0n1", NVME: true}, {Path: "/dev/nvme1n1", NVME: true}},
+		},
+		{
+			InstanceType:           "m5d.4xlarge",
+			VCPU:                   16,
+			Memory:                 68719476736,
+			NVMEInstanceStorage:    false,
+			InstanceStorageDevices: []StorageDevice{{Path: "/dev/nvme1n1", NVME: true}, {Path: "/dev/nvme2n1", NVME: true}},
+		},
+	} {
+		t.Run(tc.InstanceType, func(t *testing.T) {
+			info, err := InstanceInfo(tc.InstanceType)
+			require.NoError(t, err)
+			require.Equal(t, tc.InstanceType, info.InstanceType)
+			require.Equal(t, tc.VCPU, info.VCPU)
+			require.Equal(t, tc.Memory, info.Memory)
+			require.Equal(t, tc.NVMEInstanceStorage, info.NVMEInstanceStorage)
+			require.Equal(t, tc.InstanceStorageDevices, info.InstanceStorageDevices)
+		})
+	}
+}


### PR DESCRIPTION
* Deprecate `instance_info.NVMEInstanceStorage`
* Expose `instance_info.InstanceStorageDevices`, which is an array of structs, one per each instance storage disk. Cluster templates should switch to using this information instead of trying to guess the mount path, because that might be different based on how the instance's root volume is attached, for example. Currently only supported for NVME instance storage devices, but may be extended to support non-NVME ones as well.