### PR TITLE
Support non-ocean spotio node pool

### DIFF
--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -69,7 +69,8 @@ const (
 	clusterStackOutputKey              = "ClusterStackOutputs"
 	spotIOAccessTokenKey               = "spotio_access_token"
 	spotIOAccountIDKey                 = "spotio_account_id"
-	spotIONodePoolProfile              = "worker-spotio-ocean"
+	spotIONodePoolProfileLegacy        = "worker-spotio-ocean"
+	spotIONodePoolProfile              = "worker-spotio"
 	decommissionNodeNoScheduleTaintKey = "decommission_node_no_schedule_taint"
 )
 
@@ -779,6 +780,7 @@ func (p *clusterpyProvisioner) prepareProvision(logger *log.Entry, cluster *api.
 		spotIOClient := spotio.New(spotiosession.New(cfg))
 
 		spotIOBackend := updatestrategy.NewSpotIONodePoolsBackend(cluster.ID, adapter.session, spotIOClient)
+		additionalBackends[spotIONodePoolProfileLegacy] = spotIOBackend
 		additionalBackends[spotIONodePoolProfile] = spotIOBackend
 	}
 


### PR DESCRIPTION
Defined a new node pool profile: `worker-spotio` where the spotio setup is different thant `worker-spotio-ocean` profiles, but from CLM PoV it needs to be handled the same way.


This is needed for https://github.com/zalando-incubator/kubernetes-on-aws/pull/3787 and later we can drop support from `worker-spotio-ocean` when we have migrated away.