### PR TITLE
Deprecate NodePool.AvailableStorage, move to instance info instead

### DIFF
--- a/api/node_pool.go
+++ b/api/node_pool.go
@@ -25,6 +25,7 @@ func (np NodePool) IsSpot() bool {
 // AvailableStorage returns the storage available on the instance for the user data based on the
 // instance type. If the nodes have instance storage devices, it returns the minimum of the total
 // size scaled by scaleFactor, otherwise it returns ebsSize.
+// Deprecated.
 func (np NodePool) AvailableStorage(ebsSize int64, scaleFactor float64) (int64, error) {
 	instanceInfo, err := aws.SyntheticInstanceInfo(np.InstanceTypes)
 	if err != nil {

--- a/pkg/aws/instance_info.go
+++ b/pkg/aws/instance_info.go
@@ -22,6 +22,13 @@ type Instance struct {
 	InstanceStorageDeviceSize int64
 }
 
+func (i Instance) AvailableStorage(instanceStorageScaleFactor float64, rootVolumeSize int64, rootVolumeScaleFactor float64) float64 {
+	if i.InstanceStorageDevices == 0 {
+		return float64(rootVolumeSize) * rootVolumeScaleFactor
+	}
+	return instanceStorageScaleFactor * float64(i.InstanceStorageDevices*i.InstanceStorageDeviceSize)
+}
+
 type instanceInfo struct {
 	InstanceType string      `json:"instance_type"`
 	VCPU         interface{} `json:"vCPU"`

--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -34,6 +34,7 @@ const (
 
 	userDataValuesKey             = "UserData"
 	s3GeneratedFilesPathValuesKey = "S3GeneratedFilesPath"
+	instanceInfoKey               = "InstanceInfo"
 )
 
 // NodePoolProvisioner is able to provision node pools for a cluster.
@@ -145,7 +146,7 @@ func (p *AWSNodePoolProvisioner) provisionNodePool(ctx context.Context, nodePool
 	if err != nil {
 		return err
 	}
-	values["instance_info"] = instanceInfo
+	values[instanceInfoKey] = instanceInfo
 
 	// handle AZ overrides for the node pool
 	if azNames, ok := nodePool.ConfigItems[availabilityZonesConfigItemKey]; ok {


### PR DESCRIPTION
This is a preparation for #408.

Changes:
 * Rename `.Values.instance_info` -> `.Values.InstanceInfo`. It wasn't used anywhere so it's safe.
 * Deprecate `.NodePool.AvailableStorage` (since it relies on global AWS data which will not be readily available. Add `.Values.InstanceInfo.AvailableStorage` instead.
