### PR TITLE
Support for cloud-init and CLC at the same time

### DIFF
--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -255,8 +255,8 @@ func (p *AWSNodePoolProvisioner) prepareUserData(templateCtx *templateContext, n
 
 // prepareCloudInit prepares the user data by rendering the golang template.
 // A EC2 UserData ready base64 string will be returned.
-func (p *AWSNodePoolProvisioner) prepareCloudInit(templateCtx *templateContext, clcPath string) (string, error) {
-	rendered, err := renderTemplate(templateCtx, clcPath)
+func (p *AWSNodePoolProvisioner) prepareCloudInit(templateCtx *templateContext, cloudInitPath string) (string, error) {
+	rendered, err := renderTemplate(templateCtx, cloudInitPath)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This adds back support for plain-old `cloud-init` in parallel with `clc/ignition`.

Upon defining the NodePool's UserData CLM looks for the current `userdata.clc.yaml` and processes/uploads it as before. If the file doesn't exist it checks for a file `userdata.yaml`, processes it and sets its content as UserData.

Note, that it doesn't upload to S3 at this point as it's not as easy as with `ignition` afaik. With a lot of stuff moving into the custom Ubuntu AMI it's likely we manage to stay under the UserData limit this time, WDYT?

Code is not the prettiest but as I understood this conditional is temporary again? If not I'm happy to make it a little nicer.

/cc @njuettner @mikkeloscar  @aermakov-zalando 