### PR TITLE
Make overriding a channel a bit easier

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -10,6 +10,10 @@ import (
 	"github.com/zalando-incubator/cluster-lifecycle-manager/channel"
 )
 
+const (
+	overrideChannelConfigItem = "override_channel"
+)
+
 // Cluster describes a kubernetes cluster and related configuration.
 type Cluster struct {
 	Alias                 string            `json:"alias"                  yaml:"alias"`
@@ -155,5 +159,10 @@ func (cluster *Cluster) Version(channelVersion channel.ConfigVersion) (*ClusterV
 }
 
 func (cluster *Cluster) Channels() []string {
-	return []string{cluster.Channel}
+	var result []string
+	if override, ok := cluster.ConfigItems[overrideChannelConfigItem]; ok {
+		result = append(result, override)
+	}
+	result = append(result, cluster.Channel)
+	return result
 }

--- a/api/cluster.go
+++ b/api/cluster.go
@@ -153,3 +153,7 @@ func (cluster *Cluster) Version(channelVersion channel.ConfigVersion) (*ClusterV
 	}
 	return result, nil
 }
+
+func (cluster *Cluster) Channels() []string {
+	return []string{cluster.Channel}
+}

--- a/channel/caching_source.go
+++ b/channel/caching_source.go
@@ -2,6 +2,7 @@ package channel
 
 import (
 	"context"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 )
@@ -28,14 +29,16 @@ func (c *CachingSource) Update(ctx context.Context, logger *logrus.Entry) error 
 	return c.target.Update(ctx, logger)
 }
 
-func (c *CachingSource) Version(channel string) (ConfigVersion, error) {
-	if cached, ok := c.cache[channel]; ok {
+func (c *CachingSource) Version(channels []string) (ConfigVersion, error) {
+	cacheKey := strings.Join(channels, "\x00")
+
+	if cached, ok := c.cache[cacheKey]; ok {
 		return cached, nil
 	}
-	res, err := c.target.Version(channel)
+	res, err := c.target.Version(channels)
 	if err != nil {
 		return nil, err
 	}
-	c.cache[channel] = res
+	c.cache[cacheKey] = res
 	return res, nil
 }

--- a/channel/combined.go
+++ b/channel/combined.go
@@ -53,12 +53,12 @@ func (c *CombinedSource) Update(ctx context.Context, logger *logrus.Entry) error
 	return nil
 }
 
-func (c *CombinedSource) Version(channel string) (ConfigVersion, error) {
+func (c *CombinedSource) Version(channels []string) (ConfigVersion, error) {
 	versions := make([]ConfigVersion, len(c.sources))
 	for i, source := range c.sources {
-		version, err := source.Version(channel)
+		version, err := source.Version(channels)
 		if err != nil {
-			return nil, fmt.Errorf("unknown channel %s for source %s: %v", channel, source.Name(), err)
+			return nil, fmt.Errorf("unable to determine version for source %s: %v", source.Name(), err)
 		}
 		versions[i] = version
 	}

--- a/channel/combined_test.go
+++ b/channel/combined_test.go
@@ -52,7 +52,7 @@ func TestCombinedSource(t *testing.T) {
 	combined, err := NewCombinedSource([]ConfigSource{mainSrc, secondarySrc})
 	require.NoError(t, err)
 
-	anyVersion, err := combined.Version("foobar")
+	anyVersion, err := combined.Version([]string{"foobar"})
 	require.NoError(t, err)
 
 	config, err := anyVersion.Get(context.Background(), logger)

--- a/channel/config_source.go
+++ b/channel/config_source.go
@@ -23,8 +23,8 @@ type ConfigSource interface {
 	// Update synchronizes the local copy of the configuration with the remote one.
 	Update(ctx context.Context, logger *log.Entry) error
 
-	// Version returns the ConfigVersion for a corresponding channel
-	Version(channel string) (ConfigVersion, error)
+	// Version returns the ConfigVersion for the first channel that exists in this ConfigSource
+	Version(channels []string) (ConfigVersion, error)
 }
 
 type Manifest struct {

--- a/channel/directory.go
+++ b/channel/directory.go
@@ -28,7 +28,7 @@ func (d *Directory) Update(ctx context.Context, logger *log.Entry) error {
 	return nil
 }
 
-func (d *Directory) Version(channel string) (ConfigVersion, error) {
+func (d *Directory) Version(channels []string) (ConfigVersion, error) {
 	return d, nil
 }
 

--- a/channel/directory_test.go
+++ b/channel/directory_test.go
@@ -23,7 +23,7 @@ func TestDirectoryChannel(t *testing.T) {
 	err = d.Update(context.Background(), logger)
 	require.NoError(t, err)
 
-	anyVersion, err := d.Version("foobar")
+	anyVersion, err := d.Version([]string{"foobar"})
 	require.NoError(t, err)
 
 	config, err := anyVersion.Get(context.Background(), logger)

--- a/channel/git.go
+++ b/channel/git.go
@@ -112,16 +112,20 @@ func (g *Git) Update(ctx context.Context, logger *log.Entry) error {
 	return nil
 }
 
-func (g *Git) Version(channel string) (ConfigVersion, error) {
-	sha, err := exec.Command("git", "--git-dir", g.repoDir, "rev-parse", channel).Output()
-	if err != nil {
-		return nil, err
+func (g *Git) Version(channels []string) (ConfigVersion, error) {
+	for _, channel := range channels {
+		sha, err := exec.Command("git", "--git-dir", g.repoDir, "rev-parse", channel).Output()
+		if err != nil {
+			continue
+		}
+
+		return &gitVersion{
+			git: g,
+			sha: strings.TrimSpace(string(sha)),
+		}, nil
 	}
 
-	return &gitVersion{
-		git: g,
-		sha: strings.TrimSpace(string(sha)),
-	}, nil
+	return nil, fmt.Errorf("channels not found: %s", strings.Join(channels, ", "))
 }
 
 // localClone duplicates a repo by cloning to temp location with unix time

--- a/channel/git_test.go
+++ b/channel/git_test.go
@@ -50,8 +50,8 @@ func createGitRepo(t *testing.T, logger *log.Entry, dir string) {
 	commit("branch commit")
 }
 
-func checkout(t *testing.T, logger *log.Entry, source ConfigSource, channel string) Config {
-	version, err := source.Version(channel)
+func checkout(t *testing.T, logger *log.Entry, source ConfigSource, channels []string) Config {
+	version, err := source.Version(channels)
 	require.NoError(t, err)
 
 	checkout, err := version.Get(context.Background(), logger)
@@ -77,18 +77,22 @@ func TestGitGet(t *testing.T) {
 	require.NoError(t, err)
 
 	// check master channel
-	master := checkout(t, logger, c, "master")
+	master := checkout(t, logger, c, []string{"master"})
 	verifyExampleConfig(t, master, "testsrc", "channel1")
 
 	// check another channel
-	channel2 := checkout(t, logger, c, "channel2")
+	channel2 := checkout(t, logger, c, []string{"channel2"})
 	verifyExampleConfig(t, channel2, "testsrc", "channel2")
+
+	// check that missing channels are ignored
+	channel3 := checkout(t, logger, c, []string{"channel3", "master"})
+	verifyExampleConfig(t, channel3, "testsrc", "channel1")
 
 	// check sha
 	out, err := exec.Command("git", "-C", repoTempdir, "rev-parse", "master").Output()
 	require.NoError(t, err)
 
-	sha := checkout(t, logger, c, strings.TrimSpace(string(out)))
+	sha := checkout(t, logger, c, []string{strings.TrimSpace(string(out))})
 	verifyExampleConfig(t, sha, "testsrc", "channel1")
 }
 

--- a/cmd/clm/main.go
+++ b/cmd/clm/main.go
@@ -163,7 +163,7 @@ func main() {
 			log.Fatalf("%+v", err)
 		}
 
-		version, err := configSource.Version(cluster.Channel)
+		version, err := configSource.Version(cluster.Channels())
 		if err != nil {
 			log.Fatalf("%+v", err)
 		}

--- a/controller/cluster_list.go
+++ b/controller/cluster_list.go
@@ -115,7 +115,7 @@ func (clusterList *ClusterList) updateClusters(configSource channel.ConfigSource
 		var channelVersion channel.ConfigVersion
 		var nextVersion *api.ClusterVersion
 		var nextError error
-		channelVersion, nextError = configSource.Version(cluster.Channel)
+		channelVersion, nextError = configSource.Version(cluster.Channels())
 
 		if nextError == nil {
 			nextVersion, nextError = cluster.Version(channelVersion)

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strings"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -106,9 +107,9 @@ func (r *mockChannelSource) Name() string {
 	return "mock"
 }
 
-func (r *mockChannelSource) Version(channel string) (channel.ConfigVersion, error) {
+func (r *mockChannelSource) Version(channels []string) (channel.ConfigVersion, error) {
 	if r.failVersion {
-		return nil, fmt.Errorf("failed to get version %s", channel)
+		return nil, fmt.Errorf("failed to get version %s", strings.Join(channels, ","))
 	}
 	return &mockVersion{failGet: r.failGet}, nil
 }


### PR DESCRIPTION
 * `ConfigSource`: support multiple channels in `Version()`. The first one that exists in the source would be returned.
 * Prepend the value of `override_channel` config item to the channel list so we could use it for temporary experiments.