### PR TITLE
Always use PreferNoSchedule for master nodes

### DIFF
--- a/pkg/updatestrategy/updatestrategy.go
+++ b/pkg/updatestrategy/updatestrategy.go
@@ -57,6 +57,7 @@ type Node struct {
 	Generation      int
 	VolumesAttached bool
 	Ready           bool
+	Master          bool
 }
 
 // ProfileNodePoolProvisioner is a NodePoolProvisioner which selects the


### PR DESCRIPTION
When `noScheduleTaint=true` nodes about to be decommissioned will get a `NoSchedule` taint to avoid new pods being scheduled there.
For master nodes it's possible to end in a situation where two separate master node updates can cause all current nodes to be marked for decommissioning meaning nothing new can be scheduled on them. When we do a rolling update we want the Cluster Lifecycle Controller (CLC) (and other master pods) to be moved to one of the other nodes when the current nodes is being decommissioned. When all nodes are marked for decommissioning the pods can no longer be scheduled resulting in the update not continuing.

This changes the taint such that for `master` nodes it's always `PreferNoSchedule`. This can have the side effect that master pods are bounced a bit around between the nodes, but it's better than having them not running at all.