### PR TITLE
Print git status to debug version tag

### DIFF
--- a/delivery.yaml
+++ b/delivery.yaml
@@ -20,6 +20,7 @@ pipeline:
       make build.docker
   - desc: push
     cmd: |
+      git status
       if [[ $CDP_TARGET_BRANCH == master && ! $CDP_PULL_REQUEST_NUMBER ]]; then
         IMAGE=registry-write.opensource.zalan.do/teapot/cluster-lifecycle-manager
         VERSION=$(git describe --tags --always --dirty)


### PR DESCRIPTION
Version tag is generated based on the `git describe --tags --always --dirty`.
Starting from `9a6ffb4-dirty` it has `-dirty` suffix signalling that
working tree has local modification.

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>