### PR TITLE
Support any region in AWS session

### DIFF
--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -700,7 +700,9 @@ func (p *clusterpyProvisioner) setupAWSAdapter(logger *log.Entry, cluster *api.C
 		roleArn = fmt.Sprintf("arn:aws:iam::%s:role/%s", infrastructureAccount[1], p.assumedRole)
 	}
 
-	sess, err := awsUtils.Session(p.awsConfig, roleArn)
+	awsConfig := p.awsConfig.Copy()
+	awsConfig.Region = aws.String(cluster.Region)
+	sess, err := awsUtils.Session(awsConfig, roleArn)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is a small fix which enables CLM to provision clusters in any region eventhough CLM itself may be running in one particular region.

This would allow deploying a cluster in another region in an EMPTY account. In order to run clusters in two regions in the same account some changes to the etcd setup is still needed.