### PR TITLE
Propagate cluster config items to node pool

### DIFF
--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -161,16 +161,6 @@ func (p *AWSNodePoolProvisioner) provisionNodePool(nodePool *api.NodePool, value
 		values[availabilityZonesValueKey] = azInfo.AvailabilityZones()
 	}
 
-	// Propagate cluster config items to node pool if undefined on node pool
-	if nodePool.ConfigItems == nil {
-		nodePool.ConfigItems = map[string]string{}
-	}
-	for name, value := range p.Cluster.ConfigItems {
-		if _, ok := nodePool.ConfigItems[name]; !ok {
-			nodePool.ConfigItems[name] = value
-		}
-	}
-
 	template, err := p.generateNodePoolStackTemplate(nodePool, values)
 	if err != nil {
 		return err

--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -161,6 +161,16 @@ func (p *AWSNodePoolProvisioner) provisionNodePool(nodePool *api.NodePool, value
 		values[availabilityZonesValueKey] = azInfo.AvailabilityZones()
 	}
 
+	// Propagate cluster config items to node pool if undefined on node pool
+	if nodePool.ConfigItems == nil {
+		nodePool.ConfigItems = map[string]string{}
+	}
+	for name, value := range p.Cluster.ConfigItems {
+		if _, ok := nodePool.ConfigItems[name]; !ok {
+			nodePool.ConfigItems[name] = value
+		}
+	}
+
 	template, err := p.generateNodePoolStackTemplate(nodePool, values)
 	if err != nil {
 		return err


### PR DESCRIPTION
Forward config items from the cluster to the node pool if it's not defined on the node pool.

Allows to use `{{ .NodePool.ConfigItems.pod_max_pids }}` in the templates without any guarding ifs. Logically, it will lookup the value first in the node pool's config items, then in the cluster's config items, then it uses the default. Allows to have cluster-wide defaults for node-pool specific values such as PID limit or node pool labels.

An alternative would be to - instead - overwrite `Cluster.ConfigItems` with `NodePool.ConfigItems` if duplicate keys exist. In this case we could always use the same syntax for reading config items, i.e. ``{{ .Cluster.ConfigItems.pod_max_pids }}``. This way any config item can be overwritten by any node pool and the templates don't need to know.

Let me know what you prefer.

/cc @aermakov-zalando @mikkeloscar 