### PR TITLE
Improve err message after waiting for a CF Stack to be applied

### DIFF
--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -293,7 +293,10 @@ func (a *awsAdapter) waitForStack(ctx context.Context, waitTime time.Duration, s
 			err = errUpdateRollbackFailed
 		}
 		if err != nil {
-			return fmt.Errorf("%s, reason: %s", err, *stack.StackStatusReason)
+			if stack.StackStatusReason != nil {
+				return fmt.Errorf("%s, reason: %s", err, *stack.StackStatusReason)
+			}
+			return err
 		}
 		a.logger.Debugf("Stack '%s' - [%s]", stackName, *stack.StackStatus)
 

--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -272,7 +272,6 @@ func (a *awsAdapter) waitForStack(ctx context.Context, waitTime time.Duration, s
 			return err
 		}
 
-		var err error
 		switch *stack.StackStatus {
 		case cloudformation.StackStatusUpdateComplete:
 			return nil

--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -294,7 +294,7 @@ func (a *awsAdapter) waitForStack(ctx context.Context, waitTime time.Duration, s
 		}
 		if err != nil {
 			if stack.StackStatusReason != nil {
-				return fmt.Errorf("%s, reason: %s", err, *stack.StackStatusReason)
+				return fmt.Errorf("%v, reason: %v", err, *stack.StackStatusReason)
 			}
 			return err
 		}

--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -271,6 +271,8 @@ func (a *awsAdapter) waitForStack(ctx context.Context, waitTime time.Duration, s
 		if err != nil {
 			return err
 		}
+
+		var err error
 		switch *stack.StackStatus {
 		case cloudformation.StackStatusUpdateComplete:
 			return nil
@@ -279,17 +281,20 @@ func (a *awsAdapter) waitForStack(ctx context.Context, waitTime time.Duration, s
 		case cloudformation.StackStatusDeleteComplete:
 			return nil
 		case cloudformation.StackStatusCreateFailed:
-			return errCreateFailed
+			err = errCreateFailed
 		case cloudformation.StackStatusDeleteFailed:
-			return errDeleteFailed
+			err = errDeleteFailed
 		case cloudformation.StackStatusRollbackComplete:
-			return errRollbackComplete
+			err = errRollbackComplete
 		case cloudformation.StackStatusRollbackFailed:
-			return errRollbackFailed
+			err = errRollbackFailed
 		case cloudformation.StackStatusUpdateRollbackComplete:
-			return errUpdateRollbackComplete
+			err = errUpdateRollbackComplete
 		case cloudformation.StackStatusUpdateRollbackFailed:
-			return errUpdateRollbackFailed
+			err = errUpdateRollbackFailed
+		}
+		if err != nil {
+			return fmt.Errorf("%s, reason: %s", err, *stack.StackStatusReason)
 		}
 		a.logger.Debugf("Stack '%s' - [%s]", stackName, *stack.StackStatus)
 


### PR DESCRIPTION
If there's an error after for a CF Stack to be applied, the StackStatus is sometimes too generic to understand the error message. Including the Reason in the error message so we don't have to look at the AWS console just for the error message.

Signed-off-by: Muhammad Muaaz Saleem <muhammad.muaaz.saleem@zalando.de>