### PR TITLE
nodeCIDRMaxPods: allow specifying extra capacity

### DIFF
--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -598,13 +598,13 @@ func nodeCIDRMaxNodes(maskSize int) (int, error) {
 	return 2 << (maskSize - 16 - 1), nil
 }
 
-func nodeCIDRMaxPods(maskSize int) (int, error) {
+func nodeCIDRMaxPods(maskSize int, extraCapacity int) (int, error) {
 	err := checkCIDRMaxSize(maskSize)
 	if err != nil {
 		return 0, err
 	}
 
-	maxPods := 2 << (32 - maskSize - 2)
+	maxPods := 2<<(32-maskSize-2) + extraCapacity
 	if maxPods > 110 {
 		maxPods = 110
 	}

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -626,6 +626,7 @@ func TestNodeCIDRMaxPods(t *testing.T) {
 	for _, tc := range []struct {
 		name          string
 		cidr          int
+		extraCapacity int
 		expected      string
 		expectedError bool
 	}{
@@ -635,14 +636,21 @@ func TestNodeCIDRMaxPods(t *testing.T) {
 			expected: "110",
 		},
 		{
+			name:          "basic+extra",
+			cidr:          24,
+			extraCapacity: 10,
+			expected:      "110",
+		},
+		{
 			name:     "larger",
 			cidr:     25,
 			expected: "64",
 		},
 		{
-			name:     "large",
-			cidr:     27,
-			expected: "16",
+			name:          "large",
+			cidr:          27,
+			extraCapacity: 5,
+			expected:      "21",
 		},
 		{
 			name:          "error: too small",
@@ -656,7 +664,10 @@ func TestNodeCIDRMaxPods(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := renderSingle(t, "{{ nodeCIDRMaxPods .Values.data }}", tc.cidr)
+			result, err := renderSingle(t, "{{ nodeCIDRMaxPods .Values.data.cidr .Values.data.extra_capacity }}", map[string]int{
+				"cidr":           tc.cidr,
+				"extra_capacity": tc.extraCapacity,
+			})
 			if tc.expectedError {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
This should allow us to still run master nodes with a CIDR of /27, because most of the pods there don't use any IPs.