### PR TITLE
Fixed the check for existing etcd stack if it doesn't exist

### DIFF
--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -410,11 +410,8 @@ func (a *awsAdapter) CreateOrUpdateEtcdStack(parentCtx context.Context, stackNam
 	}
 
 	resp, err := a.cloudformationClient.DescribeStacks(describeParams)
-	if err != nil {
-		return err
-	}
-
-	if len(resp.Stacks) == 1 {
+	// Ignore the error because the error indicates that the stack is missing
+	if err == nil && len(resp.Stacks) == 1 {
 		return nil
 	}
 


### PR DESCRIPTION
Currently if the stack doesn't exist the CLM doesn't proceed at all because this check fails.