### PR TITLE
Improvements for running CLM locally

### DIFF
--- a/pkg/aws/session.go
+++ b/pkg/aws/session.go
@@ -1,11 +1,12 @@
 package aws
 
 import (
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"time"
 )
 
 const (
@@ -16,6 +17,7 @@ const (
 func Config(maxRetries int, maxRetryInterval time.Duration) *aws.Config {
 	result := aws.NewConfig()
 	result.Retryer = NewClampedRetryer(maxRetries, maxRetryInterval)
+	result.EnforceShouldRetryCheck = aws.Bool(true)
 	return result
 }
 

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -596,6 +596,11 @@ func (p *clusterpyProvisioner) prepareProvision(logger *log.Entry, cluster *api.
 		return nil, nil, nil, err
 	}
 
+	err = adapter.VerifyAccount(cluster.InfrastructureAccount)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	err = p.updateDefaults(cluster, channelConfig)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("unable to read configuration defaults: %v", err)


### PR DESCRIPTION
* Perform less retries when talking to the EC2 metadata service
* Verify that the AWS account used is the one configured in `cluster.yaml`