### PR TITLE
Debug when retrying deployments downscale

### DIFF
--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -524,7 +524,11 @@ func (p *clusterpyProvisioner) Decommission(ctx context.Context, logger *log.Ent
 	// recreate resources we delete in the next step
 	err = backoff.Retry(
 		func() error {
-			return p.downscaleDeployments(ctx, logger, cluster, "kube-system")
+			err := p.downscaleDeployments(ctx, logger, cluster, "kube-system")
+			if err != nil {
+				logger.Debugf("Failed to downscale deployments, will retry: %s", err.Error())
+			}
+			return err
 		},
 		backoff.WithMaxRetries(backoff.NewConstantBackOff(10*time.Second), 5))
 	if err != nil {


### PR DESCRIPTION
When decommissioning clusters where API server is not running, the
operation might seem stuck, even with `--debug` since the retries of
deployments downscale are running in silent. It will run after the
backoff retries, but adding a debug message make it quicker to
understand.