### PR TITLE
Make override_channel more reliable

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -5,7 +5,9 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"encoding/binary"
+	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/zalando-incubator/cluster-lifecycle-manager/channel"
 )
@@ -158,11 +160,17 @@ func (cluster *Cluster) Version(channelVersion channel.ConfigVersion) (*ClusterV
 	return result, nil
 }
 
-func (cluster *Cluster) Channels() []string {
-	var result []string
-	if override, ok := cluster.ConfigItems[overrideChannelConfigItem]; ok {
-		result = append(result, override)
+func (cluster *Cluster) ChannelOverrides() (map[string]string, error) {
+	result := map[string]string{}
+	if overrides, ok := cluster.ConfigItems[overrideChannelConfigItem]; ok {
+		channelOverrides := strings.Split(overrides, ",")
+		for _, override := range channelOverrides {
+			parts := strings.SplitN(override, "=", 2)
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("invalid override definition: %s", override)
+			}
+			result[parts[0]] = parts[1]
+		}
 	}
-	result = append(result, cluster.Channel)
-	return result
+	return result, nil
 }

--- a/channel/caching_source.go
+++ b/channel/caching_source.go
@@ -29,16 +29,24 @@ func (c *CachingSource) Update(ctx context.Context, logger *logrus.Entry) error 
 	return c.target.Update(ctx, logger)
 }
 
-func (c *CachingSource) Version(channels []string) (ConfigVersion, error) {
-	cacheKey := strings.Join(channels, "\x00")
+func (c *CachingSource) Version(channel string, overrides map[string]string) (ConfigVersion, error) {
+	cacheKey := strings.Builder{}
+	cacheKey.WriteString(channel)
+	cacheKey.WriteRune('\x00')
+	for k, v := range overrides {
+		cacheKey.WriteString(k)
+		cacheKey.WriteRune('\x00')
+		cacheKey.WriteString(v)
+		cacheKey.WriteRune('\x00')
+	}
 
-	if cached, ok := c.cache[cacheKey]; ok {
+	if cached, ok := c.cache[cacheKey.String()]; ok {
 		return cached, nil
 	}
-	res, err := c.target.Version(channels)
+	res, err := c.target.Version(channel, overrides)
 	if err != nil {
 		return nil, err
 	}
-	c.cache[cacheKey] = res
+	c.cache[cacheKey.String()] = res
 	return res, nil
 }

--- a/channel/combined.go
+++ b/channel/combined.go
@@ -53,10 +53,15 @@ func (c *CombinedSource) Update(ctx context.Context, logger *logrus.Entry) error
 	return nil
 }
 
-func (c *CombinedSource) Version(channels []string) (ConfigVersion, error) {
+func (c *CombinedSource) Version(channel string, overrides map[string]string) (ConfigVersion, error) {
 	versions := make([]ConfigVersion, len(c.sources))
 	for i, source := range c.sources {
-		version, err := source.Version(channels)
+		sourceChannel := channel
+		if overrideChannel, ok := overrides[source.Name()]; ok {
+			sourceChannel = overrideChannel
+		}
+
+		version, err := source.Version(sourceChannel, nil)
 		if err != nil {
 			return nil, fmt.Errorf("unable to determine version for source %s: %v", source.Name(), err)
 		}

--- a/channel/config_source.go
+++ b/channel/config_source.go
@@ -23,8 +23,9 @@ type ConfigSource interface {
 	// Update synchronizes the local copy of the configuration with the remote one.
 	Update(ctx context.Context, logger *log.Entry) error
 
-	// Version returns the ConfigVersion for the first channel that exists in this ConfigSource
-	Version(channels []string) (ConfigVersion, error)
+	// Version returns the ConfigVersion for the corresponding channel (or overrides, if this is a
+	// combined source)
+	Version(channel string, overrides map[string]string) (ConfigVersion, error)
 }
 
 type Manifest struct {

--- a/channel/directory.go
+++ b/channel/directory.go
@@ -28,7 +28,7 @@ func (d *Directory) Update(ctx context.Context, logger *log.Entry) error {
 	return nil
 }
 
-func (d *Directory) Version(channels []string) (ConfigVersion, error) {
+func (d *Directory) Version(channel string, overrides map[string]string) (ConfigVersion, error) {
 	return d, nil
 }
 

--- a/channel/directory_test.go
+++ b/channel/directory_test.go
@@ -23,7 +23,7 @@ func TestDirectoryChannel(t *testing.T) {
 	err = d.Update(context.Background(), logger)
 	require.NoError(t, err)
 
-	anyVersion, err := d.Version([]string{"foobar"})
+	anyVersion, err := d.Version("foobar", nil)
 	require.NoError(t, err)
 
 	config, err := anyVersion.Get(context.Background(), logger)

--- a/channel/git.go
+++ b/channel/git.go
@@ -112,20 +112,16 @@ func (g *Git) Update(ctx context.Context, logger *log.Entry) error {
 	return nil
 }
 
-func (g *Git) Version(channels []string) (ConfigVersion, error) {
-	for _, channel := range channels {
-		sha, err := exec.Command("git", "--git-dir", g.repoDir, "rev-parse", channel).Output()
-		if err != nil {
-			continue
-		}
-
-		return &gitVersion{
-			git: g,
-			sha: strings.TrimSpace(string(sha)),
-		}, nil
+func (g *Git) Version(channel string, overrides map[string]string) (ConfigVersion, error) {
+	sha, err := exec.Command("git", "--git-dir", g.repoDir, "rev-parse", channel).Output()
+	if err != nil {
+		return nil, err
 	}
 
-	return nil, fmt.Errorf("channels not found: %s", strings.Join(channels, ", "))
+	return &gitVersion{
+		git: g,
+		sha: strings.TrimSpace(string(sha)),
+	}, nil
 }
 
 // localClone duplicates a repo by cloning to temp location with unix time

--- a/channel/git_test.go
+++ b/channel/git_test.go
@@ -50,8 +50,8 @@ func createGitRepo(t *testing.T, logger *log.Entry, dir string) {
 	commit("branch commit")
 }
 
-func checkout(t *testing.T, logger *log.Entry, source ConfigSource, channels []string) Config {
-	version, err := source.Version(channels)
+func checkout(t *testing.T, logger *log.Entry, source ConfigSource, channel string) Config {
+	version, err := source.Version(channel, nil)
 	require.NoError(t, err)
 
 	checkout, err := version.Get(context.Background(), logger)
@@ -61,7 +61,7 @@ func checkout(t *testing.T, logger *log.Entry, source ConfigSource, channels []s
 }
 
 func TestGitGet(t *testing.T) {
-	logger := log.StandardLogger().WithFields(map[string]interface{}{})
+	logger := log.WithFields(map[string]interface{}{})
 
 	repoTempdir := createTempDir(t)
 	defer os.RemoveAll(repoTempdir)
@@ -77,22 +77,18 @@ func TestGitGet(t *testing.T) {
 	require.NoError(t, err)
 
 	// check master channel
-	master := checkout(t, logger, c, []string{"master"})
+	master := checkout(t, logger, c, "master")
 	verifyExampleConfig(t, master, "testsrc", "channel1")
 
 	// check another channel
-	channel2 := checkout(t, logger, c, []string{"channel2"})
+	channel2 := checkout(t, logger, c, "channel2")
 	verifyExampleConfig(t, channel2, "testsrc", "channel2")
-
-	// check that missing channels are ignored
-	channel3 := checkout(t, logger, c, []string{"channel3", "master"})
-	verifyExampleConfig(t, channel3, "testsrc", "channel1")
 
 	// check sha
 	out, err := exec.Command("git", "-C", repoTempdir, "rev-parse", "master").Output()
 	require.NoError(t, err)
 
-	sha := checkout(t, logger, c, []string{strings.TrimSpace(string(out))})
+	sha := checkout(t, logger, c, strings.TrimSpace(string(out)))
 	verifyExampleConfig(t, sha, "testsrc", "channel1")
 }
 

--- a/channel/mock_source.go
+++ b/channel/mock_source.go
@@ -1,0 +1,42 @@
+package channel
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
+type mockSource struct {
+	name          string
+	validChannels []string
+}
+
+type mockVersion struct {
+	channel string
+}
+
+func (s *mockSource) Name() string {
+	return s.name
+}
+
+func (s *mockSource) Update(ctx context.Context, logger *logrus.Entry) error {
+	return nil
+}
+
+func (s *mockSource) Version(channel string, overrides map[string]string) (ConfigVersion, error) {
+	for _, validChannel := range s.validChannels {
+		if validChannel == channel {
+			return &mockVersion{channel: channel}, nil
+		}
+	}
+	return nil, fmt.Errorf("unknown version: %s", channel)
+}
+
+func (v *mockVersion) ID() string {
+	return v.channel
+}
+
+func (v *mockVersion) Get(ctx context.Context, logger *logrus.Entry) (Config, error) {
+	return nil, fmt.Errorf("not implemented")
+}

--- a/cmd/clm/main.go
+++ b/cmd/clm/main.go
@@ -163,7 +163,12 @@ func main() {
 			log.Fatalf("%+v", err)
 		}
 
-		version, err := configSource.Version(cluster.Channels())
+		channelOverrides, err := cluster.ChannelOverrides()
+		if err != nil {
+			log.Fatalf("%+v", err)
+		}
+
+		version, err := configSource.Version(cluster.Channel, channelOverrides)
 		if err != nil {
 			log.Fatalf("%+v", err)
 		}

--- a/controller/cluster_list.go
+++ b/controller/cluster_list.go
@@ -114,9 +114,13 @@ func (clusterList *ClusterList) updateClusters(configSource channel.ConfigSource
 
 		var channelVersion channel.ConfigVersion
 		var nextVersion *api.ClusterVersion
+		var channelOverrides map[string]string
 		var nextError error
-		channelVersion, nextError = configSource.Version(cluster.Channels())
 
+		channelOverrides, nextError = cluster.ChannelOverrides()
+		if nextError == nil {
+			channelVersion, nextError = configSource.Version(cluster.Channel, channelOverrides)
+		}
 		if nextError == nil {
 			nextVersion, nextError = cluster.Version(channelVersion)
 		}

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"strings"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -107,9 +106,9 @@ func (r *mockChannelSource) Name() string {
 	return "mock"
 }
 
-func (r *mockChannelSource) Version(channels []string) (channel.ConfigVersion, error) {
+func (r *mockChannelSource) Version(channel string, overrides map[string]string) (channel.ConfigVersion, error) {
 	if r.failVersion {
-		return nil, fmt.Errorf("failed to get version %s", strings.Join(channels, ","))
+		return nil, fmt.Errorf("failed to get version %s (%s)", channel, overrides)
 	}
 	return &mockVersion{failGet: r.failGet}, nil
 }

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -1,7 +1,7 @@
 version: "2017-09-20"
 pipeline:
 - id: build
-  overlay: ci/golang
+  overlay: ci/golang-1-13
   type: script
   env:
     GOFLAGS: "-mod=readonly"


### PR DESCRIPTION
Instead of silently falling back from `override_channel` to `channel` if the corresponding branch is missing, make it a hard failure. Additionally, change the format of `override_channel` so that the source that's being overridden is explicitly specified.