### PR TITLE
Unify template data, add proper AZ support

### DIFF
--- a/provisioner/aws_az.go
+++ b/provisioner/aws_az.go
@@ -1,0 +1,50 @@
+package provisioner
+
+import (
+	"sort"
+)
+
+// AZInfo tracks information about available AZs based on explicit restrictions or available subnets
+type AZInfo struct {
+	subnets map[string]string
+}
+
+// RestrictAZs returns a new AZInfo that is restricted to provided AZs
+func (info *AZInfo) RestrictAZs(availableAZs []string) *AZInfo {
+	result := make(map[string]string)
+
+	for _, az := range availableAZs {
+		if subnet, ok := info.subnets[az]; ok {
+			result[az] = subnet
+		}
+	}
+
+	return &AZInfo{subnets: result}
+}
+
+// Subnets returns a map of AZ->subnet that also contains an entry for the virtual '*' AZ
+// TODO drop the *
+func (info *AZInfo) SubnetsByAZ() map[string]string {
+	result := make(map[string]string)
+	for _, az := range info.AvailabilityZones() {
+		subnet := info.subnets[az]
+		result[az] = subnet
+
+		if existing, ok := result[subnetAllAZName]; ok {
+			result[subnetAllAZName] = existing + "," + subnet
+		} else {
+			result[subnetAllAZName] = subnet
+		}
+	}
+	return result
+}
+
+// AvailabilityZones returns a list of available AZs
+func (info *AZInfo) AvailabilityZones() []string {
+	var result []string
+	for az := range info.subnets {
+		result = append(result, az)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/provisioner/aws_az_test.go
+++ b/provisioner/aws_az_test.go
@@ -1,0 +1,38 @@
+package provisioner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	info = &AZInfo{
+		subnets: map[string]string{
+			"eu-central-1a": "subnet-1a",
+			"eu-central-1b": "subnet-1b",
+			"eu-central-1c": "subnet-1c",
+		},
+	}
+)
+
+func TestSubnetsByAZ(t *testing.T) {
+	expected := map[string]string{
+		"*":             "subnet-1a,subnet-1b,subnet-1c",
+		"eu-central-1a": "subnet-1a",
+		"eu-central-1b": "subnet-1b",
+		"eu-central-1c": "subnet-1c",
+	}
+	require.Equal(t, expected, info.SubnetsByAZ())
+}
+
+func TestAvailabilityZones(t *testing.T) {
+	require.Equal(t, []string{"eu-central-1a", "eu-central-1b", "eu-central-1c"}, info.AvailabilityZones())
+}
+
+func TestRestrictAZs(t *testing.T) {
+	restricted := info.RestrictAZs([]string{"eu-central-1b", "eu-central-1d"})
+	require.NotEqual(t, info, restricted)
+	require.Equal(t, map[string]string{"*": "subnet-1b", "eu-central-1b": "subnet-1b"}, restricted.SubnetsByAZ())
+	require.Equal(t, []string{"eu-central-1b"}, restricted.AvailabilityZones())
+}

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -41,10 +41,11 @@ import (
 
 const (
 	providerID                     = "zalando-aws"
-	manifestsPath                  = "cluster/manifests"
+	configRootPath                 = "cluster"
+	manifestsDir                   = "manifests"
 	deletionsFile                  = "deletions.yaml"
 	clusterStackFileName           = "cluster.yaml"
-	defaultsFile                   = "cluster/config-defaults.yaml"
+	defaultsFile                   = "config-defaults.yaml"
 	defaultNamespace               = "default"
 	kubectlNotFound                = "(NotFound)"
 	tagNameKubernetesClusterPrefix = "kubernetes.io/cluster/"
@@ -52,6 +53,9 @@ const (
 	resourceLifecycleShared        = "shared"
 	resourceLifecycleOwned         = "owned"
 	subnetsConfigItemKey           = "subnets"
+	subnetsValueKey                = "subnets"
+	availabilityZonesConfigItemKey = "availability_zones"
+	availabilityZonesValueKey      = "availability_zones"
 	vpcIDConfigItemKey             = "vpc_id"
 	subnetAllAZName                = "*"
 	maxApplyRetries                = 10
@@ -99,12 +103,13 @@ func (p *clusterpyProvisioner) Supports(cluster *api.Cluster) bool {
 }
 
 func (p *clusterpyProvisioner) updateDefaults(cluster *api.Cluster, channelConfig *channel.Config) error {
-	defaultsFile := path.Join(channelConfig.Path, defaultsFile)
+	defaultsFile := path.Join(channelConfig.Path, configRootPath, defaultsFile)
 
 	withoutConfigItems := *cluster
 	withoutConfigItems.ConfigItems = make(map[string]string)
 
-	result, err := renderTemplate(newTemplateContext(channelConfig.Path), defaultsFile, &withoutConfigItems)
+	params := newTemplateContext(path.Join(channelConfig.Path, configRootPath), &withoutConfigItems, nil, nil, "")
+	result, err := renderTemplate(params, defaultsFile)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -198,23 +203,16 @@ func (p *clusterpyProvisioner) Provision(ctx context.Context, logger *log.Entry,
 	}
 
 	// find the best subnet for each AZ
-	subnetsPerZone := selectSubnetIDs(subnets)
+	azInfo := selectSubnetIDs(subnets)
 
-	// build a subnet list for the virtual '*' AZ
-	for az, subnet := range subnetsPerZone {
-		if az == subnetAllAZName {
-			continue
-		}
-		if existing, ok := subnetsPerZone[subnetAllAZName]; ok {
-			subnetsPerZone[subnetAllAZName] = existing + "," + subnet
-		} else {
-			subnetsPerZone[subnetAllAZName] = subnet
-		}
+	// if availability zones are defined, filter the subnet list
+	if azNames, ok := cluster.ConfigItems[availabilityZonesConfigItemKey]; ok {
+		azInfo = azInfo.RestrictAZs(strings.Split(azNames, ","))
 	}
 
 	// TODO legacy, remove once we switch to Values in all clusters
 	if _, ok := cluster.ConfigItems[subnetsConfigItemKey]; !ok {
-		cluster.ConfigItems[subnetsConfigItemKey] = subnetsPerZone[subnetAllAZName]
+		cluster.ConfigItems[subnetsConfigItemKey] = azInfo.SubnetsByAZ()[subnetAllAZName]
 	}
 
 	apiURL, err := url.Parse(cluster.APIServerURL)
@@ -243,25 +241,27 @@ func (p *clusterpyProvisioner) Provision(ctx context.Context, logger *log.Entry,
 		"node_labels": fmt.Sprintf("lifecycle-status=%s", lifecycleStatusReady),
 		// TODO(tech-debt): custom legacy value
 		"apiserver_count":           "1",
-		"subnets":                   subnetsPerZone,
+		subnetsValueKey:             azInfo.SubnetsByAZ(),
+		availabilityZonesValueKey:   azInfo.AvailabilityZones(),
 		"hosted_zone":               hostedZone,
 		"load_balancer_certificate": loadBalancerCert.ID(),
 		"vpc_ipv4_cidr":             aws.StringValue(vpc.CidrBlock),
 	}
 
 	// render the manifests to find out if they're valid
-	manifestsPath := path.Join(channelConfig.Path, manifestsPath)
-	deletions, err := parseDeletions(cluster, manifestsPath)
+	configPath := path.Join(channelConfig.Path, configRootPath)
+	templateCtx := newTemplateContext(configPath, cluster, nil, values, "")
+	deletions, err := parseDeletions(templateCtx, path.Join(configPath, manifestsDir, deletionsFile))
 	if err != nil {
 		return err
 	}
-	manifests, err := renderManifests(cluster, manifestsPath)
+	manifests, err := renderManifests(templateCtx, path.Join(configPath, manifestsDir))
 	if err != nil {
 		return err
 	}
 
 	// create etcd stack if needed.
-	etcdStackDefinitionPath := path.Join(channelConfig.Path, "cluster", "etcd-cluster.yaml")
+	etcdStackDefinitionPath := path.Join(configPath, "etcd-cluster.yaml")
 
 	err = awsAdapter.CreateOrUpdateEtcdStack(ctx, "etcd-cluster-etcd", etcdStackDefinitionPath, aws.StringValue(vpc.CidrBlock), aws.StringValue(vpc.VpcId), cluster)
 	if err != nil {
@@ -272,13 +272,11 @@ func (p *clusterpyProvisioner) Provision(ctx context.Context, logger *log.Entry,
 		return err
 	}
 
-	cfgBasePath := path.Join(channelConfig.Path, "cluster")
-
 	// create bucket name with aws account ID to ensure uniqueness across
 	// accounts.
 	bucketName := fmt.Sprintf(clmCFBucketPattern, strings.TrimPrefix(cluster.InfrastructureAccount, "aws:"), cluster.Region)
 
-	err = createOrUpdateClusterStack(awsAdapter, ctx, cfgBasePath, cluster, values, bucketName)
+	err = createOrUpdateClusterStack(awsAdapter, ctx, templateCtx, path.Join(configPath, clusterStackFileName), bucketName)
 	if err != nil {
 		return err
 	}
@@ -287,7 +285,7 @@ func (p *clusterpyProvisioner) Provision(ctx context.Context, logger *log.Entry,
 		return err
 	}
 
-	cfgNodePoolBaseDir := path.Join(cfgBasePath, "node-pools")
+	cfgNodePoolBaseDir := path.Join(configPath, "node-pools")
 
 	// provision node pools
 	nodePoolProvisioner := &AWSNodePoolProvisioner{
@@ -296,6 +294,8 @@ func (p *clusterpyProvisioner) Provision(ctx context.Context, logger *log.Entry,
 		bucketName:      bucketName,
 		cfgBaseDir:      cfgNodePoolBaseDir,
 		Cluster:         cluster,
+		templateContext: templateCtx,
+		azInfo:          azInfo,
 		logger:          logger,
 	}
 
@@ -349,31 +349,20 @@ func (p *clusterpyProvisioner) Provision(ctx context.Context, logger *log.Entry,
 	return p.apply(ctx, logger, cluster, deletions, manifests)
 }
 
-type clusterStackParams struct {
-	Cluster *api.Cluster
-	Values  map[string]interface{}
-}
-
-func createOrUpdateClusterStack(awsAdapter *awsAdapter, ctx context.Context, baseDir string, cluster *api.Cluster, values map[string]interface{}, bucketName string) error {
-	params := &clusterStackParams{
-		Cluster: cluster,
-		Values:  values,
-	}
-
-	stackFilePath := path.Join(baseDir, clusterStackFileName)
-	output, err := renderTemplate(newTemplateContext(baseDir), stackFilePath, params)
+func createOrUpdateClusterStack(awsAdapter *awsAdapter, ctx context.Context, templateCtx *templateContext, stackFilePath string, bucketName string) error {
+	output, err := renderTemplate(templateCtx, stackFilePath)
 	if err != nil {
 		return err
 	}
 
-	err = awsAdapter.applyClusterStack(cluster.LocalID, output, cluster, bucketName)
+	err = awsAdapter.applyClusterStack(templateCtx.cluster.LocalID, output, templateCtx.cluster, bucketName)
 	if err != nil {
 		return err
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, maxWaitTimeout)
 	defer cancel()
-	err = awsAdapter.waitForStack(ctx, waitTime, cluster.LocalID)
+	err = awsAdapter.waitForStack(ctx, waitTime, templateCtx.cluster.LocalID)
 	if err != nil {
 		return err
 	}
@@ -410,7 +399,7 @@ func filterSubnets(allSubnets []*ec2.Subnet, subnetIds []string) ([]*ec2.Subnet,
 // kube-controller-manager when finding subnets for ELBs used for services of
 // type LoadBalancer.
 // https://github.com/kubernetes/kubernetes/blob/65efeee64f772e0f38037e91a677138a335a7570/pkg/cloudprovider/providers/aws/aws.go#L2949-L3027
-func selectSubnetIDs(subnets []*ec2.Subnet) map[string]string {
+func selectSubnetIDs(subnets []*ec2.Subnet) *AZInfo {
 	subnetsByAZ := make(map[string]*ec2.Subnet)
 	for _, subnet := range subnets {
 		az := aws.StringValue(subnet.AvailabilityZone)
@@ -446,7 +435,7 @@ func selectSubnetIDs(subnets []*ec2.Subnet) map[string]string {
 		result[az] = aws.StringValue(subnet.SubnetId)
 	}
 
-	return result
+	return &AZInfo{subnets: result}
 }
 
 // Decommission decommissions a cluster provisioned in AWS.
@@ -917,11 +906,8 @@ func (p *clusterpyProvisioner) Deletions(ctx context.Context, logger *log.Entry,
 }
 
 // parseDeletions reads and parses the deletions.yaml.
-func parseDeletions(cluster *api.Cluster, manifestsPath string) (*deletions, error) {
-	file := path.Join(manifestsPath, deletionsFile)
-
-	applyContext := newTemplateContext(manifestsPath)
-	rendered, err := renderTemplate(applyContext, file, cluster)
+func parseDeletions(ctx *templateContext, file string) (*deletions, error) {
+	rendered, err := renderTemplate(ctx, file)
 	if err != nil {
 		// if the file doesn't exist we just treat it as if it was
 		// empty.
@@ -953,14 +939,13 @@ func parseDeletions(cluster *api.Cluster, manifestsPath string) (*deletions, err
 	return &deletions, nil
 }
 
-func renderManifests(cluster *api.Cluster, manifestsPath string) ([]string, error) {
+func renderManifests(ctx *templateContext, manifestsPath string) ([]string, error) {
 	components, err := ioutil.ReadDir(manifestsPath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot read directory: %s", manifestsPath)
 	}
 
 	var result []string
-	applyContext := newTemplateContext(manifestsPath)
 
 	for _, c := range components {
 		// skip deletions.yaml if found
@@ -984,7 +969,7 @@ func renderManifests(cluster *api.Cluster, manifestsPath string) ([]string, erro
 				log.Warnf("File isn't a manifest, skipping: %s", file)
 				continue
 			}
-			manifest, err := renderTemplate(applyContext, file, cluster)
+			manifest, err := renderTemplate(ctx, file)
 			if err != nil {
 				return nil, fmt.Errorf("error rendering template %s/%s: %v", c.Name(), f.Name(), err)
 			}

--- a/provisioner/kubesystem_test.go
+++ b/provisioner/kubesystem_test.go
@@ -67,13 +67,13 @@ func TestApplyTemplate(t *testing.T) {
 
 	cdir, err := os.Getwd()
 	require.NoError(t, err)
-	context := newTemplateContext(cdir)
 
 	region := "eu-central"
 	localID := "kube-aws-test-rdifazio55"
 	cluster := &api.Cluster{Region: region, LocalID: localID}
+	context := newTemplateContext(cdir, cluster, nil, nil, "")
 
-	_, err = renderTemplate(context, "test_template", cluster)
+	_, err = renderTemplate(context, "test_template")
 	if err == nil {
 		t.Errorf("should fail, mate hosted zone configitems are not passed!")
 	}
@@ -81,7 +81,7 @@ func TestApplyTemplate(t *testing.T) {
 	cluster.ConfigItems = map[string]string{
 		"mate_hosted_zone": "hosted-zone",
 	}
-	s, err := renderTemplate(context, "test_template", cluster)
+	s, err := renderTemplate(context, "test_template")
 	if err != nil {
 		t.Errorf("should not fail %v", err)
 	}
@@ -128,7 +128,6 @@ func TestApplyTemplateBase64Fun(t *testing.T) {
 
 	cdir, err := os.Getwd()
 	require.NoError(t, err)
-	context := newTemplateContext(cdir)
 
 	value := "value"
 
@@ -136,7 +135,9 @@ func TestApplyTemplateBase64Fun(t *testing.T) {
 	cluster.ConfigItems = map[string]string{
 		"my_value": value,
 	}
-	s, err := renderTemplate(context, "test_template", cluster)
+	context := newTemplateContext(cdir, cluster, nil, nil, "")
+
+	s, err := renderTemplate(context, "test_template")
 	if err != nil {
 		t.Errorf("should not fail %v", err)
 	}
@@ -198,11 +199,13 @@ func TestParseDeletions(t *testing.T) {
 		},
 	}
 
-	deletions, err := parseDeletions(exampleCluster, ".")
+	context := newTemplateContext(".", exampleCluster, nil, nil, "")
+
+	deletions, err := parseDeletions(context, deletionsFile)
 	require.NoError(t, err)
 	require.EqualValues(t, expected, deletions)
 
 	// test not getting an error if file doesn't exists
-	_, err = parseDeletions(exampleCluster, "invalid_folder")
+	_, err = parseDeletions(context, "missing.yaml")
 	require.NoError(t, err)
 }

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -39,8 +39,8 @@ func render(t *testing.T, templates map[string]string, templateName string, data
 		require.NoError(t, err, "error while writing %s", fullPath)
 	}
 
-	context := newTemplateContext(basedir)
-	return renderTemplate(context, path.Join(basedir, templateName), data)
+	context := newTemplateContext(basedir, &api.Cluster{}, nil, map[string]interface{}{"data": data}, "")
+	return renderTemplate(context, path.Join(basedir, templateName))
 }
 
 func renderSingle(t *testing.T, template string, data interface{}) (string, error) {
@@ -54,7 +54,7 @@ func renderSingle(t *testing.T, template string, data interface{}) (string, erro
 func TestTemplating(t *testing.T) {
 	result, err := renderSingle(
 		t,
-		"foo {{ . }}",
+		"foo {{ .Values.data }}",
 		"1")
 
 	require.NoError(t, err)
@@ -64,7 +64,7 @@ func TestTemplating(t *testing.T) {
 func TestBase64Encode(t *testing.T) {
 	result, err := renderSingle(
 		t,
-		"{{ . | base64 }}",
+		"{{ .Values.data | base64 }}",
 		"abc123")
 
 	require.NoError(t, err)
@@ -74,7 +74,7 @@ func TestBase64Encode(t *testing.T) {
 func TestBase64Decode(t *testing.T) {
 	result, err := renderSingle(
 		t,
-		"{{ . | base64Decode }}",
+		"{{ .Values.data | base64Decode }}",
 		"YWJjMTIz")
 
 	require.NoError(t, err)
@@ -85,7 +85,7 @@ func TestManifestHash(t *testing.T) {
 	result, err := render(
 		t,
 		map[string]string{
-			"dir/config.yaml": "foo {{ . }}",
+			"dir/config.yaml": "foo {{ .Values.data }}",
 			"dir/foo.yaml":    `{{ manifestHash "config.yaml" }}`,
 		},
 		"dir/foo.yaml",
@@ -123,7 +123,7 @@ func TestManifestHashRecursiveInclude(t *testing.T) {
 func renderAutoscaling(t *testing.T, cluster *api.Cluster) (string, error) {
 	return renderSingle(
 		t,
-		`{{ with autoscalingBufferSettings . }}{{.CPU}} {{.Memory}}{{end}}`,
+		`{{ with autoscalingBufferSettings .Values.data }}{{.CPU}} {{.Memory}}{{end}}`,
 		cluster)
 }
 
@@ -155,7 +155,7 @@ func TestAutoscalingBufferExplicitOnlyOne(t *testing.T) {
 func TestAutoscalingBufferPoolBasedScale(t *testing.T) {
 	result, err := renderSingle(
 		t,
-		`{{ with autoscalingBufferSettings . }}{{.CPU}} {{.Memory}}{{end}}`,
+		`{{ with autoscalingBufferSettings .Values.data }}{{.CPU}} {{.Memory}}{{end}}`,
 		exampleCluster([]*api.NodePool{
 			{
 				InstanceTypes: []string{"m4.xlarge"},
@@ -179,7 +179,7 @@ func TestAutoscalingBufferPoolBasedScale(t *testing.T) {
 func TestAutoscalingBufferPoolBasedReserved(t *testing.T) {
 	result, err := renderSingle(
 		t,
-		`{{ with autoscalingBufferSettings . }}{{.CPU}} {{.Memory}}{{end}}`,
+		`{{ with autoscalingBufferSettings .Values.data }}{{.CPU}} {{.Memory}}{{end}}`,
 		exampleCluster([]*api.NodePool{
 			{
 				// 8 vcpu / 32gb
@@ -195,7 +195,7 @@ func TestAutoscalingBufferPoolBasedReserved(t *testing.T) {
 func TestAutoscalingBufferPoolBasedNoPools(t *testing.T) {
 	_, err := renderSingle(
 		t,
-		`{{ with autoscalingBufferSettings . }}{{.CPU}} {{.Memory}}{{end}}`,
+		`{{ with autoscalingBufferSettings .Values.data }}{{.CPU}} {{.Memory}}{{end}}`,
 		exampleCluster([]*api.NodePool{
 			{
 				InstanceTypes: []string{"m4.xlarge"},
@@ -290,7 +290,7 @@ func TestAZID(t *testing.T) {
 func TestAZCountSimple(t *testing.T) {
 	result, err := renderSingle(
 		t,
-		`{{ azCount . }}`,
+		`{{ azCount .Values.data }}`,
 		map[string]string{
 			"*":             "subnet-foo,subnet-bar,subnet-baz",
 			"eu-central-1a": "subnet-foo",
@@ -305,7 +305,7 @@ func TestAZCountSimple(t *testing.T) {
 func TestAZCountStarOnly(t *testing.T) {
 	result, err := renderSingle(
 		t,
-		`{{ azCount . }}`,
+		`{{ azCount .Values.data }}`,
 		map[string]string{
 			"*": "",
 		})
@@ -317,7 +317,7 @@ func TestAZCountStarOnly(t *testing.T) {
 func TestAZCountNoSubnets(t *testing.T) {
 	result, err := renderSingle(
 		t,
-		`{{ azCount . }}`,
+		`{{ azCount .Values.data }}`,
 		map[string]string{})
 
 	require.NoError(t, err)
@@ -361,8 +361,8 @@ func TestAccountIDFailsOnInvalid(t *testing.T) {
 }
 
 func TestParsePortRanges(t *testing.T) {
-	testTemplate := `{{- if index .portRanges -}}
-{{- range $index, $element := portRanges .portRanges -}}
+	testTemplate := `{{- if index .Values.data.portRanges -}}
+{{- range $index, $element := portRanges .Values.data.portRanges -}}
 - CidrIp: 0.0.0.0/0
   FromPort: {{ $element.FromPort }}
   IpProtocol: tcp
@@ -459,7 +459,7 @@ DwIDAQAB
 
 	result, err := renderSingle(
 		t,
-		`{{ publicKey . }}`,
+		`{{ publicKey .Values.data }}`,
 		privkey)
 	require.NoError(t, err)
 	require.EqualValues(t, pubkey, result)


### PR DESCRIPTION
Add support for `availability_zones` property. It can be specified at either the cluster level, in which case it affects everything, or on the node pool level (then it's merged with the cluster values). Subnets are automatically restricted to only the available AZs, and `values` now gains a new attribute, `availability_zones`.

Template data is now unified across all templates, which makes it possible to use `values` in Kubernetes manifests as well. Some of the data (e.g. `NodePool`) will obviously not be available in all of the templates, but at least the structure of the data will be the same. Ideally, we should migrate all Kubernetes manifests to use `.Cluster.ConfigItems` instead of `.ConfigItems` and then drop the compatibility properties in `templateData`.