### PR TITLE
Drop support for clm_new_userdata_path

### DIFF
--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -313,7 +313,7 @@ func (p *AWSNodePoolProvisioner) renderUploadGeneratedFiles(nodePool *api.NodePo
 		return "", err
 	}
 	var (
-		keyName, poolKind, filename string
+		keyName, poolKind string
 	)
 	if nodePool.IsMaster() {
 		keyName = masterFilesKMSKey
@@ -335,14 +335,7 @@ func (p *AWSNodePoolProvisioner) renderUploadGeneratedFiles(nodePool *api.NodePo
 		return "", fmt.Errorf("failed to generate hash of userdata: %v", err)
 	}
 
-	// Make it possible to migrate one channel at a time.
-	// TODO drop once all the clusters have migrated.
-	if p.cluster.ConfigItems["clm_new_userdata_path"] == "true" {
-		filename = path.Join(p.cluster.LocalID, poolKind, userDataHash)
-	} else {
-		filename = userDataHash
-	}
-
+	filename := path.Join(p.cluster.LocalID, poolKind, userDataHash)
 	return p.uploadUserDataToS3(filename, archive, p.bucketName)
 }
 


### PR DESCRIPTION
The [kubernetes-on-aws PR](https://github.com/zalando-incubator/kubernetes-on-aws/pull/4031) has been rolled out everywhere, so we don't need this anymore.

Note that this still doesn't implement any kind of cleanup, but we can at least drop the config item.