### PR TITLE
When only 1 VPC, assume default.

### DIFF
--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -777,6 +777,10 @@ func (a *awsAdapter) GetDefaultVPC() (*ec2.Vpc, error) {
 		return nil, err
 	}
 
+	if len(vpcResp.Vpcs) == 1 {
+		return vpcResp.Vpcs[0], nil
+	}
+
 	var defaultVpc *ec2.Vpc
 	for _, vpc := range vpcResp.Vpcs {
 		if aws.BoolValue(vpc.IsDefault) {


### PR DESCRIPTION
To avoid depending on a VPC being the default, but only when only 1 VPC exists in the account. 

Signed-off-by: rreis <rodrigo@zalando.de>