### PR TITLE
Return a KB string for the kubernetesSizeToByte template function

### DIFF
--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -272,7 +272,7 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		"parseInt64":                    parseInt64,
 		"generateJWKSDocument":          generateJWKSDocument,
 		"generateOIDCDiscoveryDocument": generateOIDCDiscoveryDocument,
-		"kubernetesSizeToBytes":         kubernetesSizeToBytes,
+		"kubernetesSizeToKiloBytes":     kubernetesSizeToKiloBytes,
 	}
 
 	content, ok := context.fileData[file]
@@ -610,14 +610,15 @@ func nodeCIDRMaxPods(maskSize int64, extraCapacity int64) (int64, error) {
 	return maxPods, nil
 }
 
-func kubernetesSizeToBytes(quantity string, scale float64) (int, error) {
+func kubernetesSizeToKiloBytes(quantity string, scale float64) (string, error) {
 	resource, err := k8sresource.ParseQuantity(quantity)
 	if err != nil {
-		return 0, err
+		return "", err
 	}
 	val, converted := resource.AsInt64()
 	if !converted {
-		return 0, fmt.Errorf("unexpected size for quantity: %s", quantity)
+		return "", fmt.Errorf("unexpected size for quantity: %s", quantity)
 	}
-	return int(math.Ceil(float64(val) * scale)), nil
+	kbs := int(math.Ceil(float64(val) / 1024 * scale))
+	return fmt.Sprintf("%dKB", kbs), nil
 }

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -691,27 +691,27 @@ func TestParseInt64Error(t *testing.T) {
 func TestKubernetesSizeToBytes(t *testing.T) {
 	for _, tc := range []struct {
 		input  string
-		output int
+		output string
 		scale  float64
 	}{
 		{
 			input:  "1Ki",
-			output: 1024,
+			output: "1KB",
 			scale:  1,
 		},
 		{
 			input:  "1Gi",
-			output: 536870912,
+			output: "524288KB",
 			scale:  0.5,
 		},
 		{
 			input:  "4Gi",
-			output: 3435973837,
+			output: "3355444KB",
 			scale:  0.8,
 		},
 	} {
 		t.Run(tc.input, func(t *testing.T) {
-			bytes, err := kubernetesSizeToBytes(tc.input, tc.scale)
+			bytes, err := kubernetesSizeToKiloBytes(tc.input, tc.scale)
 			require.NoError(t, err)
 			require.Equal(t, tc.output, bytes)
 		})


### PR DESCRIPTION
Prometheus needs the TSDB size to be specified in `KB`, `MB` or `GB`. So I have changed the return type of the `kubernetesSizeToBytes` to a string which returns _KB_s and change the name of the function accordingly.