### PR TITLE
Template: add parseInt64

### DIFF
--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -279,6 +279,7 @@ func renderTemplate(context *templateContext, filePath string) (string, error) {
 		},
 		"nodeCIDRMaxNodes": nodeCIDRMaxNodes,
 		"nodeCIDRMaxPods":  nodeCIDRMaxPods,
+		"parseInt64":       parseInt64,
 	}
 
 	content, err := ioutil.ReadFile(filePath)
@@ -582,14 +583,18 @@ func amiID(adapter *awsAdapter, imageName, imageOwner string) (string, error) {
 	return *output.Images[0].ImageId, nil
 }
 
-func checkCIDRMaxSize(maskSize int) error {
+func parseInt64(value string) (int64, error) {
+	return strconv.ParseInt(value, 10, 64)
+}
+
+func checkCIDRMaxSize(maskSize int64) error {
 	if maskSize < 24 || maskSize > 28 {
 		return fmt.Errorf("invalid value for maskSize: %d", maskSize)
 	}
 	return nil
 }
 
-func nodeCIDRMaxNodes(maskSize int) (int, error) {
+func nodeCIDRMaxNodes(maskSize int64) (int64, error) {
 	err := checkCIDRMaxSize(maskSize)
 	if err != nil {
 		return 0, err
@@ -598,7 +603,7 @@ func nodeCIDRMaxNodes(maskSize int) (int, error) {
 	return 2 << (maskSize - 16 - 1), nil
 }
 
-func nodeCIDRMaxPods(maskSize int, extraCapacity int) (int, error) {
+func nodeCIDRMaxPods(maskSize int64, extraCapacity int64) (int64, error) {
 	err := checkCIDRMaxSize(maskSize)
 	if err != nil {
 		return 0, err

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -585,7 +585,7 @@ func TestAmiID(t *testing.T) {
 func TestNodeCIDRMaxNodes(t *testing.T) {
 	for _, tc := range []struct {
 		name          string
-		cidr          int
+		cidr          int64
 		expected      string
 		expectedError bool
 	}{
@@ -625,8 +625,8 @@ func TestNodeCIDRMaxNodes(t *testing.T) {
 func TestNodeCIDRMaxPods(t *testing.T) {
 	for _, tc := range []struct {
 		name          string
-		cidr          int
-		extraCapacity int
+		cidr          int64
+		extraCapacity int64
 		expected      string
 		expectedError bool
 	}{
@@ -664,7 +664,7 @@ func TestNodeCIDRMaxPods(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := renderSingle(t, "{{ nodeCIDRMaxPods .Values.data.cidr .Values.data.extra_capacity }}", map[string]int{
+			result, err := renderSingle(t, "{{ nodeCIDRMaxPods .Values.data.cidr .Values.data.extra_capacity }}", map[string]int64{
 				"cidr":           tc.cidr,
 				"extra_capacity": tc.extraCapacity,
 			})
@@ -676,4 +676,15 @@ func TestNodeCIDRMaxPods(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseInt64(t *testing.T) {
+	result, err := renderSingle(t, `{{ parseInt64 "1234" }}`, nil)
+	require.NoError(t, err)
+	require.EqualValues(t, "1234", result)
+}
+
+func TestParseInt64Error(t *testing.T) {
+	_, err := renderSingle(t, `{{ parseInt64 "foobar" }}`, nil)
+	require.Error(t, err)
 }


### PR DESCRIPTION
Follow-up for #190, #192. Easier than making all these functions parse as well.