### PR TITLE
Support for multiple instance types (MixedInstancesPolicy)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -61,7 +61,7 @@
   version = "v9"
 
 [[projects]]
-  digest = "1:aa0255912ca1ea445db812dc75ac0b18f3becc78014c9e78d6570e9ff93644eb"
+  digest = "1:40d174f5c44f6bf0055306f5061c35290e71c01ccb29814a561438e9892697c3"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -73,18 +73,25 @@
     "aws/credentials",
     "aws/credentials/ec2rolecreds",
     "aws/credentials/endpointcreds",
+    "aws/credentials/processcreds",
     "aws/credentials/stscreds",
+    "aws/csm",
     "aws/defaults",
     "aws/ec2metadata",
     "aws/endpoints",
     "aws/request",
     "aws/session",
     "aws/signer/v4",
+    "internal/ini",
+    "internal/s3err",
     "internal/sdkio",
     "internal/sdkrand",
+    "internal/sdkuri",
     "internal/shareddefaults",
     "private/protocol",
     "private/protocol/ec2query",
+    "private/protocol/eventstream",
+    "private/protocol/eventstream/eventstreamapi",
     "private/protocol/json/jsonutil",
     "private/protocol/jsonrpc",
     "private/protocol/query",
@@ -113,8 +120,8 @@
     "service/sts",
   ]
   pruneopts = "UT"
-  revision = "5197757a58a794d49d2d0c50a932997157734100"
-  version = "v1.13.60"
+  revision = "d75ca9c91e5bcf0c3adb9672a786ac65e8073a6e"
+  version = "v1.16.13"
 
 [[projects]]
   branch = "master"
@@ -211,14 +218,6 @@
   pruneopts = "UT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
-
-[[projects]]
-  digest = "1:fe8a03a8222d5b913f256972933d26d24ad7c8286692a42943bc01633cc8fce3"
-  name = "github.com/go-ini/ini"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "358ee7663966325963d4e8b2e1fbd570c5195153"
-  version = "v1.38.1"
 
 [[projects]]
   branch = "master"
@@ -473,11 +472,11 @@
   version = "v1.4.0"
 
 [[projects]]
-  digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"
+  digest = "1:bb81097a5b62634f3e9fec1014657855610c82d19b9a40c17612e32651e35dca"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
   pruneopts = "UT"
-  revision = "0b12d6b5"
+  revision = "c2b33e84"
 
 [[projects]]
   digest = "1:bb3cc4c1b21ea18cfa4e3e47440fc74d316ab25b0cf42927e8c1274917bd9891"
@@ -757,15 +756,15 @@
   revision = "9a301d65acbb728fcc3ace14f45f511a4cfeea9c"
 
 [[projects]]
-  digest = "1:931ad98cbd49d6c1711729718a8067ba024feb49b16a535d894af048b4909786"
+  digest = "1:9b6b1ce9a0f28363ca049f2c89050db91d94dd37c2e7bcf1869ba98e722c42bb"
   name = "github.com/zalando-incubator/kube-ingress-aws-controller"
   packages = [
     "aws",
     "certs",
   ]
   pruneopts = "UT"
-  revision = "c563054f0c02ae2e42c8463f93790bd28ffd4f6b"
-  version = "v0.8.0"
+  revision = "e0d8a32bc57dac5765d3381689c34790aae1b037"
+  version = "v0.8.1"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -763,8 +763,8 @@
     "certs",
   ]
   pruneopts = "UT"
-  revision = "e0d8a32bc57dac5765d3381689c34790aae1b037"
-  version = "v0.8.1"
+  revision = "368164e5261212441433af528a0a50cf4d1449eb"
+  version = "v0.8.2"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,13 +3,13 @@ required = [
   "github.com/jteeuwen/go-bindata/go-bindata"
 ]
 
-[[override]]
+[[constraint]]
   name = "github.com/aws/aws-sdk-go"
   version = "~1.16.13"
 
 [[constraint]]
   name = "github.com/zalando-incubator/kube-ingress-aws-controller"
-  version = "~0.8.0"
+  version = "~0.8.2"
 
 [[constraint]]
   name = "github.com/coreos/container-linux-config-transpiler"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,9 +3,13 @@ required = [
   "github.com/jteeuwen/go-bindata/go-bindata"
 ]
 
-[[constraint]]
+[[override]]
   name = "github.com/aws/aws-sdk-go"
-  version = "~1.13.4"
+  version = "~1.16.13"
+
+[[constraint]]
+  name = "github.com/zalando-incubator/kube-ingress-aws-controller"
+  version = "~0.8.0"
 
 [[constraint]]
   name = "github.com/coreos/container-linux-config-transpiler"

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -103,9 +103,11 @@ func (cluster *Cluster) Version(channelVersion channel.ConfigVersion) (*ClusterV
 		if err != nil {
 			return nil, err
 		}
-		_, err = state.WriteString(nodePool.InstanceType)
-		if err != nil {
-			return nil, err
+		for _, instanceType := range nodePool.InstanceTypes {
+			_, err = state.WriteString(instanceType)
+			if err != nil {
+				return nil, err
+			}
 		}
 		_, err = state.WriteString(nodePool.DiscountStrategy)
 		if err != nil {

--- a/api/cluster_test.go
+++ b/api/cluster_test.go
@@ -45,6 +45,13 @@ func permute(value interface{}, field string) error {
 		default:
 			return fmt.Errorf("invalid map type for %s", field)
 		}
+	case reflect.Slice:
+		switch fld.Interface().(type) {
+		case []string:
+			fld.Set(reflect.ValueOf([]string{"a", "b", "c"}))
+		default:
+			return fmt.Errorf("invalid slice type for %s", field)
+		}
 	default:
 		return fmt.Errorf("unsupported type: %s", fld.Type())
 	}
@@ -72,7 +79,7 @@ func sampleCluster() *Cluster {
 			{
 				Name:             "master-default",
 				Profile:          "master-default",
-				InstanceType:     "m4.large",
+				InstanceTypes:    []string{"m4.large"},
 				DiscountStrategy: "none",
 				MinSize:          2,
 				MaxSize:          2,
@@ -81,7 +88,7 @@ func sampleCluster() *Cluster {
 			{
 				Name:             "worker-default",
 				Profile:          "worker-default",
-				InstanceType:     "m5.large",
+				InstanceTypes:    []string{"m5.large", "m5.2xlarge"},
 				DiscountStrategy: "none",
 				MinSize:          3,
 				MaxSize:          21,
@@ -123,6 +130,10 @@ func TestVersion(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, field := range fields {
+		if field == "InstanceType" {
+			continue
+		}
+
 		cluster := sampleCluster()
 		err := permute(cluster.NodePools[0], field)
 		require.NoError(t, err, "node pool field: %s", field)

--- a/api/node_pool.go
+++ b/api/node_pool.go
@@ -10,12 +10,15 @@ const (
 // NodePool describes a node pool in a kubernetes cluster.
 type NodePool struct {
 	DiscountStrategy string            `json:"discount_strategy" yaml:"discount_strategy"`
-	InstanceType     string            `json:"instance_type"     yaml:"instance_type"`
+	InstanceTypes    []string          `json:"instance_types"    yaml:"instance_types"`
 	Name             string            `json:"name"              yaml:"name"`
 	Profile          string            `json:"profile"           yaml:"profile"`
 	MinSize          int64             `json:"min_size"          yaml:"min_size"`
 	MaxSize          int64             `json:"max_size"          yaml:"max_size"`
 	ConfigItems      map[string]string `json:"config_items"      yaml:"config_items"`
+
+	// Deprecated, only kept here so the existing clusters don't break
+	InstanceType string
 }
 
 // NodePools is a slice of *NodePool which implements the sort interface to

--- a/docs/cluster-registry.yaml
+++ b/docs/cluster-registry.yaml
@@ -73,6 +73,11 @@ paths:
           required: false
           type: string
           description: Filter on type.
+        - name: cost_center
+          in: query
+          required: false
+          type: string
+          description: Filter on cost center number.
       responses:
         200:
           description: List of all infrastructure accounts.
@@ -252,6 +257,12 @@ paths:
           type: boolean
           default: true
           description: Include technical data (config items, node pools) in the response, true by default
+        - name: cost_center
+          in: query
+          required: false
+          type: string
+          description: Filter on cost center number.
+
       responses:
         200:
           description: List of all Kubernetes clusters.
@@ -516,6 +527,38 @@ paths:
           description: Unexpected error
           schema:
             $ref: '#/definitions/Error'
+    patch:
+      summary: Update node pool
+      description: Update a node pool.
+      tags:
+        - NodePools
+      operationId: updateNodePool
+      parameters:
+        - $ref: '#/parameters/cluster_id'
+        - $ref: '#/parameters/node_pool_name'
+        - name: node-pool
+          required: true
+          in: body
+          description: Node pool to be updated.
+          schema:
+            '$ref': '#/definitions/NodePoolUpdate'
+      responses:
+        200:
+          description: The node pool update request is accepted.
+          schema:
+            '$ref': '#/definitions/NodePool'
+        400:
+          description: Invalid request
+          schema:
+            $ref: '#/definitions/Error'
+        401:
+          description: Unauthorized
+        403:
+          description: Forbidden
+        500:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
     delete:
       summary: Delete node pool
       description: Deletes node pool.
@@ -661,6 +704,10 @@ definitions:
         type: string
         example: team/bar
         description: Owner of the infrastructure account (references an object in the organization service)
+      cost_center:
+        type: string
+        example: "0000001234"
+        description: Cost center of the Owner/infrastructure account
       environment:
         type: string
         example: production
@@ -687,6 +734,7 @@ definitions:
       - type
       - name
       - owner
+      - cost_center
       - environment
       - criticality_level
       - external_id
@@ -713,6 +761,10 @@ definitions:
         type: string
         example: team/bar
         description: Owner of the infrastructure account (references an object in the organization service)
+      cost_center:
+        type: string
+        example: "0000001234"
+        description: Cost center of the Owner/infrastructure account
       environment:
         type: string
         example: production
@@ -989,12 +1041,15 @@ definitions:
           Profile used for the node pool. Possible values are "worker-default",
           "worker-database", "worker-gpu", "master". The "master" profile
           identifies the pool containing the cluster master
-      instance_type:
-        type: string
-        example: m5.large
-        description: |
-          Type of the instance to use for the nodes in the pool. All the nodes
-          in the pool share the same instance types
+      instance_types:
+        type: array
+        minItems: 1
+        uniqueItems: true
+        items:
+          type: string
+          example: m5.large
+          description: |
+            Types of the instances to use for the nodes in the pool.
       discount_strategy:
         type: string
         example: none
@@ -1023,10 +1078,59 @@ definitions:
     required:
       - name
       - profile
-      - instance_type
       - discount_strategy
+      - instance_types
       - min_size
       - max_size
+
+  NodePoolUpdate:
+    type: object
+    properties:
+      name:
+        type: string
+        example: pool-1
+        description: Name of the node pool
+      profile:
+        type: string
+        example: worker-default
+        description: |
+          Profile used for the node pool. Possible values are "worker-default",
+          "worker-database", "worker-gpu", "master". The "master" profile
+          identifies the pool containing the cluster master
+      instance_types:
+        type: array
+        minItems: 1
+        uniqueItems: true
+        items:
+          type: string
+          example: m5.large
+          description: |
+            Types of the instances to use for the nodes in the pool.
+      discount_strategy:
+        type: string
+        example: none
+        description: |
+          A discount strategy indicates the type of discount to be associated
+          with the node pool. This might affect the availability of the nodes in
+          the pools in case of preemptible or spot instances.  Possible values
+          depend on the provider, the only common one is "none".
+      min_size:
+        type: integer
+        example: 3
+        description: Minimum size of the node pool
+      max_size:
+        type: integer
+        example: 20
+        description: Maximum size of the node pool
+      config_items:
+        type: object
+        additionalProperties:
+          type: string
+        example:
+          local_storage: "yes"
+        description: |
+          Configuration items unique to the node pool. E.g. custom volume
+          configuration.
 
   Error:
     type: object

--- a/pkg/updatestrategy/aws_asg_test.go
+++ b/pkg/updatestrategy/aws_asg_test.go
@@ -101,12 +101,11 @@ func (e *mockELBAPI) DescribeInstanceHealth(input *elb.DescribeInstanceHealthInp
 
 func TestGet(tt *testing.T) {
 	for _, tc := range []struct {
-		msg                  string
-		autoscalingInstances []*autoscaling.Instance
-		asgClient            autoscalingiface.AutoScalingAPI
-		ec2Client            ec2iface.EC2API
-		elbClient            elbiface.ELBAPI
-		success              bool
+		msg       string
+		asgClient autoscalingiface.AutoScalingAPI
+		ec2Client ec2iface.EC2API
+		elbClient elbiface.ELBAPI
+		success   bool
 	}{
 		{
 			msg:       "test not returning any ASG",

--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -146,13 +146,20 @@ func (p *AWSNodePoolProvisioner) Provision(values map[string]interface{}) error 
 	return nil
 }
 
+func supportsT2Unlimited(instanceTypes []string) bool {
+	for _, instanceType := range instanceTypes {
+		if !strings.HasPrefix(instanceType, "t2.") {
+			return false
+		}
+	}
+	return true
+}
+
 // provisionNodePool provisions a single node pool.
 func (p *AWSNodePoolProvisioner) provisionNodePool(nodePool *api.NodePool, values map[string]interface{}) error {
-	// TODO support multiple instance types here
-	values["supports_t2_unlimited"] = strings.HasPrefix(nodePool.InstanceTypes[0], "t2")
+	values["supports_t2_unlimited"] = supportsT2Unlimited(nodePool.InstanceTypes)
 
-	// TODO support multiple instance types here
-	instanceInfo, err := awsExt.InstanceInfo(nodePool.InstanceTypes[0])
+	instanceInfo, err := awsExt.SyntheticInstanceInfo(nodePool.InstanceTypes)
 	if err != nil {
 		return err
 	}

--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -148,9 +148,11 @@ func (p *AWSNodePoolProvisioner) Provision(values map[string]interface{}) error 
 
 // provisionNodePool provisions a single node pool.
 func (p *AWSNodePoolProvisioner) provisionNodePool(nodePool *api.NodePool, values map[string]interface{}) error {
-	values["supports_t2_unlimited"] = strings.HasPrefix(nodePool.InstanceType, "t2")
+	// TODO support multiple instance types here
+	values["supports_t2_unlimited"] = strings.HasPrefix(nodePool.InstanceTypes[0], "t2")
 
-	instanceInfo, err := awsExt.InstanceInfo(nodePool.InstanceType)
+	// TODO support multiple instance types here
+	instanceInfo, err := awsExt.InstanceInfo(nodePool.InstanceTypes[0])
 	if err != nil {
 		return err
 	}

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -147,17 +147,19 @@ func autoscalingBufferSettings(cluster *api.Cluster) (*podResources, error) {
 	currentLargestInstance := aws.Instance{}
 
 	for _, pool := range pools {
-		instanceInfo, err := aws.InstanceInfo(pool.InstanceType)
-		if err != nil {
-			return nil, err
-		}
+		for _, instanceType := range pool.InstanceTypes {
+			instanceInfo, err := aws.InstanceInfo(instanceType)
+			if err != nil {
+				return nil, err
+			}
 
-		if instanceInfo.VCPU > currentLargestInstance.VCPU && instanceInfo.Memory > currentLargestInstance.Memory {
-			currentLargestInstance = instanceInfo
-		} else if instanceInfo.VCPU <= currentLargestInstance.VCPU && instanceInfo.Memory <= currentLargestInstance.Memory {
-			// do nothing
-		} else {
-			return nil, fmt.Errorf("unable to select autoscaling buffer settings, conflicting instance types %s and %s", currentLargestInstance.InstanceType, instanceInfo.InstanceType)
+			if instanceInfo.VCPU > currentLargestInstance.VCPU && instanceInfo.Memory > currentLargestInstance.Memory {
+				currentLargestInstance = instanceInfo
+			} else if instanceInfo.VCPU <= currentLargestInstance.VCPU && instanceInfo.Memory <= currentLargestInstance.Memory {
+				// do nothing
+			} else {
+				return nil, fmt.Errorf("unable to select autoscaling buffer settings, conflicting instance types %s and %s", currentLargestInstance.InstanceType, instanceInfo.InstanceType)
+			}
 		}
 	}
 

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -148,17 +148,17 @@ func TestAutoscalingBufferPoolBasedScale(t *testing.T) {
 		`{{ with autoscalingBufferSettings . }}{{.CPU}} {{.Memory}}{{end}}`,
 		exampleCluster([]*api.NodePool{
 			{
-				InstanceType: "m4.xlarge",
-				Name:         "master-default",
+				InstanceTypes: []string{"m4.xlarge"},
+				Name:          "master-default",
 			},
 			{
-				InstanceType: "t2.nano",
-				Name:         "worker-small",
+				InstanceTypes: []string{"t2.nano"},
+				Name:          "worker-small",
 			},
 			{
 				// 2 vcpu / 8gb
-				InstanceType: "m4.large",
-				Name:         "worker-default",
+				InstanceTypes: []string{"m4.large"},
+				Name:          "worker-default",
 			},
 		}))
 
@@ -173,8 +173,8 @@ func TestAutoscalingBufferPoolBasedReserved(t *testing.T) {
 		exampleCluster([]*api.NodePool{
 			{
 				// 8 vcpu / 32gb
-				InstanceType: "m4.2xlarge",
-				Name:         "worker-default",
+				InstanceTypes: []string{"m4.2xlarge"},
+				Name:          "worker-default",
 			},
 		}))
 
@@ -188,12 +188,12 @@ func TestAutoscalingBufferPoolBasedNoPools(t *testing.T) {
 		`{{ with autoscalingBufferSettings . }}{{.CPU}} {{.Memory}}{{end}}`,
 		exampleCluster([]*api.NodePool{
 			{
-				InstanceType: "m4.xlarge",
-				Name:         "master-default",
+				InstanceTypes: []string{"m4.xlarge"},
+				Name:          "master-default",
 			},
 			{
-				InstanceType: "m4.large",
-				Name:         "testing-default",
+				InstanceTypes: []string{"m4.large"},
+				Name:          "testing-default",
 			},
 		}))
 
@@ -206,12 +206,12 @@ func TestAutoscalingBufferPoolBasedMismatchingType(t *testing.T) {
 		`{{ with autoscalingBufferSettings . }}{{.CPU}} {{.Memory}}{{end}}`,
 		exampleCluster([]*api.NodePool{
 			{
-				InstanceType: "r4.large",
-				Name:         "worker-one",
+				InstanceTypes: []string{"r4.large"},
+				Name:          "worker-one",
 			},
 			{
-				InstanceType: "c4.xlarge",
-				Name:         "worker-two",
+				InstanceTypes: []string{"c4.xlarge"},
+				Name:          "worker-two",
 			},
 		}))
 
@@ -233,8 +233,8 @@ func TestAutoscalingBufferPoolBasedInvalidSettings(t *testing.T) {
 	for _, configItems := range configSets {
 		cluster := exampleCluster([]*api.NodePool{
 			{
-				InstanceType: "m4.large",
-				Name:         "worker",
+				InstanceTypes: []string{"m4.large"},
+				Name:          "worker",
 			},
 		})
 		cluster.ConfigItems = configItems

--- a/registry/file.go
+++ b/registry/file.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	yaml "gopkg.in/yaml.v2"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
+	"gopkg.in/yaml.v2"
 )
 
 type fileRegistry struct {
@@ -41,6 +40,9 @@ func (r *fileRegistry) ListClusters(filter Filter) ([]*api.Cluster, error) {
 
 	for _, cluster := range fileClusters.Clusters {
 		for _, nodePool := range cluster.NodePools {
+			if len(nodePool.InstanceTypes) == 0 {
+				return nil, fmt.Errorf("no instance types for cluster %s, pool %s", cluster.ID, nodePool.Name)
+			}
 			nodePool.InstanceType = nodePool.InstanceTypes[0]
 		}
 	}

--- a/registry/file.go
+++ b/registry/file.go
@@ -39,6 +39,12 @@ func (r *fileRegistry) ListClusters(filter Filter) ([]*api.Cluster, error) {
 		return nil, err
 	}
 
+	for _, cluster := range fileClusters.Clusters {
+		for _, nodePool := range cluster.NodePools {
+			nodePool.InstanceType = nodePool.InstanceTypes[0]
+		}
+	}
+
 	return fileClusters.Clusters, nil
 }
 

--- a/registry/http.go
+++ b/registry/http.go
@@ -178,7 +178,8 @@ func convertFromClusterModel(cluster *models.Cluster) *api.Cluster {
 func convertFromNodePoolModel(nodePool *models.NodePool) *api.NodePool {
 	return &api.NodePool{
 		DiscountStrategy: *nodePool.DiscountStrategy,
-		InstanceType:     *nodePool.InstanceType,
+		InstanceTypes:    nodePool.InstanceTypes,
+		InstanceType:     nodePool.InstanceTypes[0],
 		Name:             *nodePool.Name,
 		Profile:          *nodePool.Profile,
 		MinSize:          *nodePool.MinSize,


### PR DESCRIPTION
Add support for ASGs with multiple instance types (using MixedInstancesPolicy):
 * node pools: add `instance_types`, keep `instance_type` set to the first type for BC
 * support ASGs that use `MixedInstancesPolicy`:
   - fetch launch template name & version correctly
   - determine whether the ASG uses spot or not (on-demand+spot not supported at the moment)
   - determine whether the instances should be updated (e.g. because one of the types is no longer valid)
 * template values:
   - `supports_t2_unlimited`: set to true iff all instance types are T2
   - `instance_info`: if a pool uses more than one type, return a synthetic value with instance type set to `<multiple>`, CPU/Memory set to the minimum across all types. Storage information must be the same across all types, an error will be thrown if it's not the case.
 * add a bunch of tests