### PR TITLE
Update to golangci-lint 1.21.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
   - "1.13.x"
 
 env:
-- GOLANGCI_RELEASE="v1.19.1"
+- GOLANGCI_RELEASE="v1.21.0"
 
 before_install:
   - GO111MODULE=off go get github.com/mattn/goveralls

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -2,7 +2,6 @@ version: "2017-09-20"
 pipeline:
 - id: build
   overlay: ci/golang
-  vm: large
   type: script
   cache:
     paths:


### PR DESCRIPTION
Update to golangci-lint 1.21.0

We can use a smaller build VM because the memory leak issue in golangci-lint has been fixed since the previous version. (was updated in the overlay)