### PR TITLE
Fix filtering of subnets

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -24,8 +24,3 @@ pipeline:
         VERSION=$CDP_BUILD_VERSION
       fi
       IMAGE=$IMAGE VERSION=$VERSION make build.push
-
-notifications:
-  hipchat:
-    rooms:
-    - "Teapot CICD"

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -384,11 +384,12 @@ func filterSubnets(allSubnets []*ec2.Subnet, subnetIds []string) ([]*ec2.Subnet,
 
 	var result []*ec2.Subnet
 	for _, subnet := range allSubnets {
-		subnet := aws.StringValue(subnet.SubnetId)
-		_, ok := desiredSubnets[subnet]
+		subnet := *subnet
+		subnetID := aws.StringValue(subnet.SubnetId)
+		_, ok := desiredSubnets[subnetID]
 		if ok {
-			result = append(result)
-			delete(desiredSubnets, subnet)
+			result = append(result, &subnet)
+			delete(desiredSubnets, subnetID)
 		}
 	}
 


### PR DESCRIPTION
Fix filtering of subnets

```
provisioner/clusterpy.go:390:13: x = append(y) is equivalent to x = y (SA4021)

10:00:48 AM  Makefile:29: recipe for target 'test' failed
```

Correctly append to the slice.