### PR TITLE
Be more robust when deleting stacks

### DIFF
--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -351,12 +351,22 @@ func cloudformationHasTags(expected map[string]string, tags []*cloudformation.Ta
 
 }
 
+func isStackDeleting(stack *cloudformation.Stack) bool {
+	switch aws.StringValue(stack.StackStatus) {
+	case cloudformation.StackStatusDeleteInProgress,
+		cloudformation.StackStatusDeleteComplete:
+		return true
+	default:
+		return false
+	}
+}
+
 // DeleteStack deletes a cloudformation stack.
 func (a *awsAdapter) DeleteStack(parentCtx context.Context, stack *cloudformation.Stack) error {
 	stackName := aws.StringValue(stack.StackName)
 	a.logger.Infof("Deleting stack '%s'", stackName)
 
-	if aws.BoolValue(stack.EnableTerminationProtection) {
+	if !isStackDeleting(stack) {
 		// disable termination protection on stack before deleting
 		terminationParams := &cloudformation.UpdateTerminationProtectionInput{
 			StackName:                   aws.String(stackName),
@@ -370,23 +380,23 @@ func (a *awsAdapter) DeleteStack(parentCtx context.Context, stack *cloudformatio
 			}
 			return err
 		}
-	}
 
-	deleteParams := &cloudformation.DeleteStackInput{
-		StackName: aws.String(stackName),
-	}
-
-	_, err := a.cloudformationClient.DeleteStack(deleteParams)
-	if err != nil {
-		if isDoesNotExistsErr(err) {
-			return nil
+		deleteParams := &cloudformation.DeleteStackInput{
+			StackName: aws.String(stackName),
 		}
-		return err
+
+		_, err = a.cloudformationClient.DeleteStack(deleteParams)
+		if err != nil {
+			if isDoesNotExistsErr(err) {
+				return nil
+			}
+			return err
+		}
 	}
 
 	ctx, cancel := context.WithTimeout(parentCtx, maxWaitTimeout)
 	defer cancel()
-	err = a.waitForStack(ctx, waitTime, stackName)
+	err := a.waitForStack(ctx, waitTime, stackName)
 	if err != nil {
 		if isDoesNotExistsErr(err) {
 			return nil

--- a/provisioner/aws_test.go
+++ b/provisioner/aws_test.go
@@ -297,3 +297,14 @@ func TestCreateOrUpdateClusterStack(t *testing.T) {
 	err = awsAdapter.applyClusterStack("stack-name", `{"stack": "template"}`, cluster, s3Bucket)
 	assert.Error(t, err)
 }
+
+func TestIsStackDeleting(t *testing.T) {
+	stack := &cloudformation.Stack{
+		StackStatus: aws.String(cloudformation.StackStatusDeleteInProgress),
+	}
+
+	assert.True(t, isStackDeleting(stack))
+
+	stack.StackStatus = aws.String(cloudformation.StackStatusCreateComplete)
+	assert.False(t, isStackDeleting(stack))
+}

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -472,8 +472,12 @@ func (p *clusterpyProvisioner) Decommission(logger *log.Entry, cluster *api.Clus
 		return err
 	}
 
+	stack := &cloudformation.Stack{
+		StackName: aws.String(cluster.LocalID),
+	}
+
 	// delete the main cluster stack
-	err = awsAdapter.DeleteStack(ctx, cluster.LocalID)
+	err = awsAdapter.DeleteStack(ctx, stack)
 	if err != nil {
 		return err
 	}
@@ -781,7 +785,7 @@ func (p *clusterpyProvisioner) deleteClusterStacks(ctx context.Context, adapter 
 	for _, stack := range stacks {
 		go func(stack cloudformation.Stack, errorsc chan error) {
 			deleteStack := func() error {
-				err := adapter.DeleteStack(ctx, aws.StringValue(stack.StackName))
+				err := adapter.DeleteStack(ctx, &stack)
 				if err != nil {
 					if isWrongStackStatusErr(err) {
 						return err

--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -237,7 +237,7 @@ func (p *AWSNodePoolProvisioner) Reconcile(ctx context.Context, updater updatest
 		}
 
 		// delete node pool stack
-		err = p.awsAdapter.DeleteStack(ctx, aws.StringValue(stack.StackName))
+		err = p.awsAdapter.DeleteStack(ctx, stack)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When deleting a cluster don't try to delete stacks which are already being deleted. ~disable termination protection of stacks where it's already disabled (and potentially already being deleted).~