### PR TITLE
Fix worker-spotio support

### DIFF
--- a/api/node_pool.go
+++ b/api/node_pool.go
@@ -25,7 +25,7 @@ func (np NodePool) IsSpot() bool {
 }
 
 func (np NodePool) IsSpotIO() bool {
-	return np.Profile == "worker-spotio-ocean" || np.Profile == "worker-spotio"
+	return np.Profile == "worker-spotio"
 }
 
 func (np NodePool) IsMaster() bool {

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -69,7 +69,6 @@ const (
 	clusterStackOutputKey              = "ClusterStackOutputs"
 	spotIOAccessTokenKey               = "spotio_access_token"
 	spotIOAccountIDKey                 = "spotio_account_id"
-	spotIONodePoolProfileLegacy        = "worker-spotio-ocean"
 	spotIONodePoolProfile              = "worker-spotio"
 	decommissionNodeNoScheduleTaintKey = "decommission_node_no_schedule_taint"
 )
@@ -784,7 +783,6 @@ func (p *clusterpyProvisioner) prepareProvision(logger *log.Entry, cluster *api.
 		spotIOClient := spotio.New(spotiosession.New(cfg))
 
 		spotIOBackend := updatestrategy.NewSpotIONodePoolsBackend(cluster.ID, adapter.session, spotIOClient)
-		additionalBackends[spotIONodePoolProfileLegacy] = spotIOBackend
 		additionalBackends[spotIONodePoolProfile] = spotIOBackend
 	}
 


### PR DESCRIPTION
* Fix supporting multiple node pools of type `worker-spotio` by looking up the right LaunchSpec based on node pool name
* Drop support for `worker-spotio-ocean` (one ocean per node pool setup). This is no longer compatible with the above change AND it's no longer used.