### PR TITLE
Added template function to generate AMI id

### DIFF
--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/cloudformation/cloudformationiface"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/kms/kmsiface"
@@ -85,17 +86,6 @@ type iamAPI interface {
 	ListAccountAliases(input *iam.ListAccountAliasesInput) (*iam.ListAccountAliasesOutput, error)
 }
 
-type ec2API interface {
-	DescribeVpcs(input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error)
-	DescribeVolumes(input *ec2.DescribeVolumesInput) (*ec2.DescribeVolumesOutput, error)
-	DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error)
-
-	CreateTags(input *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error)
-	DeleteTags(input *ec2.DeleteTagsInput) (*ec2.DeleteTagsOutput, error)
-
-	DeleteVolume(input *ec2.DeleteVolumeInput) (*ec2.DeleteVolumeOutput, error)
-}
-
 type s3UploaderAPI interface {
 	Upload(input *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
 }
@@ -107,7 +97,7 @@ type awsAdapter struct {
 	s3Uploader           s3UploaderAPI
 	autoscalingClient    autoscalingAPI
 	iamClient            iamAPI
-	ec2Client            ec2API
+	ec2Client            ec2iface.EC2API
 	acmClient            acmiface.ACMAPI
 	region               string
 	apiServer            string

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -110,7 +110,7 @@ func (p *clusterpyProvisioner) updateDefaults(cluster *api.Cluster, channelConfi
 	withoutConfigItems := *cluster
 	withoutConfigItems.ConfigItems = make(map[string]string)
 
-	params := newTemplateContext(path.Join(channelConfig.Path, configRootPath), &withoutConfigItems, nil, nil, "")
+	params := newTemplateContext(path.Join(channelConfig.Path, configRootPath), &withoutConfigItems, nil, nil, "", nil)
 	result, err := renderTemplate(params, defaultsFile)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -268,7 +268,7 @@ func (p *clusterpyProvisioner) Provision(ctx context.Context, logger *log.Entry,
 
 	// render the manifests to find out if they're valid
 	configPath := path.Join(channelConfig.Path, configRootPath)
-	templateCtx := newTemplateContext(configPath, cluster, nil, values, "")
+	templateCtx := newTemplateContext(configPath, cluster, nil, values, "", awsAdapter)
 	deletions, err := parseDeletions(templateCtx, path.Join(configPath, manifestsDir, deletionsFile))
 	if err != nil {
 		return err

--- a/provisioner/kubesystem_test.go
+++ b/provisioner/kubesystem_test.go
@@ -77,7 +77,7 @@ func TestApplyTemplate(t *testing.T) {
 	region := "eu-central"
 	localID := "kube-aws-test-rdifazio55"
 	cluster := &api.Cluster{Region: region, LocalID: localID}
-	context := newTemplateContext(cdir, cluster, nil, nil, "")
+	context := newTemplateContext(cdir, cluster, nil, nil, "", nil)
 
 	_, err = renderTemplate(context, "test_template")
 	if err == nil {
@@ -143,7 +143,7 @@ func TestApplyTemplateBase64Fun(t *testing.T) {
 	cluster.ConfigItems = map[string]string{
 		"my_value": value,
 	}
-	context := newTemplateContext(cdir, cluster, nil, nil, "")
+	context := newTemplateContext(cdir, cluster, nil, nil, "", nil)
 
 	s, err := renderTemplate(context, "test_template")
 	if err != nil {
@@ -207,7 +207,7 @@ func TestParseDeletions(t *testing.T) {
 		},
 	}
 
-	context := newTemplateContext(".", exampleCluster, nil, nil, "")
+	context := newTemplateContext(".", exampleCluster, nil, nil, "", nil)
 
 	deletions, err := parseDeletions(context, deletionsFile)
 	require.NoError(t, err)


### PR DESCRIPTION
Added a new `amiID` function to the template context which can get the AMI ID when given the `name` and `owner-id`.