### PR TITLE
Use client-go instead of forking out to kubectl to handle deletions

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -4,14 +4,13 @@ import (
 	"net/http"
 
 	"golang.org/x/oauth2"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
 
-// NewKubeClientWithTokenSource initializes a Kubernetes client with the
-// specified token source.
-func NewKubeClientWithTokenSource(host string, tokenSrc oauth2.TokenSource) (kubernetes.Interface, error) {
-	cfg := &rest.Config{
+func newConfig(host string, tokenSrc oauth2.TokenSource) *rest.Config {
+	return &rest.Config{
 		Host: host,
 		WrapTransport: func(rt http.RoundTripper) http.RoundTripper {
 			return &oauth2.Transport{
@@ -19,7 +18,18 @@ func NewKubeClientWithTokenSource(host string, tokenSrc oauth2.TokenSource) (kub
 				Base:   rt,
 			}
 		},
+		Burst: 100,
 	}
+}
 
-	return kubernetes.NewForConfig(cfg)
+// NewClient initializes a Kubernetes client with the
+// specified token source.
+func NewClient(host string, tokenSrc oauth2.TokenSource) (kubernetes.Interface, error) {
+	return kubernetes.NewForConfig(newConfig(host, tokenSrc))
+}
+
+// NewDynamicClient initializes a dynamic Kubernetes client with the
+// specified token source.
+func NewDynamicClient(host string, tokenSrc oauth2.TokenSource) (dynamic.Interface, error) {
+	return dynamic.NewForConfig(newConfig(host, tokenSrc))
 }


### PR DESCRIPTION
This should make our updates slightly faster (and use less resources) since we won't need to constantly spawn kubectls just to delete things from the cluster. The code to resolve Kind into a GVR was adapted from [cli-runtime](https://github.com/kubernetes/cli-runtime/blob/be96dd2fb350ca2e227f26978d7cafdc56399636/pkg/resource/builder.go#L695), it seems to work fine for most of our use cases but we can change it later if we want fancier things.