### PR TITLE
Check Etcd CF stack before running senza

### DIFF
--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -402,6 +402,22 @@ func (a *awsAdapter) CreateOrUpdateEtcdStack(parentCtx context.Context, stackNam
 		return err
 	}
 
+	// check if stack exists
+	// this is a hack to avoid calling senza to generate the etcd stack
+	// which is only applied if the stack doesn't already exist
+	describeParams := &cloudformation.DescribeStacksInput{
+		StackName: aws.String(stackName),
+	}
+
+	resp, err := a.cloudformationClient.DescribeStacks(describeParams)
+	if err != nil {
+		return err
+	}
+
+	if len(resp.Stacks) == 1 {
+		return nil
+	}
+
 	args := []string{
 		"print",
 		stackDefinitionPath,


### PR DESCRIPTION
This is a simple hack to avoid invoking senza on every run of CLM when
the resulting generated CF stack won't be used anyway.

Should make CLM more robust to AWS ratelimits and avoids senza as
dependency if there's already an etcd cluster in the target AWS account.