### PR TITLE
CLC: correctly delete node pools with non-0 min sizes

### DIFF
--- a/pkg/updatestrategy/node_pool_manager.go
+++ b/pkg/updatestrategy/node_pool_manager.go
@@ -328,7 +328,7 @@ func (m *KubernetesNodePoolManager) TerminateNode(ctx context.Context, node *Nod
 }
 
 func (m *KubernetesNodePoolManager) MarkPoolForDecommission(nodePool *api.NodePool) error {
-	return m.backend.SuspendAutoscaling(nodePool)
+	return m.backend.MarkForDecommission(nodePool)
 }
 
 // ScalePool scales a nodePool to the specified number of replicas.
@@ -341,7 +341,7 @@ func (m *KubernetesNodePoolManager) ScalePool(ctx context.Context, nodePool *api
 	// in case we are scaling down to 0 replicas, disable the autoscaler to
 	// not fight with it.
 	if replicas == 0 {
-		err := m.backend.SuspendAutoscaling(nodePool)
+		err := m.backend.MarkForDecommission(nodePool)
 		if err != nil {
 			return err
 		}

--- a/pkg/updatestrategy/node_pool_manager_test.go
+++ b/pkg/updatestrategy/node_pool_manager_test.go
@@ -66,7 +66,7 @@ func (n *mockProviderNodePoolsBackend) UpdateSize(nodePool *api.NodePool) error 
 	return n.err
 }
 
-func (n *mockProviderNodePoolsBackend) SuspendAutoscaling(nodePool *api.NodePool) error {
+func (n *mockProviderNodePoolsBackend) MarkForDecommission(nodePool *api.NodePool) error {
 	return n.err
 }
 

--- a/pkg/updatestrategy/updatestrategy.go
+++ b/pkg/updatestrategy/updatestrategy.go
@@ -18,7 +18,7 @@ type UpdateStrategy interface {
 type ProviderNodePoolsBackend interface {
 	Get(nodePool *api.NodePool) (*NodePool, error)
 	Scale(nodePool *api.NodePool, replicas int) error
-	SuspendAutoscaling(nodePool *api.NodePool) error
+	MarkForDecommission(nodePool *api.NodePool) error
 	Terminate(node *Node, decrementDesired bool) error
 }
 


### PR DESCRIPTION
When we delete a pool, forcibly reset all ASGs to have min. size 0. Otherwise CLC will keep terminating nodes that AWS will replace with identical ones, so the node pool will never get deleted.