### PR TITLE
etcd: add support for TLS, custom image

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -26,11 +26,7 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
-github.com/aws/aws-sdk-go v1.26.2 h1:MzYLmCeny4bMQcAbYcucIduVZKp0sEf1eRLvHpKI5Is=
-github.com/aws/aws-sdk-go v1.26.2/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.29.34/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
-github.com/aws/aws-sdk-go v1.30.1 h1:cUMxtoFvIHhScZgv17tGxw15r6rVKJHR1hsIFRx9hcA=
-github.com/aws/aws-sdk-go v1.30.1/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.30.7 h1:IaXfqtioP6p9SFAnNfsqdNczbR5UNbYqvcZUSsCAdTY=
 github.com/aws/aws-sdk-go v1.30.7/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
@@ -424,8 +420,6 @@ github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc/go.mod h1:Jhud4/sHM
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/zalando-incubator/kube-ingress-aws-controller v0.10.5 h1:6qs/plnc/UBl4zXbmGs6INUcigKWtbvXYMOPBRmX+Rs=
-github.com/zalando-incubator/kube-ingress-aws-controller v0.10.5/go.mod h1:xfdZLJxH2yDDWvA8M8vb8RlxFMdJ7VIORcSHPruWTNk=
 github.com/zalando-incubator/kube-ingress-aws-controller v0.10.8 h1:LhRu6IG28anUvlaKqBs+OJSSQLbvKB4uk658NK3BRQY=
 github.com/zalando-incubator/kube-ingress-aws-controller v0.10.8/go.mod h1:LeU/FIk2F4W171i1vb9lXoLFDwy3iwySR4iWo086QBc=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -53,6 +53,7 @@ const (
 	etcdClientCAConfigItem          = "etcd_client_ca_cert"
 	etcdClientKeyConfigItem         = "etcd_client_server_key"
 	etcdClientCertificateConfigItem = "etcd_client_server_cert"
+	etcdClientTLSEnabledConfigItem  = "etcd_client_tls_enabled"
 	etcdImageConfigItem             = "etcd_image"
 
 	applicationTagKey = "application"
@@ -488,6 +489,7 @@ func (a *awsAdapter) CreateOrUpdateEtcdStack(parentCtx context.Context, stackNam
 		{configItem: etcdClientCAConfigItem, senzaArgument: "ClientCACertificate", encrypt: true},
 		{configItem: etcdClientKeyConfigItem, senzaArgument: "ClientKey", encrypt: true},
 		{configItem: etcdClientCertificateConfigItem, senzaArgument: "ClientCertificate", encrypt: true},
+		{configItem: etcdClientTLSEnabledConfigItem, senzaArgument: "ClientTLSEnabled"},
 		{configItem: etcdImageConfigItem, senzaArgument: "EtcdImage"},
 	} {
 		if value, ok := cluster.ConfigItems[ci.configItem]; ok {


### PR DESCRIPTION
Add support for (optional) config items for the Docker image used for the etcd instances and for client-side TLS.