### PR TITLE
Drop support for LaunchConfigurations

### DIFF
--- a/pkg/updatestrategy/aws_asg.go
+++ b/pkg/updatestrategy/aws_asg.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -27,9 +26,6 @@ const (
 	resourceLifecycleOwned           = "owned"
 	kubeAutoScalerEnabledTagKey      = "k8s.io/cluster-autoscaler/enabled"
 	nodePoolTag                      = "NodePool"
-	userDataAttribute                = "userData"
-	instanceTypeAttribute            = "instanceType"
-	instanceIdFilter                 = "instance-id"
 	instanceHealthStatusHealthy      = "Healthy"
 	ec2AutoscalingGroupTagKey        = "aws:autoscaling:groupName"
 	instanceTerminationRetryDuration = time.Duration(15) * time.Minute
@@ -43,12 +39,6 @@ const (
 type asgLaunchParameters struct {
 	launchTemplateName    string
 	launchTemplateVersion string
-
-	launchConfigurationInstanceType string
-	launchConfigurationAMI          string
-	launchConfigurationSpotPrice    string
-	launchConfigurationUserData     string
-	instanceAMIs                    map[string]string
 }
 
 // ASGNodePoolsBackend defines a node pool backed by an AWS Auto Scaling Group.
@@ -442,28 +432,6 @@ func (n *ASGNodePoolsBackend) getNodePoolASGs(nodePool *api.NodePool) ([]*autosc
 	return asgs, nil
 }
 
-// getLaunchConfiguration gets the launch configuration of an ASG.
-func (n *ASGNodePoolsBackend) getLaunchConfiguration(asg *autoscaling.Group) (*autoscaling.LaunchConfiguration, error) {
-	params := &autoscaling.DescribeLaunchConfigurationsInput{
-		LaunchConfigurationNames: []*string{
-			asg.LaunchConfigurationName,
-		},
-	}
-
-	resp, err := n.asgClient.DescribeLaunchConfigurations(params)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(resp.LaunchConfigurations) != 1 {
-		return nil, fmt.Errorf("expected 1 launch configuration, got %d", len(resp.LaunchConfigurations))
-	}
-
-	lc := resp.LaunchConfigurations[0]
-
-	return lc, nil
-}
-
 // getInstancesToUpdate returns a list of instances with outdated userData.
 func (n *ASGNodePoolsBackend) getInstancesToUpdate(asg *autoscaling.Group) (map[string]bool, error) {
 	// return early if the ASG is empty
@@ -473,59 +441,23 @@ func (n *ASGNodePoolsBackend) getInstancesToUpdate(asg *autoscaling.Group) (map[
 
 	launchParams := &asgLaunchParameters{}
 
-	if asg.LaunchTemplate != nil && aws.StringValue(asg.LaunchTemplate.LaunchTemplateName) != "" {
-		version := aws.StringValue(asg.LaunchTemplate.Version)
-
-		// don't allow dynamic versions like $Default/$Latest
-		if version == "" || strings.HasPrefix(version, "$") {
-			return nil, fmt.Errorf("unsupported launch template version for ASG %s: %s", aws.StringValue(asg.AutoScalingGroupName), version)
-		}
-		launchParams.launchTemplateName = aws.StringValue(asg.LaunchTemplate.LaunchTemplateName)
-		launchParams.launchTemplateVersion = version
-	} else {
-		launchConfig, err := n.getLaunchConfiguration(asg)
-		if err != nil {
-			return nil, err
-		}
-
-		launchParams.launchConfigurationInstanceType = aws.StringValue(launchConfig.InstanceType)
-		launchParams.launchConfigurationAMI = aws.StringValue(launchConfig.ImageId)
-		launchParams.launchConfigurationSpotPrice = aws.StringValue(launchConfig.SpotPrice)
-		launchParams.launchConfigurationUserData = aws.StringValue(launchConfig.UserData)
-		launchParams.instanceAMIs = make(map[string]string)
-
-		instanceIds := make([]*string, 0, len(asg.Instances))
-		for _, instance := range asg.Instances {
-			instanceIds = append(instanceIds, instance.InstanceId)
-		}
-
-		params := &ec2.DescribeInstancesInput{
-			InstanceIds: instanceIds,
-		}
-
-		err = n.ec2Client.DescribeInstancesPages(params, func(resp *ec2.DescribeInstancesOutput, lastPage bool) bool {
-			for _, reservation := range resp.Reservations {
-				for _, instance := range reservation.Instances {
-					launchParams.instanceAMIs[aws.StringValue(instance.InstanceId)] = aws.StringValue(instance.ImageId)
-				}
-			}
-			return true
-		})
-		if err != nil {
-			return nil, err
-		}
-
+	if asg.LaunchTemplate == nil || aws.StringValue(asg.LaunchTemplate.LaunchTemplateName) == "" {
+		return nil, fmt.Errorf("no launch template found for ASG %s", aws.StringValue(asg.AutoScalingGroupName))
 	}
+
+	version := aws.StringValue(asg.LaunchTemplate.Version)
+
+	// don't allow dynamic versions like $Default/$Latest
+	if version == "" || strings.HasPrefix(version, "$") {
+		return nil, fmt.Errorf("unsupported launch template version for ASG %s: %s", aws.StringValue(asg.AutoScalingGroupName), version)
+	}
+	launchParams.launchTemplateName = aws.StringValue(asg.LaunchTemplate.LaunchTemplateName)
+	launchParams.launchTemplateVersion = version
 
 	oldInstances := make(map[string]bool)
 
 	for _, instance := range asg.Instances {
-		old, err := n.instancePendingUpgrade(launchParams, instance)
-		if err != nil {
-			return nil, err
-		}
-
-		if old {
+		if n.instancePendingUpgrade(launchParams, instance) {
 			oldInstances[aws.StringValue(instance.InstanceId)] = true
 		}
 	}
@@ -533,84 +465,9 @@ func (n *ASGNodePoolsBackend) getInstancesToUpdate(asg *autoscaling.Group) (map[
 	return oldInstances, nil
 }
 
-func (n *ASGNodePoolsBackend) instancePendingUpgrade(launchParams *asgLaunchParameters, instance *autoscaling.Instance) (bool, error) {
-	if launchParams.launchTemplateName != "" {
-		old := instance.LaunchTemplate == nil ||
-			aws.StringValue(instance.LaunchTemplate.LaunchTemplateName) != launchParams.launchTemplateName ||
-			aws.StringValue(instance.LaunchTemplate.Version) != launchParams.launchTemplateVersion
-		return old, nil
-	} else {
-		params := &ec2.DescribeInstanceAttributeInput{
-			Attribute:  aws.String(userDataAttribute),
-			InstanceId: instance.InstanceId,
-		}
-		userDataResp, err := n.ec2Client.DescribeInstanceAttribute(params)
-		if err != nil {
-			return false, err
-		}
-
-		params.Attribute = aws.String(instanceTypeAttribute)
-		instanceTypeResp, err := n.ec2Client.DescribeInstanceAttribute(params)
-		if err != nil {
-			return false, err
-		}
-
-		var instanceSpotPrice *string
-		spotPriceResp, err := n.ec2Client.DescribeSpotInstanceRequests(&ec2.DescribeSpotInstanceRequestsInput{
-			Filters: []*ec2.Filter{
-				{
-					Name:   aws.String(instanceIdFilter),
-					Values: []*string{instance.InstanceId},
-				},
-			},
-		})
-		if err != nil {
-			return false, err
-		}
-		if len(spotPriceResp.SpotInstanceRequests) != 0 {
-			instanceSpotPrice = spotPriceResp.SpotInstanceRequests[0].SpotPrice
-		}
-
-		spotPricesMatch, err := compareSpotPrices(launchParams.launchConfigurationSpotPrice, instanceSpotPrice)
-		if err != nil {
-			return false, err
-		}
-
-		// an instance is considered old when userdata, instance type
-		// or AMI does not match what is in the Launch Configuration
-		// for the ASG.
-		old := aws.StringValue(userDataResp.UserData.Value) != launchParams.launchConfigurationUserData ||
-			aws.StringValue(instanceTypeResp.InstanceType.Value) != launchParams.launchConfigurationInstanceType ||
-			launchParams.instanceAMIs[aws.StringValue(instance.InstanceId)] != launchParams.launchConfigurationAMI ||
-			!spotPricesMatch
-		return old, nil
-	}
-}
-
-func parseSpotPrice(spotPrice string) (float64, error) {
-	if spotPrice == "" {
-		return 0, nil
-	}
-
-	return strconv.ParseFloat(spotPrice, 64)
-}
-
-// compareSpotPrices returns true if spot prices are identical (either both are absent or both are present and equal
-// in value. it's needed because AWS munges the spot price in some places, e.g. price on the launch configuration turns
-// from 0.12 into 0.1200000 when read back from the API, but the same doesn't apply to the DescribeSpotInstanceRequests
-// API
-func compareSpotPrices(oldSpotPrice string, newSpotPrice *string) (bool, error) {
-	parsedOld, err := parseSpotPrice(oldSpotPrice)
-	if err != nil {
-		return false, err
-	}
-
-	parsedNew, err := parseSpotPrice(aws.StringValue(newSpotPrice))
-	if err != nil {
-		return false, err
-	}
-
-	return parsedOld == parsedNew, err
+func (n *ASGNodePoolsBackend) instancePendingUpgrade(launchParams *asgLaunchParameters, instance *autoscaling.Instance) bool {
+	return aws.StringValue(instance.LaunchTemplate.LaunchTemplateName) != launchParams.launchTemplateName ||
+		aws.StringValue(instance.LaunchTemplate.Version) != launchParams.launchTemplateVersion
 }
 
 // getLoadBalancerAttachedInstancesReadiness returns a mapping of instanceId ->

--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -85,7 +85,6 @@ type s3API interface {
 
 type autoscalingAPI interface {
 	DescribeAutoScalingGroups(input *autoscaling.DescribeAutoScalingGroupsInput) (*autoscaling.DescribeAutoScalingGroupsOutput, error)
-	DescribeLaunchConfigurations(input *autoscaling.DescribeLaunchConfigurationsInput) (*autoscaling.DescribeLaunchConfigurationsOutput, error)
 	UpdateAutoScalingGroup(input *autoscaling.UpdateAutoScalingGroupInput) (*autoscaling.UpdateAutoScalingGroupOutput, error)
 	SuspendProcesses(input *autoscaling.ScalingProcessQuery) (*autoscaling.SuspendProcessesOutput, error)
 	ResumeProcesses(*autoscaling.ScalingProcessQuery) (*autoscaling.ResumeProcessesOutput, error)
@@ -97,8 +96,6 @@ type iamAPI interface {
 }
 
 type ec2API interface {
-	DescribeInstanceAttribute(input *ec2.DescribeInstanceAttributeInput) (*ec2.DescribeInstanceAttributeOutput, error)
-	DescribeSpotInstanceRequests(input *ec2.DescribeSpotInstanceRequestsInput) (*ec2.DescribeSpotInstanceRequestsOutput, error)
 	DescribeVpcs(input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error)
 	DescribeVolumes(input *ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error)
 	DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error)
@@ -220,7 +217,7 @@ func (a *awsAdapter) applyStack(stackName string, stackTemplate string, stackTem
 		OnFailure:                   aws.String(cloudformation.OnFailureDelete),
 		Capabilities:                []*string{aws.String(cloudformation.CapabilityCapabilityNamedIam)},
 		EnableTerminationProtection: aws.Bool(true),
-		Tags:                        tags,
+		Tags: tags,
 	}
 
 	if stackTemplateURL != "" {


### PR DESCRIPTION
We don't use them anymore, and it'll just complicate the code responsible for MixedInstancesPolicy support.