### PR TITLE
Add splitHostPort template function

### DIFF
--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"math"
+	"net"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -195,6 +196,7 @@ func renderTemplate(context *templateContext, filePath string, data interface{})
 		"mountUnitName":             mountUnitName,
 		"accountID":                 accountID,
 		"portRanges":                portRanges,
+		"splitHostPort":             splitHostPort,
 	}
 
 	content, err := ioutil.ReadFile(filePath)
@@ -311,6 +313,20 @@ func accountID(account string) (string, error) {
 		return "", fmt.Errorf("invalid account (expected type:id): %s", account)
 	}
 	return items[1], nil
+}
+
+type HostPort struct {
+	Host string
+	Port string
+}
+
+// splitHostPort exposes net.SplitHostPort
+func splitHostPort(hostport string) (HostPort, error) {
+	host, port, err := net.SplitHostPort(hostport)
+	if err != nil {
+		return HostPort{}, err
+	}
+	return HostPort{Host: host, Port: port}, nil
 }
 
 type PortRange struct {

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -388,3 +388,22 @@ func TestParsePortRanges(t *testing.T) {
 	_, err = renderSingle(t, `{{ portRanges "0-200000" }}`, "")
 	require.Error(t, err)
 }
+
+func TestSplitHostPort(t *testing.T) {
+	result, err := renderSingle(
+		t,
+		`{{ with splitHostPort "example.org:80" }}{{.Host}} - {{.Port}}{{end}}`,
+		nil)
+
+	require.NoError(t, err)
+	require.EqualValues(t, "example.org - 80", result)
+}
+
+func TestSplitHostPortError(t *testing.T) {
+	_, err := renderSingle(
+		t,
+		`{{ with splitHostPort "a:b:c" }}{{.Host}} - {{.Port}}{{end}}`,
+		nil)
+
+	require.Error(t, err)
+}


### PR DESCRIPTION
This is needed to parse `etcd_endpoints`.