### PR TITLE
Tag etcd stack with application/component

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -28,10 +28,6 @@ github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/aws/aws-sdk-go v1.26.2 h1:MzYLmCeny4bMQcAbYcucIduVZKp0sEf1eRLvHpKI5Is=
 github.com/aws/aws-sdk-go v1.26.2/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/aws/aws-sdk-go v1.29.19 h1:+jifYixffn6kzWygtGWFWQMv0tDGyISZHNwugF9V2sE=
-github.com/aws/aws-sdk-go v1.29.19/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
-github.com/aws/aws-sdk-go v1.29.24 h1:KOnds/LwADMDBaALL4UB98ZR+TUR1A1mYmAYbdLixLA=
-github.com/aws/aws-sdk-go v1.29.24/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
 github.com/aws/aws-sdk-go v1.29.29 h1:4TdSYzXL8bHKu80tzPjO4c0ALw4Fd8qZGqf1aozUcBU=
 github.com/aws/aws-sdk-go v1.29.29/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=

--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -49,6 +49,8 @@ const (
 	etcdKMSKeyAlias             = "alias/etcd-cluster"
 	etcdScalyrAccountKey        = "etcd_scalyr_key"
 	etcdS3BackupBucketKey       = "etcd_s3_backup_bucket"
+	applicationTagKey           = "application"
+	componentTagKey             = "component"
 )
 
 var (
@@ -496,7 +498,18 @@ func (a *awsAdapter) CreateOrUpdateEtcdStack(parentCtx context.Context, stackNam
 		return err
 	}
 
-	err = a.applyStack(stackName, string(output), "", nil, false)
+	tags := []*cloudformation.Tag{
+		{
+			Key:   aws.String(applicationTagKey),
+			Value: aws.String("kubernetes-etcd"),
+		},
+		{
+			Key:   aws.String(componentTagKey),
+			Value: aws.String("etcd-cluster"),
+		},
+	}
+
+	err = a.applyStack(stackName, string(output), "", tags, false)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Tag the whole cloudformation stack so tags will propagate to ALL resources.
This makes the etcd part of https://github.com/zalando-incubator/kubernetes-on-aws/pull/3107 obsolete.