### PR TITLE
Rename spot_max_price profile to just spot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ test: $(CR_CLIENT) $(AWS_INSTANCE_DATA)
 
 lint: $(CR_CLIENT) $(SOURCES) $(AWS_INSTANCE_DATA)
 	$(GO) mod download
-	golangci-lint run ./...
+	golangci-lint -v run --timeout=10m ./...
 
 fmt:
 	$(GO) fmt $(GOPKGS)

--- a/api/node_pool.go
+++ b/api/node_pool.go
@@ -2,11 +2,6 @@ package api
 
 import "strings"
 
-const (
-	DiscountStrategyNone = "none"
-	DiscountStrategySpot = "spot_max_price"
-)
-
 // NodePool describes a node pool in a kubernetes cluster.
 type NodePool struct {
 	DiscountStrategy string            `json:"discount_strategy" yaml:"discount_strategy"`
@@ -19,6 +14,10 @@ type NodePool struct {
 
 	// Deprecated, only kept here so the existing clusters don't break
 	InstanceType string
+}
+
+func (np NodePool) IsSpot() bool {
+	return np.Profile == "spot_max_price" || np.Profile == "spot"
 }
 
 // NodePools is a slice of *NodePool which implements the sort interface to

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -5,6 +5,7 @@ pipeline:
   type: script
   env:
     GOFLAGS: "-mod=readonly"
+  vm: large
   cache:
     paths:
     - /go/pkg/mod

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -3,6 +3,8 @@ pipeline:
 - id: build
   overlay: ci/golang
   type: script
+  env:
+    GOFLAGS: "-mod=readonly"
   cache:
     paths:
     - /go/pkg/mod

--- a/pkg/updatestrategy/node_pool_manager.go
+++ b/pkg/updatestrategy/node_pool_manager.go
@@ -427,7 +427,7 @@ func WaitForDesiredNodes(ctx context.Context, logger *log.Entry, n NodePoolManag
 		}
 
 		// Don't wait for Spot nodes, just proceed with whatever we want to do
-		if nodePoolDesc.DiscountStrategy == api.DiscountStrategySpot {
+		if nodePoolDesc.IsSpot() {
 			break
 		}
 

--- a/pkg/updatestrategy/rolling_update.go
+++ b/pkg/updatestrategy/rolling_update.go
@@ -120,7 +120,7 @@ func (r *RollingUpdateStrategy) Update(ctx context.Context, nodePoolDesc *api.No
 
 	// limit surge to max size of the node pool
 	surge := int(math.Min(float64(nodePoolDesc.MaxSize), float64(r.surge)))
-	spotPool := nodePoolDesc.DiscountStrategy == api.DiscountStrategySpot
+	spotPool := nodePoolDesc.IsSpot()
 
 	for {
 		// wait/scale to ensure that we have at least 'surge' new nodes in the node pool


### PR DESCRIPTION
Easier to type, and allows us to tune the actual allocation strategy without having to rename every time.