### PR TITLE
CLC: disable autoscaling when decommissioning pools

### DIFF
--- a/pkg/updatestrategy/clc_update.go
+++ b/pkg/updatestrategy/clc_update.go
@@ -54,6 +54,11 @@ func (c *CLCUpdateStrategy) PrepareForRemoval(ctx context.Context, nodePoolDesc 
 			return err
 		}
 
+		err = c.nodePoolManager.MarkPoolForDecommission(nodePoolDesc)
+		if err != nil {
+			return err
+		}
+
 		for _, node := range nodePool.Nodes {
 			err := c.nodePoolManager.DisableReplacementNodeProvisioning(node)
 			if err != nil {

--- a/pkg/updatestrategy/clc_update_test.go
+++ b/pkg/updatestrategy/clc_update_test.go
@@ -33,6 +33,10 @@ type mockNodePoolManagerCLC struct {
 	abortFunc             func()
 }
 
+func (m *mockNodePoolManagerCLC) MarkPoolForDecommission(nodePool *api.NodePool) error {
+	return nil
+}
+
 func (m *mockNodePoolManagerCLC) DisableReplacementNodeProvisioning(node *Node) error {
 	return nil
 }

--- a/pkg/updatestrategy/node_pool_manager.go
+++ b/pkg/updatestrategy/node_pool_manager.go
@@ -46,6 +46,7 @@ type NodePoolManager interface {
 	AbortNodeDecommissioning(node *Node) error
 	ScalePool(ctx context.Context, nodePool *api.NodePool, replicas int) error
 	TerminateNode(ctx context.Context, node *Node, decrementDesired bool) error
+	MarkPoolForDecommission(nodePool *api.NodePool) error
 	DisableReplacementNodeProvisioning(node *Node) error
 	CordonNode(node *Node) error
 }
@@ -324,6 +325,10 @@ func (m *KubernetesNodePoolManager) TerminateNode(ctx context.Context, node *Nod
 	m.logger.WithField("node", node.Name).Info("Terminating node")
 
 	return m.backend.Terminate(node, decrementDesired)
+}
+
+func (m *KubernetesNodePoolManager) MarkPoolForDecommission(nodePool *api.NodePool) error {
+	return m.backend.SuspendAutoscaling(nodePool)
 }
 
 // ScalePool scales a nodePool to the specified number of replicas.

--- a/pkg/updatestrategy/rolling_update_test.go
+++ b/pkg/updatestrategy/rolling_update_test.go
@@ -43,6 +43,10 @@ type mockNodePoolManager struct {
 	nodePool *NodePool
 }
 
+func (m *mockNodePoolManager) MarkPoolForDecommission(nodePool *api.NodePool) error {
+	return nil
+}
+
 func (m *mockNodePoolManager) DisableReplacementNodeProvisioning(node *Node) error {
 	return nil
 }


### PR DESCRIPTION
CLC strategy didn't disable autoscaling for pools that were decommissioned, so it never finished.