### PR TITLE
Wire-in context.TODOs with parent context

### DIFF
--- a/cmd/clm/main.go
+++ b/cmd/clm/main.go
@@ -197,7 +197,7 @@ func main() {
 			log.Infof("Provisioning done for cluster %s", cluster.ID)
 		case decommissionCmd.FullCommand():
 			log.Infof("Decommissioning cluster %s", cluster.ID)
-			err = p.Decommission(rootLogger, cluster)
+			err = p.Decommission(context.Background(), rootLogger, cluster)
 			if err != nil {
 				log.Fatalf("Fail to decommission: %v", err)
 			}

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -139,7 +139,7 @@ func (c *Controller) dropUnsupported(clusters []*api.Cluster) []*api.Cluster {
 
 // doProcessCluster checks if an action needs to be taken depending on the
 // cluster state and triggers the provisioner accordingly.
-func (c *Controller) doProcessCluster(updateCtx context.Context, logger *log.Entry, clusterInfo *ClusterInfo) (rerr error) {
+func (c *Controller) doProcessCluster(ctx context.Context, logger *log.Entry, clusterInfo *ClusterInfo) (rerr error) {
 	cluster := clusterInfo.Cluster
 	if cluster.Status == nil {
 		cluster.Status = &api.ClusterStatus{}
@@ -150,7 +150,7 @@ func (c *Controller) doProcessCluster(updateCtx context.Context, logger *log.Ent
 		return clusterInfo.NextError
 	}
 
-	config, err := clusterInfo.ChannelVersion.Get(updateCtx, logger)
+	config, err := clusterInfo.ChannelVersion.Get(ctx, logger)
 	if err != nil {
 		return err
 	}
@@ -171,7 +171,7 @@ func (c *Controller) doProcessCluster(updateCtx context.Context, logger *log.Ent
 			}
 		}
 
-		err = c.provisioner.Provision(updateCtx, logger, cluster, config)
+		err = c.provisioner.Provision(ctx, logger, cluster, config)
 		if err != nil {
 			return err
 		}
@@ -182,7 +182,7 @@ func (c *Controller) doProcessCluster(updateCtx context.Context, logger *log.Ent
 		cluster.Status.NextVersion = ""
 		cluster.Status.Problems = []*api.Problem{}
 	case statusDecommissionRequested:
-		err = c.provisioner.Decommission(logger, cluster)
+		err = c.provisioner.Decommission(ctx, logger, cluster)
 		if err != nil {
 			return err
 		}

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -34,7 +34,7 @@ func (p *mockProvisioner) Provision(ctx context.Context, logger *log.Entry, clus
 	return nil
 }
 
-func (p *mockProvisioner) Decommission(logger *log.Entry, cluster *api.Cluster) error {
+func (p *mockProvisioner) Decommission(ctx context.Context, logger *log.Entry, cluster *api.Cluster) error {
 	return nil
 }
 
@@ -48,7 +48,7 @@ func (p *mockErrProvisioner) Provision(ctx context.Context, logger *log.Entry, c
 	return fmt.Errorf("failed to provision")
 }
 
-func (p *mockErrProvisioner) Decommission(logger *log.Entry, cluster *api.Cluster) error {
+func (p *mockErrProvisioner) Decommission(ctx context.Context, logger *log.Entry, cluster *api.Cluster) error {
 	return fmt.Errorf("failed to decommission")
 }
 

--- a/pkg/updatestrategy/clc_update_test.go
+++ b/pkg/updatestrategy/clc_update_test.go
@@ -37,7 +37,7 @@ func (m *mockNodePoolManagerCLC) MarkPoolForDecommission(nodePool *api.NodePool)
 	return nil
 }
 
-func (m *mockNodePoolManagerCLC) DisableReplacementNodeProvisioning(node *Node) error {
+func (m *mockNodePoolManagerCLC) DisableReplacementNodeProvisioning(ctx context.Context, node *Node) error {
 	return nil
 }
 
@@ -63,7 +63,7 @@ func (m *mockNodePoolManagerCLC) advance() {
 	}
 }
 
-func (m *mockNodePoolManagerCLC) GetPool(nodePool *api.NodePool) (*NodePool, error) {
+func (m *mockNodePoolManagerCLC) GetPool(ctx context.Context, nodePool *api.NodePool) (*NodePool, error) {
 	m.advance()
 
 	result := &NodePool{
@@ -108,7 +108,7 @@ func (m *mockNodePoolManagerCLC) findNode(nodeName string) (*mockNodeCLC, error)
 	return nil, fmt.Errorf("unknown node: %s", nodeName)
 }
 
-func (m *mockNodePoolManagerCLC) MarkNodeForDecommission(node *Node) error {
+func (m *mockNodePoolManagerCLC) MarkNodeForDecommission(ctx context.Context, node *Node) error {
 	n, err := m.findNode(node.Name)
 	if err != nil {
 		return err
@@ -124,7 +124,7 @@ func (m *mockNodePoolManagerCLC) MarkNodeForDecommission(node *Node) error {
 	return nil
 }
 
-func (m *mockNodePoolManagerCLC) AbortNodeDecommissioning(node *Node) error {
+func (m *mockNodePoolManagerCLC) AbortNodeDecommissioning(ctx context.Context, node *Node) error {
 	n, err := m.findNode(node.Name)
 	if err != nil {
 		return err
@@ -144,7 +144,7 @@ func (m *mockNodePoolManagerCLC) TerminateNode(ctx context.Context, node *Node, 
 	panic("should not be called")
 }
 
-func (m *mockNodePoolManagerCLC) CordonNode(node *Node) error {
+func (m *mockNodePoolManagerCLC) CordonNode(ctx context.Context, node *Node) error {
 	panic("should not be called")
 }
 

--- a/pkg/updatestrategy/node_pool_manager_test.go
+++ b/pkg/updatestrategy/node_pool_manager_test.go
@@ -15,21 +15,21 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func setupMockKubernetes(t *testing.T, nodes []*v1.Node, pods []*v1.Pod, pdbs []*policy.PodDisruptionBudget) kubernetes.Interface {
+func setupMockKubernetes(ctx context.Context, t *testing.T, nodes []*v1.Node, pods []*v1.Pod, pdbs []*policy.PodDisruptionBudget) kubernetes.Interface {
 	client := fake.NewSimpleClientset()
 
 	for _, node := range nodes {
-		_, err := client.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
+		_, err := client.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
 		require.NoError(t, err)
 	}
 
 	for _, pod := range pods {
-		_, err := client.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		_, err := client.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
 		require.NoError(t, err)
 	}
 
 	for _, pdb := range pdbs {
-		_, err := client.PolicyV1beta1().PodDisruptionBudgets(pdb.GetNamespace()).Create(context.TODO(), pdb, metav1.CreateOptions{})
+		_, err := client.PolicyV1beta1().PodDisruptionBudgets(pdb.GetNamespace()).Create(ctx, pdb, metav1.CreateOptions{})
 		require.NoError(t, err)
 	}
 
@@ -94,14 +94,14 @@ func TestGetPool(t *testing.T) {
 	}
 	mgr := NewKubernetesNodePoolManager(
 		logger,
-		setupMockKubernetes(t, []*v1.Node{node}, nil, nil),
+		setupMockKubernetes(context.Background(), t, []*v1.Node{node}, nil, nil),
 		backend,
 		&DrainConfig{},
 		false,
 	)
 
 	// test getting nodes successfully
-	nodePool, err := mgr.GetPool(&api.NodePool{Name: "test"})
+	nodePool, err := mgr.GetPool(context.Background(), &api.NodePool{Name: "test"})
 	assert.NoError(t, err)
 	assert.Len(t, nodePool.Nodes, 1)
 
@@ -109,8 +109,8 @@ func TestGetPool(t *testing.T) {
 	node.ObjectMeta.Labels = map[string]string{
 		lifecycleStatusLabel: lifecycleStatusDraining,
 	}
-	mgr.kube = setupMockKubernetes(t, []*v1.Node{node}, nil, nil)
-	nodePool, err = mgr.GetPool(&api.NodePool{Name: "test"})
+	mgr.kube = setupMockKubernetes(context.Background(), t, []*v1.Node{node}, nil, nil)
+	nodePool, err = mgr.GetPool(context.Background(), &api.NodePool{Name: "test"})
 	assert.NoError(t, err)
 	assert.Len(t, nodePool.Nodes, 1)
 	assert.Equal(t, nodePool.Nodes[0].Labels[lifecycleStatusLabel], lifecycleStatusDraining)
@@ -124,20 +124,20 @@ func TestLabelNodes(t *testing.T) {
 	}
 
 	mgr := &KubernetesNodePoolManager{
-		kube: setupMockKubernetes(t, []*v1.Node{node}, nil, nil),
+		kube: setupMockKubernetes(context.Background(), t, []*v1.Node{node}, nil, nil),
 	}
 
-	err := mgr.labelNode(&Node{Name: node.Name}, "foo", "bar")
+	err := mgr.labelNode(context.Background(), &Node{Name: node.Name}, "foo", "bar")
 	assert.NoError(t, err)
 
-	updated, err := mgr.kube.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	updated, err := mgr.kube.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 	assert.EqualValues(t, updated.Labels, map[string]string{"foo": "bar"})
 
-	err = mgr.labelNode(&Node{Name: node.Name}, "foo", "baz")
+	err = mgr.labelNode(context.Background(), &Node{Name: node.Name}, "foo", "baz")
 	assert.NoError(t, err)
 
-	updated2, err := mgr.kube.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	updated2, err := mgr.kube.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 	assert.EqualValues(t, updated2.Labels, map[string]string{"foo": "baz"})
 }
@@ -150,27 +150,27 @@ func TestCompareAndSetNodeLabel(t *testing.T) {
 	}
 
 	mgr := &KubernetesNodePoolManager{
-		kube: setupMockKubernetes(t, []*v1.Node{node}, nil, nil),
+		kube: setupMockKubernetes(context.Background(), t, []*v1.Node{node}, nil, nil),
 	}
 
-	err := mgr.compareAndSetNodeLabel(&Node{Name: node.Name}, "foo", "baz", "bar")
+	err := mgr.compareAndSetNodeLabel(context.Background(), &Node{Name: node.Name}, "foo", "baz", "bar")
 	assert.NoError(t, err)
 
-	updated, err := mgr.kube.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	updated, err := mgr.kube.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 	assert.EqualValues(t, updated.Labels, map[string]string{"foo": "bar"})
 
-	err = mgr.compareAndSetNodeLabel(&Node{Name: node.Name}, "foo", "baz", "quux")
+	err = mgr.compareAndSetNodeLabel(context.Background(), &Node{Name: node.Name}, "foo", "baz", "quux")
 	assert.NoError(t, err)
 
-	updated2, err := mgr.kube.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	updated2, err := mgr.kube.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 	assert.EqualValues(t, updated2.Labels, map[string]string{"foo": "bar"})
 
-	err = mgr.compareAndSetNodeLabel(&Node{Name: node.Name}, "foo", "bar", "quux")
+	err = mgr.compareAndSetNodeLabel(context.Background(), &Node{Name: node.Name}, "foo", "bar", "quux")
 	assert.NoError(t, err)
 
-	updated3, err := mgr.kube.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	updated3, err := mgr.kube.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 	assert.EqualValues(t, updated3.Labels, map[string]string{"foo": "quux"})
 }
@@ -183,20 +183,20 @@ func TestAnnotateNodes(t *testing.T) {
 	}
 
 	mgr := &KubernetesNodePoolManager{
-		kube: setupMockKubernetes(t, []*v1.Node{node}, nil, nil),
+		kube: setupMockKubernetes(context.Background(), t, []*v1.Node{node}, nil, nil),
 	}
 
-	err := mgr.annotateNode(&Node{Name: node.Name}, "foo", "bar")
+	err := mgr.annotateNode(context.Background(), &Node{Name: node.Name}, "foo", "bar")
 	assert.NoError(t, err)
 
-	updated, err := mgr.kube.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	updated, err := mgr.kube.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 	assert.EqualValues(t, updated.Annotations, map[string]string{"foo": "bar"})
 
-	err = mgr.annotateNode(&Node{Name: node.Name}, "foo", "baz")
+	err = mgr.annotateNode(context.Background(), &Node{Name: node.Name}, "foo", "baz")
 	assert.NoError(t, err)
 
-	updated2, err := mgr.kube.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	updated2, err := mgr.kube.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 	assert.EqualValues(t, updated2.Annotations, map[string]string{"foo": "baz"})
 }
@@ -209,14 +209,14 @@ func TestTaintNode(t *testing.T) {
 	}
 
 	mgr := &KubernetesNodePoolManager{
-		kube: setupMockKubernetes(t, []*v1.Node{node}, nil, nil),
+		kube: setupMockKubernetes(context.Background(), t, []*v1.Node{node}, nil, nil),
 	}
 
 	// we can add a new taint
-	err := mgr.taintNode(&Node{Name: node.Name}, "foo", "bar", v1.TaintEffectNoSchedule)
+	err := mgr.taintNode(context.Background(), &Node{Name: node.Name}, "foo", "bar", v1.TaintEffectNoSchedule)
 	assert.NoError(t, err)
 
-	updated, err := mgr.kube.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	updated, err := mgr.kube.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 
 	assert.EqualValues(
@@ -227,10 +227,10 @@ func TestTaintNode(t *testing.T) {
 		updated.Spec.Taints)
 
 	// we can add another taint
-	err = mgr.taintNode(&Node{Name: node.Name, Taints: updated.Spec.Taints}, "bar", "quux", v1.TaintEffectNoExecute)
+	err = mgr.taintNode(context.Background(), &Node{Name: node.Name, Taints: updated.Spec.Taints}, "bar", "quux", v1.TaintEffectNoExecute)
 	assert.NoError(t, err)
 
-	updated, err = mgr.kube.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	updated, err = mgr.kube.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 
 	assert.EqualValues(
@@ -242,10 +242,10 @@ func TestTaintNode(t *testing.T) {
 		updated.Spec.Taints)
 
 	// we can replace an existing taint
-	err = mgr.taintNode(&Node{Name: node.Name, Taints: updated.Spec.Taints}, "bar", "foo", v1.TaintEffectNoSchedule)
+	err = mgr.taintNode(context.Background(), &Node{Name: node.Name, Taints: updated.Spec.Taints}, "bar", "foo", v1.TaintEffectNoSchedule)
 	assert.NoError(t, err)
 
-	updated, err = mgr.kube.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	updated, err = mgr.kube.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 
 	assert.EqualValues(
@@ -257,10 +257,10 @@ func TestTaintNode(t *testing.T) {
 		updated.Spec.Taints)
 
 	// no-op updates should work
-	err = mgr.taintNode(&Node{Name: node.Name, Taints: updated.Spec.Taints}, "bar", "foo", v1.TaintEffectNoSchedule)
+	err = mgr.taintNode(context.Background(), &Node{Name: node.Name, Taints: updated.Spec.Taints}, "bar", "foo", v1.TaintEffectNoSchedule)
 	assert.NoError(t, err)
 
-	updated, err = mgr.kube.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+	updated, err = mgr.kube.CoreV1().Nodes().Get(context.Background(), node.Name, metav1.GetOptions{})
 	assert.NoError(t, err)
 
 	assert.EqualValues(
@@ -280,15 +280,15 @@ func TestCordonNode(t *testing.T) {
 	}
 
 	mgr := &KubernetesNodePoolManager{
-		kube: setupMockKubernetes(t, []*v1.Node{node}, nil, nil),
+		kube: setupMockKubernetes(context.Background(), t, []*v1.Node{node}, nil, nil),
 	}
 
-	err := mgr.CordonNode(&Node{Name: node.Name})
+	err := mgr.CordonNode(context.Background(), &Node{Name: node.Name})
 	assert.NoError(t, err)
 }
 
 func TestScalePool(tt *testing.T) {
-	evictPod = func(client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
+	evictPod = func(ctx context.Context, client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
 		return nil
 	}
 
@@ -389,7 +389,7 @@ func TestScalePool(tt *testing.T) {
 		tt.Run(tc.msg, func(t *testing.T) {
 			mgr := &KubernetesNodePoolManager{
 				backend: tc.backend,
-				kube:    setupMockKubernetes(t, tc.nodes, nil, nil),
+				kube:    setupMockKubernetes(context.Background(), t, tc.nodes, nil, nil),
 				logger:  log.WithField("test", true),
 			}
 			assert.NoError(t, mgr.ScalePool(context.Background(), &api.NodePool{Name: "test"}, tc.replicas))

--- a/pkg/updatestrategy/rolling_update.go
+++ b/pkg/updatestrategy/rolling_update.go
@@ -32,10 +32,10 @@ func NewRollingUpdateStrategy(logger *log.Entry, nodePoolManager NodePoolManager
 	}
 }
 
-func (r *RollingUpdateStrategy) markOldNodes(nodePool *NodePool) error {
+func (r *RollingUpdateStrategy) markOldNodes(ctx context.Context, nodePool *NodePool) error {
 	for _, node := range nodePool.Nodes {
 		if node.Generation != nodePool.Generation {
-			err := r.nodePoolManager.MarkNodeForDecommission(node)
+			err := r.nodePoolManager.MarkNodeForDecommission(ctx, node)
 			if err != nil {
 				return err
 			}
@@ -77,10 +77,10 @@ func (r *RollingUpdateStrategy) terminateCordonedNodes(ctx context.Context, node
 }
 
 // cordonNodes cordons a list of nodes.
-func (r *RollingUpdateStrategy) cordonNodes(nodes []*Node) error {
+func (r *RollingUpdateStrategy) cordonNodes(ctx context.Context, nodes []*Node) error {
 	r.logger.Debugf("Found %d nodes to cordon", len(nodes))
 	for _, node := range nodes {
-		err := r.nodePoolManager.CordonNode(node)
+		err := r.nodePoolManager.CordonNode(ctx, node)
 		if err != nil {
 			return err
 		}
@@ -138,7 +138,7 @@ func (r *RollingUpdateStrategy) Update(ctx context.Context, nodePoolDesc *api.No
 			return err
 		}
 
-		err = r.markOldNodes(nodePool)
+		err = r.markOldNodes(ctx, nodePool)
 		if err != nil {
 			return err
 		}
@@ -183,7 +183,7 @@ func (r *RollingUpdateStrategy) Update(ctx context.Context, nodePoolDesc *api.No
 		}
 
 		// cordon the selected nodes
-		err = r.cordonNodes(toCordon)
+		err = r.cordonNodes(ctx, toCordon)
 		if err != nil {
 			return err
 		}

--- a/pkg/updatestrategy/rolling_update_test.go
+++ b/pkg/updatestrategy/rolling_update_test.go
@@ -47,19 +47,19 @@ func (m *mockNodePoolManager) MarkPoolForDecommission(nodePool *api.NodePool) er
 	return nil
 }
 
-func (m *mockNodePoolManager) DisableReplacementNodeProvisioning(node *Node) error {
+func (m *mockNodePoolManager) DisableReplacementNodeProvisioning(ctx context.Context, node *Node) error {
 	return nil
 }
 
-func (m *mockNodePoolManager) GetPool(nodePool *api.NodePool) (*NodePool, error) {
+func (m *mockNodePoolManager) GetPool(ctx context.Context, nodePool *api.NodePool) (*NodePool, error) {
 	return m.nodePool, nil
 }
 
-func (m *mockNodePoolManager) MarkNodeForDecommission(node *Node) error {
+func (m *mockNodePoolManager) MarkNodeForDecommission(ctx context.Context, node *Node) error {
 	return nil
 }
 
-func (m *mockNodePoolManager) AbortNodeDecommissioning(node *Node) error {
+func (m *mockNodePoolManager) AbortNodeDecommissioning(ctx context.Context, node *Node) error {
 	return nil
 }
 
@@ -104,7 +104,7 @@ func (m *mockNodePoolManager) TerminateNode(ctx context.Context, node *Node, dec
 	return nil
 }
 
-func (m *mockNodePoolManager) CordonNode(node *Node) error {
+func (m *mockNodePoolManager) CordonNode(ctx context.Context, node *Node) error {
 	for _, n := range m.nodePool.Nodes {
 		if n.ProviderID == node.ProviderID {
 			n.Cordoned = true
@@ -294,7 +294,7 @@ func TestUpdate(tt *testing.T) {
 				t.Error("expected failure")
 			}
 
-			nodePool, _ := tc.nodePoolManager.GetPool(np)
+			nodePool, _ := tc.nodePoolManager.GetPool(context.Background(), np)
 			if tc.success && !equalNodePool(nodePool, tc.expected) {
 				t.Errorf("final node pool nodePool did not match expected nodePool")
 			}

--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -30,5 +30,5 @@ type Options struct {
 type Provisioner interface {
 	Supports(cluster *api.Cluster) bool
 	Provision(ctx context.Context, logger *log.Entry, cluster *api.Cluster, channelConfig channel.Config) error
-	Decommission(logger *log.Entry, cluster *api.Cluster) error
+	Decommission(ctx context.Context, logger *log.Entry, cluster *api.Cluster) error
 }

--- a/provisioner/stdout.go
+++ b/provisioner/stdout.go
@@ -28,7 +28,7 @@ func (p *stdoutProvisioner) Provision(ctx context.Context, logger *log.Entry, cl
 }
 
 // Decommission mocks decommissioning a cluster.
-func (p *stdoutProvisioner) Decommission(logger *log.Entry, cluster *api.Cluster) error {
+func (p *stdoutProvisioner) Decommission(ctx context.Context, logger *log.Entry, cluster *api.Cluster) error {
 	logger.Infof("stdout: Decommissioning cluster %s.", cluster.ID)
 
 	return nil


### PR DESCRIPTION
Mostly replaces context.TODOs with passed-in context. Adds parent context to signature of surrounding function if not already present.

In tests, replaces context.TODO with context.Background() on the top-level.

The rest is wiring it all up and making it all compile.