### PR TITLE
Fix error message related to amount of images found

### DIFF
--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -512,8 +512,11 @@ func amiID(adapter *awsAdapter, imageName, imageOwner string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to describe image with name %s and owner %s: %v", imageName, imageOwner, err)
 	}
-	if len(output.Images) != 1 {
+	if len(output.Images) > 1 {
 		return "", fmt.Errorf("more than one image found with name: %s and owner: %s", imageName, imageOwner)
+	}
+	if len(output.Images) == 0 {
+		return "", fmt.Errorf("no image found with name: %s and owner: %s", imageName, imageOwner)
 	}
 	return *output.Images[0].ImageId, nil
 }


### PR DESCRIPTION
If no image is found, the current error message indicates that
more than one image was found. The new if ensures a clear error
message.

Signed-off-by: Katyanna Moura <amelie.kn@gmail.com>