### PR TITLE
Add support for Metadata.Tags in CF stacks

### DIFF
--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -162,27 +162,12 @@ func (p *AWSNodePoolProvisioner) provisionNodePool(ctx context.Context, nodePool
 	// TODO: stackname pattern
 	stackName := fmt.Sprintf("nodepool-%s-%s", nodePool.Name, strings.Replace(p.cluster.ID, ":", "-", -1))
 
-	tags := []*cloudformation.Tag{
-		{
-			Key:   aws.String(tagNameKubernetesClusterPrefix + p.cluster.ID),
-			Value: aws.String(resourceLifecycleOwned),
-		},
-		{
-			Key:   aws.String(nodePoolRoleTagKey),
-			Value: aws.String("true"),
-		},
-		{
-			Key:   aws.String(nodePoolTagKey),
-			Value: aws.String(nodePool.Name),
-		},
-		{
-			Key:   aws.String(nodePoolTagKeyLegacy),
-			Value: aws.String(nodePool.Name),
-		},
-		{
-			Key:   aws.String(nodePoolProfileTagKey),
-			Value: aws.String(nodePool.Profile),
-		},
+	tags := map[string]string{
+		tagNameKubernetesClusterPrefix + p.cluster.ID: resourceLifecycleOwned,
+		nodePoolRoleTagKey:                            "true",
+		nodePoolTagKey:                                nodePool.Name,
+		nodePoolTagKeyLegacy:                          nodePool.Name,
+		nodePoolProfileTagKey:                         nodePool.Profile,
 	}
 
 	err = p.awsAdapter.applyStack(stackName, template, "", tags, true)


### PR DESCRIPTION
This adds support for defining cloud formation Tags via the cloudformation yaml template similar to what we have for our internal CDP deployments. Basically it will be possible to add:

```yaml
Metadata:
  Tags:
    foo: bar
```

To a template in kubernetes-on-aws and the tags will be added when the stack is being created. This allows setting custom tags like `InfrastructureComponent=true` which we can use to control permissions.