### PR TITLE
Combined source: don't shadow components anymore

### DIFF
--- a/channel/combined.go
+++ b/channel/combined.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -150,7 +149,7 @@ func (c *combinedConfig) DeletionsManifests() ([]Manifest, error) {
 }
 
 func (c *combinedConfig) Components() ([]Component, error) {
-	allComponents := make(map[string]Component)
+	var result []Component
 
 	for i, config := range c.configs {
 		components, err := config.Components()
@@ -158,20 +157,13 @@ func (c *combinedConfig) Components() ([]Component, error) {
 			return nil, fmt.Errorf("unable to get components for source %s: %v", c.owner.sourceName(i), err)
 		}
 		for _, component := range components {
-			allComponents[component.Name] = component
+			result = append(result, Component{
+				Name:      fmt.Sprintf("%s/%s", c.owner.sourceName(i), component.Name),
+				Manifests: component.Manifests,
+			})
 		}
 	}
 
-	var keys []string
-	for key := range allComponents {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
-	var result []Component
-	for _, key := range keys {
-		result = append(result, allComponents[key])
-	}
 	return result, nil
 }
 

--- a/channel/combined_test.go
+++ b/channel/combined_test.go
@@ -107,24 +107,32 @@ func TestCombinedSource(t *testing.T) {
 	manifests, err := config.Components()
 	require.NoError(t, err)
 	expected := []Component{
-		// Overridden by secondary
+		// From main
 		{
-			Name: "example1",
+			Name: "main/example1",
 			Manifests: []Manifest{
-				expectedManifest("secondary", "cluster/manifests/example1/deployment.yaml", "example1-deployment-secondary"),
+				expectedManifest("main", "cluster/manifests/example1/config.yaml", "example1-config-main"),
+				expectedManifest("main", "cluster/manifests/example1/deployment.yaml", "example1-deployment-main"),
 			},
 		},
 		// From main
 		{
-			Name: "example2",
+			Name: "main/example2",
 			Manifests: []Manifest{
 				expectedManifest("main", "cluster/manifests/example2/config.yaml", "example2-config-main"),
 				expectedManifest("main", "cluster/manifests/example2/deployment.yaml", "example2-deployment-main"),
 			},
 		},
+		// From secondary, same name as in main
+		{
+			Name: "secondary/example1",
+			Manifests: []Manifest{
+				expectedManifest("secondary", "cluster/manifests/example1/deployment.yaml", "example1-deployment-secondary"),
+			},
+		},
 		// From secondary
 		{
-			Name: "example3",
+			Name: "secondary/example3",
 			Manifests: []Manifest{
 				expectedManifest("secondary", "cluster/manifests/example3/deployment.yaml", "example3-deployment-secondary"),
 			},

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,6 @@ github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/aws/aws-sdk-go v1.26.2 h1:MzYLmCeny4bMQcAbYcucIduVZKp0sEf1eRLvHpKI5Is=
 github.com/aws/aws-sdk-go v1.26.2/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
-github.com/aws/aws-sdk-go v1.29.29 h1:4TdSYzXL8bHKu80tzPjO4c0ALw4Fd8qZGqf1aozUcBU=
-github.com/aws/aws-sdk-go v1.29.29/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
 github.com/aws/aws-sdk-go v1.30.1 h1:cUMxtoFvIHhScZgv17tGxw15r6rVKJHR1hsIFRx9hcA=
 github.com/aws/aws-sdk-go v1.30.1/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=


### PR DESCRIPTION
Shadowing was only useful for the initial migration, and now it just creates problems. Let's get rid of it.