### PR TITLE
stupsNATSubnets: return []string

### DIFF
--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -519,31 +519,31 @@ func subdivide(network *net.IPNet, size int) ([]*net.IPNet, error) {
 }
 
 // given a VPC CIDR block, return a comma-separated list of <count> NAT subnets from the STUPS setup
-func stupsNATSubnets(vpcCidr string) (string, error) {
+func stupsNATSubnets(vpcCidr string) ([]string, error) {
 	_, vpcNet, err := net.ParseCIDR(vpcCidr)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// subdivide the network into /size+2 subnets first, take the second one
 	subnetSize, _ := vpcNet.Mask.Size()
 	if subnetSize == 0 || subnetSize > 24 {
-		return "", fmt.Errorf("invalid subnet, expecting at least /24: %s", vpcNet)
+		return nil, fmt.Errorf("invalid subnet, expecting at least /24: %s", vpcNet)
 	}
 
 	addrs, err := subdivide(vpcNet, subnetSize+2)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	natNetworks, err := subdivide(addrs[1], 28)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	var result []string
 	for i := 0; i < 3; i++ {
 		result = append(result, natNetworks[i].String())
 	}
-	return strings.Join(result, ","), nil
+	return result, nil
 }

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -472,21 +472,21 @@ func TestStupsNATSubnets(t *testing.T) {
 	}{
 		{
 			vpc:     "172.31.0.0/16",
-			subnets: "172.31.64.0/28,172.31.64.16/28,172.31.64.32/28",
+			subnets: "172.31.64.0/28 172.31.64.16/28 172.31.64.32/28 ",
 		},
 		{
 			vpc:     "10.153.192.0/19",
-			subnets: "10.153.200.0/28,10.153.200.16/28,10.153.200.32/28",
+			subnets: "10.153.200.0/28 10.153.200.16/28 10.153.200.32/28 ",
 		},
 
 		{
 			vpc:     "10.149.64.0/19",
-			subnets: "10.149.72.0/28,10.149.72.16/28,10.149.72.32/28",
+			subnets: "10.149.72.0/28 10.149.72.16/28 10.149.72.32/28 ",
 		},
 	} {
 		result, err := renderSingle(
 			t,
-			`{{ stupsNATSubnets .Values.data }}`,
+			`{{ range $elem := stupsNATSubnets .Values.data }}{{$elem}} {{ end }}`,
 			tc.vpc)
 
 		require.NoError(t, err)


### PR DESCRIPTION
We won't have to split it back in the template