### PR TITLE
CLC: when updating a pool, abort decommissioning in other pools

### DIFF
--- a/pkg/updatestrategy/clc_update_test.go
+++ b/pkg/updatestrategy/clc_update_test.go
@@ -108,7 +108,7 @@ func (m *mockNodePoolManagerCLC) findNode(nodeName string) (*mockNodeCLC, error)
 	return nil, fmt.Errorf("unknown node: %s", nodeName)
 }
 
-func (m *mockNodePoolManagerCLC) MarkNodeForDecommission(node *Node) error {
+func (m *mockNodePoolManagerCLC) MarkNodeForDecommission(node *Node, updatePriority string) error {
 	n, err := m.findNode(node.Name)
 	if err != nil {
 		return err
@@ -124,7 +124,11 @@ func (m *mockNodePoolManagerCLC) MarkNodeForDecommission(node *Node) error {
 	return nil
 }
 
-func (m *mockNodePoolManagerCLC) AbortNodeDecommissioning(node *Node) error {
+func (m *mockNodePoolManagerCLC) TargetPoolForNodeDecommission(nodePool *api.NodePool) error {
+	return nil
+}
+
+func (m *mockNodePoolManagerCLC) UnmarkNodeForDecommission(node *Node) error {
 	n, err := m.findNode(node.Name)
 	if err != nil {
 		return err

--- a/pkg/updatestrategy/rolling_update.go
+++ b/pkg/updatestrategy/rolling_update.go
@@ -35,7 +35,7 @@ func NewRollingUpdateStrategy(logger *log.Entry, nodePoolManager NodePoolManager
 func (r *RollingUpdateStrategy) markOldNodes(nodePool *NodePool) error {
 	for _, node := range nodePool.Nodes {
 		if node.Generation != nodePool.Generation {
-			err := r.nodePoolManager.MarkNodeForDecommission(node)
+			err := r.nodePoolManager.MarkNodeForDecommission(node, "")
 			if err != nil {
 				return err
 			}

--- a/pkg/updatestrategy/rolling_update_test.go
+++ b/pkg/updatestrategy/rolling_update_test.go
@@ -55,11 +55,15 @@ func (m *mockNodePoolManager) GetPool(nodePool *api.NodePool) (*NodePool, error)
 	return m.nodePool, nil
 }
 
-func (m *mockNodePoolManager) MarkNodeForDecommission(node *Node) error {
+func (m *mockNodePoolManager) MarkNodeForDecommission(node *Node, updatePriority string) error {
 	return nil
 }
 
-func (m *mockNodePoolManager) AbortNodeDecommissioning(node *Node) error {
+func (m *mockNodePoolManager) UnmarkNodeForDecommission(node *Node) error {
+	return nil
+}
+
+func (m *mockNodePoolManager) TargetPoolForNodeDecommission(nodePool *api.NodePool) error {
 	return nil
 }
 


### PR DESCRIPTION
When a node pool is being updated, set the update priority annotation to the current time and forcibly abort decommissioning processes in other node pools. This allows us to have behaviour that's close to what we had without CLC, where if we abort an update in progress master nodes will be updated again, even if some of the worker nodes were still being decommissioned.

The code is awful because of mismatch between multiple abstraction layers, but I'd rather just drop most of it completely and rewrite it into something sane once we drop non-CLC clusters completely.