### PR TITLE
Improve userdata files

### DIFF
--- a/api/node_pool.go
+++ b/api/node_pool.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"strings"
+
 	"github.com/zalando-incubator/cluster-lifecycle-manager/pkg/aws"
 )
 
@@ -20,6 +22,10 @@ type NodePool struct {
 
 func (np NodePool) IsSpot() bool {
 	return np.DiscountStrategy == "spot_max_price" || np.DiscountStrategy == "spot"
+}
+
+func (np NodePool) IsMaster() bool {
+	return strings.Contains(np.Profile, "master")
 }
 
 // AvailableStorage returns the storage available on the instance for the user data based on the

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -1287,7 +1287,7 @@ func int32Value(v *int32) int32 {
 func groupNodePools(logger *log.Entry, cluster *api.Cluster) []nodePoolGroup {
 	var masters, workers []*api.NodePool
 	for _, nodePool := range cluster.NodePools {
-		if strings.Contains(nodePool.Profile, "master") {
+		if nodePool.IsMaster() {
 			masters = append(masters, nodePool)
 			continue
 		}

--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -313,7 +313,7 @@ func (p *AWSNodePoolProvisioner) renderUploadGeneratedFiles(nodePool *api.NodePo
 		return "", err
 	}
 	var (
-		keyName, poolKind string
+		keyName, poolKind, filename string
 	)
 	if nodePool.IsMaster() {
 		keyName = masterFilesKMSKey
@@ -334,7 +334,15 @@ func (p *AWSNodePoolProvisioner) renderUploadGeneratedFiles(nodePool *api.NodePo
 	if err != nil {
 		return "", fmt.Errorf("failed to generate hash of userdata: %v", err)
 	}
-	filename := path.Join(p.cluster.LocalID, poolKind, userDataHash)
+
+	// Make it possible to migrate one channel at a time.
+	// TODO drop once all the clusters have migrated.
+	if p.cluster.ConfigItems["clm_new_userdata_path"] == "true" {
+		filename = path.Join(p.cluster.LocalID, poolKind, userDataHash)
+	} else {
+		filename = userDataHash
+	}
+
 	return p.uploadUserDataToS3(filename, archive, p.bucketName)
 }
 


### PR DESCRIPTION
 * Use the correct KMS key depending on the pool type
 * Include the cluster ID and the pool kind so it's easier to cleanup later (only if `clm_new_userdata_path` is set to true)