### PR TITLE
Correctly handle multi-manifest YAMLs

### DIFF
--- a/provisioner/clusterpy_test.go
+++ b/provisioner/clusterpy_test.go
@@ -297,6 +297,20 @@ ref2: 123
 value: 123
 `,
 		},
+		{
+			name: "manifests with multiple documents are parsed correctly",
+			source: `
+first: 1
+---
+second: 2
+---
+`,
+			expected: `
+first: 1
+---
+second: 2
+`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			remarshaled, err := remarshalYAML(tc.source)


### PR DESCRIPTION
`RemarshalYAML`: handle all documents in the YAML, not just the first one. 🤦‍♂ 