### PR TITLE
Directory config source: use an absolute path

### DIFF
--- a/channel/directory.go
+++ b/channel/directory.go
@@ -2,6 +2,8 @@ package channel
 
 import (
 	"context"
+	"path"
+	"path/filepath"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -14,8 +16,14 @@ type Directory struct {
 type directoryVersions struct{}
 
 // NewDirectory initializes a new directory-based ChannelSource.
-func NewDirectory(location string) ConfigSource {
-	return &Directory{location: location}
+func NewDirectory(location string) (ConfigSource, error) {
+	abspath, err := filepath.Abs(path.Clean(location))
+	if err != nil {
+		return nil, err
+	}
+	return &Directory{
+		location: abspath,
+	}, nil
 }
 
 func (d *Directory) Update(ctx context.Context, logger *log.Entry) (ConfigVersions, error) {

--- a/channel/directory_test.go
+++ b/channel/directory_test.go
@@ -13,7 +13,8 @@ func TestDirectoryChannel(t *testing.T) {
 
 	logger := log.StandardLogger().WithFields(map[string]interface{}{})
 
-	d := NewDirectory(location)
+	d, err := NewDirectory(location)
+	require.NoError(t, err)
 	channels, err := d.Update(context.Background(), logger)
 	require.NoError(t, err)
 	require.Empty(t, channels)

--- a/cmd/clm/main.go
+++ b/cmd/clm/main.go
@@ -81,7 +81,10 @@ func main() {
 	var configSource channel.ConfigSource
 
 	if cfg.Directory != "" {
-		configSource = channel.NewDirectory(cfg.Directory)
+		configSource, err = channel.NewDirectory(cfg.Directory)
+		if err != nil {
+			log.Fatalf("Failed to setup directory channel config source: %v", err)
+		}
 	} else {
 		var err error
 		configSource, err = channel.NewGit(execManager, cfg.Workdir, cfg.GitRepositoryURL, cfg.SSHPrivateKeyFile)


### PR DESCRIPTION
This makes template context not fail if used with a non-absolute path like ".".