### PR TITLE
Manage the etcd stack with CLM

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/zalando-incubator/cluster-lifecycle-manager/pkg/updatestrategy"
-	"gopkg.in/alecthomas/kingpin.v2"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
 const (
@@ -56,6 +56,7 @@ type LifecycleManagerConfig struct {
 	AwsMaxRetryInterval         time.Duration
 	UpdateStrategy              UpdateStrategy
 	RemoveVolumes               bool
+	ManageEtcdStack             bool
 }
 
 // UpdateStrategy defines the default update strategy configured for the
@@ -105,5 +106,6 @@ func (cfg *LifecycleManagerConfig) ParseFlags() string {
 	kingpin.Flag("update-strategy", "Update strategy to use when updating node pools.").Default(defaultUpdateStrategy).EnumVar(&cfg.UpdateStrategy.Strategy, "rolling", "clc")
 	kingpin.Flag("remove-volumes", "Remove EBS volumes when decommissioning.").BoolVar(&cfg.RemoveVolumes)
 	kingpin.Flag("concurrent-external-processes", "Number of external processes allowed to run in parallel").Default(defaultConcurrentExternalProcesses).UintVar(&cfg.ConcurrentExternalProcesses)
+	kingpin.Flag("manage-etcd-stack", "Enable creation/updates of the etcd stack (should be disabled for pet clusters)").BoolVar(&cfg.ManageEtcdStack)
 	return kingpin.Parse()
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/go-swagger/go-swagger v0.27.0
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/googleapis/gnostic v0.5.4 // indirect
-	github.com/mitchellh/copystructure v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/common v0.23.0 // indirect
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -506,8 +506,6 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
-github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
-github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
@@ -520,8 +518,6 @@ github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/mapstructure v1.4.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
-github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/pkg/util/copy.go
+++ b/pkg/util/copy.go
@@ -1,0 +1,9 @@
+package util
+
+func CopyValues(value map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{}, len(value))
+	for k, v := range value {
+		result[k] = v
+	}
+	return result
+}

--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -46,7 +46,6 @@ const (
 	cloudformationNoUpdateMsg   = "No updates are to be performed."
 	clmCFBucketPattern          = "cluster-lifecycle-manager-%s-%s"
 	lifecycleStatusReady        = "ready"
-	etcdKMSKeyAlias             = "alias/etcd-cluster"
 
 	etcdInstanceTypeConfigItem      = "etcd_instance_type"
 	etcdInstanceCountConfigItem     = "etcd_instance_count"
@@ -462,7 +461,7 @@ func (a *awsAdapter) DeleteStack(parentCtx context.Context, stack *cloudformatio
 }
 
 // CreateOrUpdateEtcdStack creates or updates an etcd stack.
-func (a *awsAdapter) CreateOrUpdateEtcdStack(parentCtx context.Context, stackName string, stackDefinition []byte, networkCIDR, vpcID string, cluster *api.Cluster) error {
+func (a *awsAdapter) CreateOrUpdateEtcdStack(parentCtx context.Context, stackName string, stackDefinition []byte, kmsKeyARN, networkCIDR, vpcID string, cluster *api.Cluster) error {
 	bucketName := fmt.Sprintf("zalando-kubernetes-etcd-%s-%s", getAWSAccountID(cluster.InfrastructureAccount), cluster.Region)
 
 	if bucket, ok := cluster.ConfigItems[etcdBackupBucketConfigItem]; ok {
@@ -485,11 +484,6 @@ func (a *awsAdapter) CreateOrUpdateEtcdStack(parentCtx context.Context, stackNam
 	// Ignore the error because the error indicates that the stack is missing
 	if err == nil && len(resp.Stacks) == 1 {
 		return nil
-	}
-
-	kmsKeyARN, err := a.resolveKeyID(etcdKMSKeyAlias)
-	if err != nil {
-		return err
 	}
 
 	encryptedScalyrKey, err := a.kmsEncryptForTaupage(kmsKeyARN, cluster.ConfigItems[etcdScalyrKeyConfigItem])

--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -563,7 +563,7 @@ func (a *awsAdapter) CreateOrUpdateEtcdStack(parentCtx context.Context, stackNam
 			if err != nil {
 				return err
 			}
-			expiry, err := certificateExpiry(string(decoded))
+			expiry, err := certificateExpiryTime(string(decoded))
 			if err != nil {
 				return err
 			}
@@ -615,7 +615,7 @@ func (a *awsAdapter) CreateOrUpdateEtcdStack(parentCtx context.Context, stackNam
 	return nil
 }
 
-func certificateExpiry(certificate string) (time.Time, error) {
+func certificateExpiryTime(certificate string) (time.Time, error) {
 	block, _ := pem.Decode([]byte(certificate))
 	if block == nil {
 		return time.Time{}, fmt.Errorf("no PEM data found")

--- a/provisioner/aws_test.go
+++ b/provisioner/aws_test.go
@@ -382,7 +382,7 @@ func TestApplyStack(t *testing.T) {
 		statusMutex: &sync.Mutex{},
 	}
 
-	err := awsAdapter.applyStack("stack-name", `{"Metadata": {"Tags": {"foo":"bar"}}}`, "", nil, true)
+	err := awsAdapter.applyStack("stack-name", `{"Metadata": {"Tags": {"foo":"bar"}}}`, "", nil, true, nil)
 	require.NoError(t, err)
 }
 

--- a/provisioner/aws_test.go
+++ b/provisioner/aws_test.go
@@ -591,27 +591,3 @@ func TestKMSKeyARN(t *testing.T) {
 		})
 	}
 }
-
-func TestCertificateExpiry(t *testing.T) {
-	certificate := strings.ReplaceAll(`-----BEGIN CERTIFICATE-----
-	MIICoDCCAYgCCQDLEipM91kVrzANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdl
-	eGFtcGxlMB4XDTIxMDMwNTExMTQzM1oXDTIyMDMwNTExMTQzM1owEjEQMA4GA1UE
-	AwwHZXhhbXBsZTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL8sxsRl
-	2gSJUdtRwaG1ASdaVPsVAWJv/Z1UpBXg/1MMIZV7oB/BI2IlHyJpJdRTWMRgqo2N
-	lZ6NdkyTSusq5p85WceJatyEWB2PwQBd1Jrv5ReoMrts+i5SNoDLSz8WSdI8L66g
-	naHL6DJ5eyOCxGTV/DiCHke3tYSPlRBxGC7iRAtkRunYPxog3s9VUbd5wwF6bV/1
-	uh7h4s7RcevGiYxR2ciRXes6WhdwYVWJttm4iMewV9Hugt/5PngsNBQOZ9M/6dX+
-	tBIIpNhfiL7VpqOE/JK+K91uIvcmaiW0u25mDLZtsDTk1ozShCWiZp3zShkG9gQ5
-	s+aF11LacNoeVvMCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAdGnfl5bX1YvVabD4
-	/nS9GN6t8KKUUGd7S3njsay/V7Iv5fxKROotFj4BTNpIpFAhZEJndfHanv2lRwc1
-	zhcy0h+ArwXaoyw2DEC8B92FxLqBNEml+EjrgIsr6ZnfujauDyCxQXGSPrTiBYIs
-	zL14G1QW02UeUFZNQU8qOSjGLf8V957ktXDHTSP2LsOpiBJV8HhLHeur6EXMJTj0
-	7PngQHnkNqH6N2XBhNlZTbYHawh0GrTZYt1W/SYmkLWBDfHpZKfhCXbryRbg9grW
-	GN3xYrTHx/v3mF21rr1aq3ejplHTq7v0QOyPxvX4CxtCssxIyxu2Z9JC8CMSRm/p
-	2OzhXg==
-	-----END CERTIFICATE-----`, "\t", "")
-
-	exp, err := certificateExpiry(certificate)
-	require.NoError(t, err)
-	require.Equal(t, time.Date(2022, 3, 5, 11, 14, 33, 0, time.UTC), exp)
-}

--- a/provisioner/cf.go
+++ b/provisioner/cf.go
@@ -1,0 +1,38 @@
+package provisioner
+
+type stackPolicyEffect string
+type stackPolicyAction string
+type stackPolicyPrincipal string
+
+const (
+	stackPolicyEffectDeny  stackPolicyEffect = "Deny"
+	stackPolicyEffectAllow stackPolicyEffect = "Allow"
+
+	stackPolicyActionUpdateModify  stackPolicyAction = "Update:Modify"
+	stackPolicyActionUpdateReplace stackPolicyAction = "Update:Replace"
+	stackPolicyActionUpdateDelete  stackPolicyAction = "Update:Delete"
+	stackPolicyActionUpdateAll     stackPolicyAction = "Update:*"
+
+	stackPolicyPrincipalAll stackPolicyPrincipal = "*"
+)
+
+type stackPolicyConditionStringEquals struct {
+	ResourceType []string `json:"ResourceType"`
+}
+
+type stackPolicyCondition struct {
+	StringEquals stackPolicyConditionStringEquals `json:"StringEquals"`
+}
+
+type stackPolicyStatement struct {
+	Effect      stackPolicyEffect     `json:"Effect"`
+	Action      []stackPolicyAction   `json:"Action,omitempty"`
+	Principal   stackPolicyPrincipal  `json:"Principal"`
+	Resource    []string              `json:"Resource,omitempty"`
+	NotResource []string              `json:"NotResource,omitempty"`
+	Condition   *stackPolicyCondition `json:"Condition,omitempty"`
+}
+
+type stackPolicy struct {
+	Statements []stackPolicyStatement `json:"Statement"`
+}

--- a/provisioner/legacy_etcd.go
+++ b/provisioner/legacy_etcd.go
@@ -1,0 +1,115 @@
+package provisioner
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
+	yaml "gopkg.in/yaml.v2"
+)
+
+// populateEncryptedEtcdValues is a horrible hack that is needed to avoid doing an update of the Taupage-based CloudFormation stack every time
+// we run. Unfortunately it's pretty much unavoidable because we rely on the KMS-encrypted config items inside the launch template, and if we
+// didn't do this, every run would create new ciphertext for the same plaintext value and then trigger a rolling update. We can drop it and switch
+// to a saner scheme (same as what we do with Kubernetes) once we migrate away from Taupage, and then this whole mess can be dropped.
+func populateEncryptedEtcdValues(adapter *awsAdapter, cluster *api.Cluster, etcdKMSKeyARN string, values map[string]interface{}) error {
+	stack, err := adapter.getStackByName(etcdStackName)
+	if err != nil && !isDoesNotExistsErr(err) {
+		return err
+	}
+
+	// Try to reload the values from the existing launch template
+	if stack != nil {
+		for _, output := range stack.Outputs {
+			if aws.StringValue(output.OutputKey) == "LaunchTemplateId" {
+				launchTemplateID := aws.StringValue(output.OutputValue)
+
+				versions, err := adapter.ec2Client.DescribeLaunchTemplateVersions(&ec2.DescribeLaunchTemplateVersionsInput{
+					LaunchTemplateId: aws.String(launchTemplateID),
+					Versions:         []*string{aws.String("$Latest")},
+				})
+				if err != nil {
+					return err
+				}
+
+				if len(versions.LaunchTemplateVersions) != 1 {
+					return fmt.Errorf("expected 1 version in launch template %s, found %d", launchTemplateID, len(versions.LaunchTemplateVersions))
+				}
+
+				userData, err := base64.StdEncoding.DecodeString(aws.StringValue(versions.LaunchTemplateVersions[0].LaunchTemplateData.UserData))
+				if err != nil {
+					return err
+				}
+
+				if bytes.HasPrefix(userData, []byte("#taupage-ami-config")) {
+					var result struct {
+						Environment struct {
+							ClientCert string `yaml:"CLIENT_CERT"`
+							ClientKey  string `yaml:"CLIENT_KEY"`
+							ClientCA   string `yaml:"CLIENT_TRUSTED_CA"`
+						} `yaml:"environment"`
+						ScalyrKey string `yaml:"scalyr_account_key"`
+					}
+					err = yaml.Unmarshal(userData, &result)
+					if err != nil {
+						return err
+					}
+
+					for k, v := range map[string]string{
+						"etcd_client_server_cert": result.Environment.ClientCert,
+						"etcd_client_server_key":  result.Environment.ClientKey,
+						"etcd_client_ca_cert":     result.Environment.ClientCA,
+						"etcd_scalyr_key":         result.ScalyrKey,
+					} {
+						decrypted, err := decryptTaupageKMSValue(adapter, v)
+						if err != nil {
+							return err
+						}
+
+						if cluster.ConfigItems[k] == decrypted {
+							// Keep the existing value
+							values[k] = v
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Fill in the missing config items
+	for _, ci := range []string{"etcd_client_server_cert", "etcd_client_server_key", "etcd_client_ca_cert", "etcd_scalyr_key"} {
+		if _, ok := values[ci]; ok {
+			continue
+		}
+
+		encrypted, err := adapter.kmsEncryptForTaupage(etcdKMSKeyARN, cluster.ConfigItems[ci])
+		if err != nil {
+			return err
+		}
+		values[ci] = encrypted
+	}
+
+	return nil
+}
+
+func decryptTaupageKMSValue(adapter *awsAdapter, value string) (string, error) {
+	if value == "" {
+		return "", nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(value, "aws:kms:"))
+	if err != nil {
+		return "", err
+	}
+	decrypted, err := adapter.kmsClient.Decrypt(&kms.DecryptInput{
+		CiphertextBlob: decoded,
+	})
+	if err != nil {
+		return "", err
+	}
+	return string(decrypted.Plaintext), nil
+}

--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -175,7 +175,7 @@ func (p *AWSNodePoolProvisioner) provisionNodePool(ctx context.Context, nodePool
 		nodePoolProfileTagKey:                         nodePool.Profile,
 	}
 
-	err = p.awsAdapter.applyStack(stackName, template, "", tags, true)
+	err = p.awsAdapter.applyStack(stackName, template, "", tags, true, nil)
 	if err != nil {
 		return err
 	}

--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -15,12 +15,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-	"github.com/mitchellh/copystructure"
 	log "github.com/sirupsen/logrus"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/channel"
 	awsUtils "github.com/zalando-incubator/cluster-lifecycle-manager/pkg/aws"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/pkg/updatestrategy"
+	"github.com/zalando-incubator/cluster-lifecycle-manager/pkg/util"
 )
 
 const (
@@ -99,15 +99,7 @@ func (p *AWSNodePoolProvisioner) Provision(ctx context.Context, nodePools []*api
 
 	// provision node pools in parallel
 	for _, nodePool := range nodePools {
-		poolValuesCopy, err := copystructure.Copy(values)
-		if err != nil {
-			return err
-		}
-
-		poolValues, ok := poolValuesCopy.(map[string]interface{})
-		if !ok {
-			return fmt.Errorf("unable to copy values for node pool %s", nodePool.Name)
-		}
+		poolValues := util.CopyValues(values)
 
 		go func(nodePool api.NodePool, errorsc chan error) {
 			err := p.provisionNodePool(ctx, &nodePool, poolValues)

--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -19,10 +19,11 @@ var (
 
 // Options is the options that can be passed to a provisioner when initialized.
 type Options struct {
-	DryRun         bool
-	ApplyOnly      bool
-	UpdateStrategy config.UpdateStrategy
-	RemoveVolumes  bool
+	DryRun          bool
+	ApplyOnly       bool
+	UpdateStrategy  config.UpdateStrategy
+	RemoveVolumes   bool
+	ManageEtcdStack bool
 }
 
 // Provisioner is an interface describing how to provision or decommission

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -126,10 +126,7 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		"kubernetesSizeToKiloBytes":     kubernetesSizeToKiloBytes,
 		"indexedList":                   indexedList,
 		"zoneDistributedNodePoolGroups": zoneDistributedNodePoolGroups,
-		"encryptForTaupage": func(kmsKeyARN string, contents string) (string, error) {
-			return encryptForTaupage(context.awsAdapter, kmsKeyARN, contents)
-		},
-		"certificateExpiry": certificateExpiry,
+		"certificateExpiry":             certificateExpiry,
 	}
 
 	content, ok := context.fileData[file]
@@ -665,15 +662,6 @@ func zoneDistributedNodePoolGroups(nodePools []*api.NodePool) map[string]bool {
 		}
 	}
 	return result
-}
-
-// encryptForTaupage encrypts the value of `contents` with the KMS key identified by `kmsKeyARN` with the scheme
-// compatible with Taupage (aws:kms:<encrypted>). If `contents` is empty, it'll return an empty string instead.
-func encryptForTaupage(adapter *awsAdapter, kmsKeyARN string, contents string) (string, error) {
-	if contents == "" {
-		return "", nil
-	}
-	return adapter.kmsEncryptForTaupage(kmsKeyARN, contents)
 }
 
 // certificateExpiry returns the notAfter timestamp of a PEM-encoded certificate in the RFC3339 format

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"time"
 
 	awsUtil "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -128,6 +129,7 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		"encryptForTaupage": func(kmsKeyARN string, contents string) (string, error) {
 			return encryptForTaupage(context.awsAdapter, kmsKeyARN, contents)
 		},
+		"certificateExpiry": certificateExpiry,
 	}
 
 	content, ok := context.fileData[file]
@@ -672,4 +674,13 @@ func encryptForTaupage(adapter *awsAdapter, kmsKeyARN string, contents string) (
 		return "", nil
 	}
 	return adapter.kmsEncryptForTaupage(kmsKeyARN, contents)
+}
+
+// certificateExpiry returns the notAfter timestamp of a PEM-encoded certificate in the RFC3339 format
+func certificateExpiry(certificate string) (string, error) {
+	expiry, err := certificateExpiryTime(certificate)
+	if err != nil {
+		return "", err
+	}
+	return expiry.UTC().Format(time.RFC3339), nil
 }

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -125,6 +125,9 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		"kubernetesSizeToKiloBytes":     kubernetesSizeToKiloBytes,
 		"indexedList":                   indexedList,
 		"zoneDistributedNodePoolGroups": zoneDistributedNodePoolGroups,
+		"encryptForTaupage": func(kmsKeyARN string, contents string) (string, error) {
+			return encryptForTaupage(context.awsAdapter, kmsKeyARN, contents)
+		},
 	}
 
 	content, ok := context.fileData[file]
@@ -660,4 +663,13 @@ func zoneDistributedNodePoolGroups(nodePools []*api.NodePool) map[string]bool {
 		}
 	}
 	return result
+}
+
+// encryptForTaupage encrypts the value of `contents` with the KMS key identified by `kmsKeyARN` with the scheme
+// compatible with Taupage (aws:kms:<encrypted>). If `contents` is empty, it'll return an empty string instead.
+func encryptForTaupage(adapter *awsAdapter, kmsKeyARN string, contents string) (string, error) {
+	if contents == "" {
+		return "", nil
+	}
+	return adapter.kmsEncryptForTaupage(kmsKeyARN, contents)
 }

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -883,58 +883,6 @@ func TestZoneDistributedNodePoolGroupsDefault(t *testing.T) {
 	}
 }
 
-func TestEncryptForTaupage(t *testing.T) {
-	for _, tc := range []struct {
-		name     string
-		payload  string
-		expected string
-		fail     bool
-	}{
-		{
-			name:     "encryption succeeds",
-			payload:  "test",
-			expected: "aws:kms:Zm9vYmFy",
-			fail:     false,
-		},
-		{
-			name:     "nothing to encrypt",
-			payload:  "",
-			expected: "",
-			fail:     false,
-		},
-		{
-			name:    "encryption fails",
-			payload: "test",
-			fail:    true,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			adapter := &awsAdapter{
-				kmsClient: mockKMSAPI{
-					expectedKeyID: "key-id",
-					expectedValue: []byte("test"),
-					encryptResult: []byte("foobar"),
-					fail:          tc.fail,
-				},
-			}
-
-			result, err := render(
-				t,
-				map[string]string{"foo.yaml": `{{ encryptForTaupage "key-id" .Values.data.payload }}`},
-				"foo.yaml",
-				map[string]interface{}{"payload": tc.payload},
-				adapter)
-
-			if tc.fail {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tc.expected, result)
-			}
-		})
-	}
-}
-
 func TestCertificateExpiry(t *testing.T) {
 	exampleCert := `-----BEGIN CERTIFICATE-----
 MIICoDCCAYgCCQCICOd8jmc77jANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdl

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -882,3 +882,55 @@ func TestZoneDistributedNodePoolGroupsDefault(t *testing.T) {
 		})
 	}
 }
+
+func TestEncryptForTaupage(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		payload  string
+		expected string
+		fail     bool
+	}{
+		{
+			name:     "encryption succeeds",
+			payload:  "test",
+			expected: "aws:kms:Zm9vYmFy",
+			fail:     false,
+		},
+		{
+			name:     "nothing to encrypt",
+			payload:  "",
+			expected: "",
+			fail:     false,
+		},
+		{
+			name:    "encryption fails",
+			payload: "test",
+			fail:    true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			adapter := &awsAdapter{
+				kmsClient: mockKMSAPI{
+					expectedKeyID: "key-id",
+					expectedValue: []byte("test"),
+					encryptResult: []byte("foobar"),
+					fail:          tc.fail,
+				},
+			}
+
+			result, err := render(
+				t,
+				map[string]string{"foo.yaml": `{{ encryptForTaupage "key-id" .Values.data.payload }}`},
+				"foo.yaml",
+				map[string]interface{}{"payload": tc.payload},
+				adapter)
+
+			if tc.fail {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, result)
+			}
+		})
+	}
+}

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -934,3 +934,26 @@ func TestEncryptForTaupage(t *testing.T) {
 		})
 	}
 }
+
+func TestCertificateExpiry(t *testing.T) {
+	exampleCert := `-----BEGIN CERTIFICATE-----
+MIICoDCCAYgCCQCICOd8jmc77jANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDDAdl
+eGFtcGxlMB4XDTIxMDYxMDEwMDY0M1oXDTIyMDYxMDEwMDY0M1owEjEQMA4GA1UE
+AwwHZXhhbXBsZTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMYr2Lsz
+Wm3I1GqxdqnuuXqT/SHWKv/CdGorE5nb1O6OBFibo0TJN8ztoooySqwF81Qh9Uwu
+mA5mkScdWJagqYlGsR+d1U3wuGmY9jSXdIn5VX0PUWD38MazT+s2kzZVg8Xu/CC8
+waBdQDZGKpJeO/z1LC8zoY9P3f3YuxmgQqzDfpJgzjSEaSqhgIDD7RCA3kngfzYP
+J3T+O54NpTNU5fZx437e7L643arZdB636yyV6dGz3ZV3WZw9TeLry6mf671BWvsN
+Ngkz0fmG1rNgzD7gwn6jTG29p5O9f3djX2oH2aHUb7ry+n40QmxVUM+JO3OgVg99
+ZV2jRxqfVNse61UCAwEAATANBgkqhkiG9w0BAQsFAAOCAQEAiLJJgKyP1aFJK+jL
+T3E9EZfiYzWE301DMzkhCDVcAEY8KNsugQPn/dNiAWcZB+JLEWby0LFyQcPVE5eu
+TLvNJLT6Iui7ITNC4bbrIqJxdKdeHX2Y/gj4j2mtHupiLHkJoLrahjAG8JrIDpMt
+MFsSQS6YJ87TjYgtlNlOLa+/k771rS9qG/uIK8+Ijx8Y3HYboS5zMVyMdELFufof
+0rjsnygpvicwVEyZU0d4sCVwyX3I9OtCUTI/CY/3UqqL2LhNEq3hYPNDFDJV9zXE
+T6qW9CgZFGg83VqV2Tz44pneTFzvbr7Kcvrhpe0Wr2Ed2zPsz5BSz194DopAdRYv
+CWeOoA==
+-----END CERTIFICATE-----`
+	res, err := renderSingle(t, `{{ certificateExpiry .Values.data.certificate }}`, map[string]interface{}{"certificate": exampleCert})
+	require.NoError(t, err)
+	require.Equal(t, "2022-06-10T10:06:43Z", res)
+}


### PR DESCRIPTION
The current state of our etcd stack is, uh, _less than ideal_. We still rely on `senza` to create the CloudFormation stack in the first place, and then never update it directly. Instead, we rely on a bunch of hacky scripts that run on our laptops and use ZMON as a data source. We also still rely on the Taupage AMI which has been deprecated and EOL'd a long time ago.

Let's slowly start migrating towards a more sane setup. This PR implements the logic to actually update the etcd CloudFormation stack with CLM. It's kinda hacky because we still have to be compatible with Taupage, but this would allow us to 1) drop `senza` completely and 2) implement the etcd node rotation as a cronjob running in the cluster without jumping through a bunch of hoops.

The new behaviour is enabled with a dedicated config item (`experimental_new_etcd_stack`), so this should be fairly safe to merge. In addition to that, management of etcd stacks in general (both creation and updates) is now disabled by default, and only enabled with a dedicated command-line argument (`--manage-etcd-stack`). This is mainly to allow for easy provisioning of pet clusters without running into tons of conflicts.