### PR TITLE
Add additional OIDC providers from config item (POC)

### DIFF
--- a/provisioner/openid_provider.go
+++ b/provisioner/openid_provider.go
@@ -27,7 +27,7 @@ type OpenIDProviderProvisioner struct {
 func NewOpenIDProviderProvisioner(adapter *awsAdapter, providerHostname string) (*OpenIDProviderProvisioner, error) {
 	return &OpenIDProviderProvisioner{
 		awsAdapter:  adapter,
-		providerUrl: providerHostname,
+		providerUrl: strings.TrimSpace(providerHostname),
 		clientIDs:   []string{stsDomain},
 		thumbprints: []string{acmRootCAThumbprint},
 	}, nil


### PR DESCRIPTION
This allows to specify additional allowed OIDC providers via config item.

If a cluster A wants to allow cross-account access from clusters B and C you would set the following config item in cluster A:

```
oidc_additional_providers: B, C
```

Biggest flaw of this approach: I don't see a good way to remove OIDC providers if items are removed from the list as well as in multi-cluster accounts, such as e2e.