### PR TITLE
Regenerates cluster-registry client

### DIFF
--- a/pkg/cluster-registry/client/clusters/list_clusters_responses.go
+++ b/pkg/cluster-registry/client/clusters/list_clusters_responses.go
@@ -199,6 +199,8 @@ func (o *ListClustersOKBody) validateItems(formats strfmt.Registry) error {
 			if err := o.Items[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("listClustersOK" + "." + "items" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("listClustersOK" + "." + "items" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -231,6 +233,8 @@ func (o *ListClustersOKBody) contextValidateItems(ctx context.Context, formats s
 			if err := o.Items[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("listClustersOK" + "." + "items" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("listClustersOK" + "." + "items" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/pkg/cluster-registry/client/infrastructure_accounts/list_infrastructure_accounts_responses.go
+++ b/pkg/cluster-registry/client/infrastructure_accounts/list_infrastructure_accounts_responses.go
@@ -199,6 +199,8 @@ func (o *ListInfrastructureAccountsOKBody) validateItems(formats strfmt.Registry
 			if err := o.Items[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("listInfrastructureAccountsOK" + "." + "items" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("listInfrastructureAccountsOK" + "." + "items" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -231,6 +233,8 @@ func (o *ListInfrastructureAccountsOKBody) contextValidateItems(ctx context.Cont
 			if err := o.Items[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("listInfrastructureAccountsOK" + "." + "items" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("listInfrastructureAccountsOK" + "." + "items" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/pkg/cluster-registry/client/node_pools/list_node_pools_responses.go
+++ b/pkg/cluster-registry/client/node_pools/list_node_pools_responses.go
@@ -199,6 +199,8 @@ func (o *ListNodePoolsOKBody) validateItems(formats strfmt.Registry) error {
 			if err := o.Items[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("listNodePoolsOK" + "." + "items" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("listNodePoolsOK" + "." + "items" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -231,6 +233,8 @@ func (o *ListNodePoolsOKBody) contextValidateItems(ctx context.Context, formats 
 			if err := o.Items[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("listNodePoolsOK" + "." + "items" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("listNodePoolsOK" + "." + "items" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/pkg/cluster-registry/models/cluster.go
+++ b/pkg/cluster-registry/models/cluster.go
@@ -298,6 +298,8 @@ func (m *Cluster) validateNodePools(formats strfmt.Registry) error {
 			if err := m.NodePools[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("node_pools" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("node_pools" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -335,6 +337,8 @@ func (m *Cluster) validateStatus(formats strfmt.Registry) error {
 		if err := m.Status.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("status")
 			}
 			return err
 		}
@@ -369,6 +373,8 @@ func (m *Cluster) contextValidateNodePools(ctx context.Context, formats strfmt.R
 			if err := m.NodePools[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("node_pools" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("node_pools" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -385,6 +391,8 @@ func (m *Cluster) contextValidateStatus(ctx context.Context, formats strfmt.Regi
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("status")
 			}
 			return err
 		}

--- a/pkg/cluster-registry/models/cluster_status.go
+++ b/pkg/cluster-registry/models/cluster_status.go
@@ -74,6 +74,8 @@ func (m *ClusterStatus) validateProblems(formats strfmt.Registry) error {
 			if err := m.Problems[i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("problems" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("problems" + "." + strconv.Itoa(i))
 				}
 				return err
 			}
@@ -106,6 +108,8 @@ func (m *ClusterStatus) contextValidateProblems(ctx context.Context, formats str
 			if err := m.Problems[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("problems" + "." + strconv.Itoa(i))
+				} else if ce, ok := err.(*errors.CompositeError); ok {
+					return ce.ValidateName("problems" + "." + strconv.Itoa(i))
 				}
 				return err
 			}

--- a/pkg/cluster-registry/models/cluster_update.go
+++ b/pkg/cluster-registry/models/cluster_update.go
@@ -160,6 +160,8 @@ func (m *ClusterUpdate) validateStatus(formats strfmt.Registry) error {
 		if err := m.Status.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("status")
 			}
 			return err
 		}
@@ -188,6 +190,8 @@ func (m *ClusterUpdate) contextValidateStatus(ctx context.Context, formats strfm
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("status")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("status")
 			}
 			return err
 		}


### PR DESCRIPTION
to avoid `-dirty` version suffix. See #544

```
rm -rf ./build/
make test
```

Signed-off-by: Alexander Yastrebov <alexander.yastrebov@zalando.de>