### PR TITLE
Add configItem to mark nodes with NoSchedule taint on decommissioning

### DIFF
--- a/pkg/updatestrategy/node_pool_manager_test.go
+++ b/pkg/updatestrategy/node_pool_manager_test.go
@@ -97,6 +97,7 @@ func TestGetPool(t *testing.T) {
 		setupMockKubernetes(t, []*v1.Node{node}, nil, nil),
 		backend,
 		&DrainConfig{},
+		false,
 	)
 
 	// test getting nodes successfully

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -35,30 +35,31 @@ import (
 )
 
 const (
-	providerID                     = "zalando-aws"
-	etcdStackFileName              = "etcd-cluster.yaml"
-	clusterStackFileName           = "cluster.yaml"
-	defaultNamespace               = "default"
-	kubectlNotFound                = "(NotFound)"
-	tagNameKubernetesClusterPrefix = "kubernetes.io/cluster/"
-	subnetELBRoleTagName           = "kubernetes.io/role/elb"
-	resourceLifecycleShared        = "shared"
-	resourceLifecycleOwned         = "owned"
-	mainStackTagKey                = "cluster-lifecycle-controller.zalando.org/main-stack"
-	stackTagValueTrue              = "true"
-	subnetsConfigItemKey           = "subnets"
-	subnetsValueKey                = "subnets"
-	availabilityZonesConfigItemKey = "availability_zones"
-	availabilityZonesValueKey      = "availability_zones"
-	vpcIDConfigItemKey             = "vpc_id"
-	subnetAllAZName                = "*"
-	maxApplyRetries                = 10
-	configKeyUpdateStrategy        = "update_strategy"
-	updateStrategyRolling          = "rolling"
-	updateStrategyCLC              = "clc"
-	defaultMaxRetryTime            = 5 * time.Minute
-	clcPollingInterval             = 10 * time.Second
-	clusterStackOutputKey          = "ClusterStackOutputs"
+	providerID                         = "zalando-aws"
+	etcdStackFileName                  = "etcd-cluster.yaml"
+	clusterStackFileName               = "cluster.yaml"
+	defaultNamespace                   = "default"
+	kubectlNotFound                    = "(NotFound)"
+	tagNameKubernetesClusterPrefix     = "kubernetes.io/cluster/"
+	subnetELBRoleTagName               = "kubernetes.io/role/elb"
+	resourceLifecycleShared            = "shared"
+	resourceLifecycleOwned             = "owned"
+	mainStackTagKey                    = "cluster-lifecycle-controller.zalando.org/main-stack"
+	stackTagValueTrue                  = "true"
+	subnetsConfigItemKey               = "subnets"
+	subnetsValueKey                    = "subnets"
+	availabilityZonesConfigItemKey     = "availability_zones"
+	availabilityZonesValueKey          = "availability_zones"
+	vpcIDConfigItemKey                 = "vpc_id"
+	subnetAllAZName                    = "*"
+	maxApplyRetries                    = 10
+	configKeyUpdateStrategy            = "update_strategy"
+	updateStrategyRolling              = "rolling"
+	updateStrategyCLC                  = "clc"
+	defaultMaxRetryTime                = 5 * time.Minute
+	clcPollingInterval                 = 10 * time.Second
+	clusterStackOutputKey              = "ClusterStackOutputs"
+	decommissionNodeNoScheduleTaintKey = "clm_decommission_node_no_schedule_taint"
 )
 
 type clusterpyProvisioner struct {
@@ -748,8 +749,13 @@ func (p *clusterpyProvisioner) prepareProvision(logger *log.Entry, cluster *api.
 		}
 	}
 
+	noScheduleTaint := false
+	if v, ok := cluster.ConfigItems[decommissionNodeNoScheduleTaintKey]; ok && v == "true" {
+		noScheduleTaint = true
+	}
+
 	poolBackend := updatestrategy.NewASGNodePoolsBackend(cluster.ID, adapter.session)
-	poolManager := updatestrategy.NewKubernetesNodePoolManager(logger, client, poolBackend, drainConfig)
+	poolManager := updatestrategy.NewKubernetesNodePoolManager(logger, client, poolBackend, drainConfig, noScheduleTaint)
 
 	var updater updatestrategy.UpdateStrategy
 	switch updateStrategy {

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -59,7 +59,7 @@ const (
 	defaultMaxRetryTime                = 5 * time.Minute
 	clcPollingInterval                 = 10 * time.Second
 	clusterStackOutputKey              = "ClusterStackOutputs"
-	decommissionNodeNoScheduleTaintKey = "clm_decommission_node_no_schedule_taint"
+	decommissionNodeNoScheduleTaintKey = "decommission_node_no_schedule_taint"
 )
 
 type clusterpyProvisioner struct {
@@ -750,7 +750,7 @@ func (p *clusterpyProvisioner) prepareProvision(logger *log.Entry, cluster *api.
 	}
 
 	noScheduleTaint := false
-	if v, ok := cluster.ConfigItems[decommissionNodeNoScheduleTaintKey]; ok && v == "true" {
+	if v, _ := cluster.ConfigItems[decommissionNodeNoScheduleTaintKey]; v == "true" {
 		noScheduleTaint = true
 	}
 


### PR DESCRIPTION
Adds a config item `clm_decommission_node_no_schedule_taint` which when set to `true` will make CLM mark nodes intended for decommissioning with a `NoSchedule` taint. If the configItem is not set the taint will still be added but with `PreferNoSchedule` as it is now.

The motivation for this change is to ensure that pods being drained during a cluster update will not land back on old nodes and have to be drained again.
The intention is to enable this behavior by default as we expect our current cluster autoscaling setup  is fast enough to provide new nodes when needed (i.e. our Pod schedule SLO).

It's implemented as a config item so we can quickly disable it in case it doesn't have the desired effect.