### PR TITLE
etcd: decode TLS-related config items before encrypting

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,6 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/aws/aws-sdk-go v1.29.34/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
-github.com/aws/aws-sdk-go v1.30.9 h1:DntpBUKkchINPDbhEzDRin1eEn1TG9TZFlzWPf0i8to=
-github.com/aws/aws-sdk-go v1.30.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.30.14 h1:vZfX2b/fknc9wKcytbLWykM7in5k6dbQ8iHTJDUP1Ng=
 github.com/aws/aws-sdk-go v1.30.14/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
@@ -426,8 +424,6 @@ github.com/xdg/stringprep v0.0.0-20180714160509-73f8eece6fdc/go.mod h1:Jhud4/sHM
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/zalando-incubator/kube-ingress-aws-controller v0.10.11 h1:T7LQbiMba/3LrGjM6olX4yLiyYbzRhy6KXN9Tx4Fr2I=
-github.com/zalando-incubator/kube-ingress-aws-controller v0.10.11/go.mod h1:doEkfHJgTekvQTuJyTjL4P1d0ETQCAOoao67SGEmARk=
 github.com/zalando-incubator/kube-ingress-aws-controller v0.10.13 h1:V7sFN32fnU4PotwTiOIxeQOnF/wTHGzdxTcFgZhRKvE=
 github.com/zalando-incubator/kube-ingress-aws-controller v0.10.13/go.mod h1:doEkfHJgTekvQTuJyTjL4P1d0ETQCAOoao67SGEmARk=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -494,7 +494,11 @@ func (a *awsAdapter) CreateOrUpdateEtcdStack(parentCtx context.Context, stackNam
 	} {
 		if value, ok := cluster.ConfigItems[ci.configItem]; ok {
 			if ci.encrypt {
-				encrypted, err := a.kmsEncryptForTaupage(kmsKeyARN, value)
+				decoded, err := base64.StdEncoding.DecodeString(value)
+				if err != nil {
+					return err
+				}
+				encrypted, err := a.kmsEncryptForTaupage(kmsKeyARN, string(decoded))
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
We store them base64-encoded, so they need to be decoded first.