### PR TITLE
Fix pool draining

### DIFF
--- a/pkg/updatestrategy/clc_update_test.go
+++ b/pkg/updatestrategy/clc_update_test.go
@@ -33,6 +33,10 @@ type mockNodePoolManagerCLC struct {
 	abortFunc             func()
 }
 
+func (m *mockNodePoolManagerCLC) DisableReplacementNodeProvisioning(node *Node) error {
+	return nil
+}
+
 func (m *mockNodePoolManagerCLC) advance() {
 	for _, node := range m.nodes {
 		switch node.state {
@@ -191,8 +195,8 @@ func TestCLCUpdateStrategy(t *testing.T) {
 			logger := log.WithField("test", true)
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			nodePoolManager := &mockNodePoolManagerCLC{
-				generation: tc.nodePoolGeneration,
-				nodes:      tc.nodes,
+				generation:            tc.nodePoolGeneration,
+				nodes:                 tc.nodes,
 				abortAfterTerminating: tc.abortAfterTerminating,
 				abortFunc:             cancel,
 			}

--- a/pkg/updatestrategy/rolling_update.go
+++ b/pkg/updatestrategy/rolling_update.go
@@ -102,6 +102,13 @@ func (r *RollingUpdateStrategy) increaseByUnmatchedNodes(ctx context.Context, no
 	return nil
 }
 
+func (r *RollingUpdateStrategy) PrepareForRemoval(ctx context.Context, nodePoolDesc *api.NodePool) error {
+	r.logger.Infof("Preparing for removal of node pool '%s'", nodePoolDesc.Name)
+
+	// gracefully downscale node pool
+	return r.nodePoolManager.ScalePool(ctx, nodePoolDesc, 0)
+}
+
 // Update performs a rolling update of a single node pool. Passing a context
 // allows stopping the update loop in case the context is canceled.
 func (r *RollingUpdateStrategy) Update(ctx context.Context, nodePoolDesc *api.NodePool) error {

--- a/pkg/updatestrategy/rolling_update_test.go
+++ b/pkg/updatestrategy/rolling_update_test.go
@@ -43,6 +43,10 @@ type mockNodePoolManager struct {
 	nodePool *NodePool
 }
 
+func (m *mockNodePoolManager) DisableReplacementNodeProvisioning(node *Node) error {
+	return nil
+}
+
 func (m *mockNodePoolManager) GetPool(nodePool *api.NodePool) (*NodePool, error) {
 	return m.nodePool, nil
 }

--- a/pkg/updatestrategy/updatestrategy.go
+++ b/pkg/updatestrategy/updatestrategy.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 // UpdateStrategy defines an interface for performing cluster node updates.
 type UpdateStrategy interface {
 	Update(ctx context.Context, nodePool *api.NodePool) error
+	PrepareForRemoval(ctx context.Context, nodePool *api.NodePool) error
 }
 
 // ProviderNodePoolsBackend is an interface for describing a node pools

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/zalando-incubator/cluster-lifecycle-manager/pkg/cluster-registry/models"
 	"github.com/zalando-incubator/kube-ingress-aws-controller/certs"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 
 	"golang.org/x/oauth2"
 
@@ -333,7 +333,7 @@ func (p *clusterpyProvisioner) Provision(ctx context.Context, logger *log.Entry,
 	}
 
 	// clean up removed node pools
-	err = nodePoolProvisioner.Reconcile(ctx)
+	err = nodePoolProvisioner.Reconcile(ctx, updater)
 	if err != nil {
 		return err
 	}

--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -213,7 +213,7 @@ func (p *AWSNodePoolProvisioner) provisionNodePool(nodePool *api.NodePool, value
 
 // Reconcile finds all orphaned node pool stacks and decommission the node
 // pools by scaling them down gracefully and deleting the corresponding stacks.
-func (p *AWSNodePoolProvisioner) Reconcile(ctx context.Context) error {
+func (p *AWSNodePoolProvisioner) Reconcile(ctx context.Context, updater updatestrategy.UpdateStrategy) error {
 	// decommission orphaned node pools
 	tags := map[string]string{
 		tagNameKubernetesClusterPrefix + p.Cluster.ID: resourceLifecycleOwned,
@@ -235,8 +235,7 @@ func (p *AWSNodePoolProvisioner) Reconcile(ctx context.Context) error {
 	for _, stack := range orphaned {
 		nodePool := nodePoolStackToNodePool(stack)
 
-		// gracefully downscale node pool
-		err := p.nodePoolManager.ScalePool(ctx, nodePool, 0)
+		err := updater.PrepareForRemoval(ctx, nodePool)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When draining, remove nodes using the `UpdateStrategy` to avoid concurrent removal by both CLC and CLM. The code is a complete mess WRT to abstraction layers, but I'd rather refactor it after we switch to CLC in all clusters and drop the whole concept of update strategies.