### PR TITLE
Add a template function to check for spot.io pools

### DIFF
--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -125,6 +125,7 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		"kubernetesSizeToKiloBytes":     kubernetesSizeToKiloBytes,
 		"indexedList":                   indexedList,
 		"zoneDistributedNodePoolGroups": zoneDistributedNodePoolGroups,
+		"spotIONodePools":               spotIONodePools,
 	}
 
 	content, ok := context.fileData[file]
@@ -627,4 +628,14 @@ func zoneDistributedNodePoolGroups(nodePools []*api.NodePool) map[string]bool {
 		}
 	}
 	return result
+}
+
+// spotIONodePools returns true at least one node pool is a spot.io node pool.
+func spotIONodePools(nodePools []*api.NodePool) bool {
+	for _, pool := range nodePools {
+		if pool.IsSpotIO() {
+			return true
+		}
+	}
+	return false
 }

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -878,3 +878,47 @@ func TestZoneDistributedNodePoolGroupsDefault(t *testing.T) {
 		})
 	}
 }
+
+func TestSpotIONodePools(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		pools    []*api.NodePool
+		expected bool
+	}{
+		{
+			name: "one pool is spot.io",
+			pools: []*api.NodePool{
+				{
+					Name:    "default",
+					Profile: "worker-spotio",
+				},
+				{
+					Name:    "default-2",
+					Profile: "worker-splitaz",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "no pools are spot.io",
+			pools: []*api.NodePool{
+				{
+					Name:    "default",
+					Profile: "worker-splitaz",
+				},
+				{
+					Name:        "default-2",
+					Profile:     "worker-default",
+					ConfigItems: map[string]string{"taints": "foo=bar:NoSchedule"},
+				},
+			},
+			expected: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := renderSingle(t, `{{ spotIONodePools .Values.data.pools }}`, map[string]interface{}{"pools": tc.pools})
+			require.NoError(t, err)
+			require.Equal(t, strconv.FormatBool(tc.expected), result)
+		})
+	}
+}


### PR DESCRIPTION
Adds a template function which returns true if any of the node pools is a spot.io pool. This will make it simple to enable/disable spot.io components based whether it's used or not.