### PR TITLE
Expose architecture of node pool to the templates

### DIFF
--- a/pkg/aws/instance_info.go
+++ b/pkg/aws/instance_info.go
@@ -155,12 +155,11 @@ func (types *InstanceTypes) SyntheticInstanceInfo(instanceTypes []string) (Insta
 func getCompatibleCPUArchitecture(instanceType *ec2.InstanceTypeInfo) (string, error) {
 	supportedArchitectures := aws.StringValueSlice(instanceType.ProcessorInfo.SupportedArchitectures)
 
-	if contains(supportedArchitectures, archARM64) {
-		return archARM64, nil
-	}
-
 	if contains(supportedArchitectures, archX86_64) {
 		return archAMD64, nil
+	}
+	if contains(supportedArchitectures, archARM64) {
+		return archARM64, nil
 	}
 
 	return "", fmt.Errorf("didn't find compatible cpu architecture within '%v'", supportedArchitectures)

--- a/pkg/aws/instance_info.go
+++ b/pkg/aws/instance_info.go
@@ -13,6 +13,10 @@ const (
 	mebibyte = 1024 * 1024
 
 	gigabyte = 1000 * 1000 * 1000
+
+	archX86_64 = "x86_64"
+	archAMD64  = "amd64"
+	archARM64  = "arm64"
 )
 
 type Instance struct {
@@ -21,6 +25,7 @@ type Instance struct {
 	Memory                    int64
 	InstanceStorageDevices    int64
 	InstanceStorageDeviceSize int64
+	Architecture              string
 }
 
 func (i Instance) AvailableStorage(instanceStorageScaleFactor float64, rootVolumeSize int64, rootVolumeScaleFactor float64) int64 {
@@ -67,12 +72,20 @@ func NewInstanceTypesFromAWS(ec2client ec2iface.EC2API) (*InstanceTypes, error) 
 				}
 			}
 
+			cpuArch, err := getCompatibleCPUArchitecture(instanceType)
+			if err != nil {
+				// Let's skip any instance types that we don't support.
+				log.Debug(err.Error())
+				continue
+			}
+
 			info := Instance{
 				InstanceType:              aws.StringValue(instanceType.InstanceType),
 				VCPU:                      aws.Int64Value(instanceType.VCpuInfo.DefaultVCpus),
 				Memory:                    aws.Int64Value(instanceType.MemoryInfo.SizeInMiB) * mebibyte,
 				InstanceStorageDevices:    deviceCount,
 				InstanceStorageDeviceSize: deviceSize,
+				Architecture:              cpuArch,
 			}
 			instances[info.InstanceType] = info
 		}
@@ -119,6 +132,7 @@ func (types *InstanceTypes) SyntheticInstanceInfo(instanceTypes []string) (Insta
 			Memory:                    first.Memory,
 			InstanceStorageDevices:    first.InstanceStorageDevices,
 			InstanceStorageDeviceSize: first.InstanceStorageDeviceSize,
+			Architecture:              first.Architecture,
 		}
 		for _, instanceType := range instanceTypes[1:] {
 			info, err := types.InstanceInfo(instanceType)
@@ -136,9 +150,34 @@ func (types *InstanceTypes) SyntheticInstanceInfo(instanceTypes []string) (Insta
 	}
 }
 
+// getCompatibleCPUArchitecture returns a single compatible CPU architecture. It's either `amd64` or `arm64`.
+// Other intance types might return 32-bit or macos specific types which will be ignored.
+func getCompatibleCPUArchitecture(instanceType *ec2.InstanceTypeInfo) (string, error) {
+	supportedArchitectures := aws.StringValueSlice(instanceType.ProcessorInfo.SupportedArchitectures)
+
+	if contains(supportedArchitectures, archARM64) {
+		return archARM64, nil
+	}
+
+	if contains(supportedArchitectures, archX86_64) {
+		return archAMD64, nil
+	}
+
+	return "", fmt.Errorf("didn't find compatible cpu architecture within '%v'", supportedArchitectures)
+}
+
 func min(a int64, b int64) int64 {
 	if a < b {
 		return a
 	}
 	return b
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/aws/instance_info_test.go
+++ b/pkg/aws/instance_info_test.go
@@ -26,7 +26,8 @@ func (mock *mockEC2) DescribeInstanceTypesPages(_ *ec2.DescribeInstanceTypesInpu
 				},
 				InstanceStorageInfo: &ec2.InstanceStorageInfo{},
 				ProcessorInfo: &ec2.ProcessorInfo{
-					SupportedArchitectures: []*string{aws.String("x86_64")},
+					// Test that unsupported architectures are correctly ignored.
+					SupportedArchitectures: []*string{aws.String("x86_64_mac"), aws.String("i386"), aws.String("x86_64")},
 				},
 			},
 			{
@@ -405,6 +406,26 @@ func TestSyntheticInstanceInfo(t *testing.T) {
 			instanceTypes: []string{"m6g.xlarge"},
 			expectedInstance: Instance{
 				InstanceType: "m6g.xlarge",
+				VCPU:         4,
+				Memory:       17179869184,
+				Architecture: "arm64",
+			},
+		},
+		{
+			name:          "multiple types, different architectures, amd64 architecture first",
+			instanceTypes: []string{"m5.xlarge", "m6g.xlarge"},
+			expectedInstance: Instance{
+				InstanceType: "<multiple>",
+				VCPU:         4,
+				Memory:       17179869184,
+				Architecture: "amd64",
+			},
+		},
+		{
+			name:          "multiple types, different architectures, arm64 architecture first",
+			instanceTypes: []string{"m6g.xlarge", "m5.xlarge"},
+			expectedInstance: Instance{
+				InstanceType: "<multiple>",
 				VCPU:         4,
 				Memory:       17179869184,
 				Architecture: "arm64",

--- a/pkg/aws/instance_info_test.go
+++ b/pkg/aws/instance_info_test.go
@@ -25,6 +25,9 @@ func (mock *mockEC2) DescribeInstanceTypesPages(_ *ec2.DescribeInstanceTypesInpu
 					SizeInMiB: aws.Int64(16384),
 				},
 				InstanceStorageInfo: &ec2.InstanceStorageInfo{},
+				ProcessorInfo: &ec2.ProcessorInfo{
+					SupportedArchitectures: []*string{aws.String("x86_64")},
+				},
 			},
 			{
 				InstanceType: aws.String("i3.4xlarge"),
@@ -42,6 +45,9 @@ func (mock *mockEC2) DescribeInstanceTypesPages(_ *ec2.DescribeInstanceTypesInpu
 						},
 					},
 				},
+				ProcessorInfo: &ec2.ProcessorInfo{
+					SupportedArchitectures: []*string{aws.String("x86_64")},
+				},
 			},
 			{
 				InstanceType: aws.String("m5.xlarge"),
@@ -52,6 +58,9 @@ func (mock *mockEC2) DescribeInstanceTypesPages(_ *ec2.DescribeInstanceTypesInpu
 					SizeInMiB: aws.Int64(16384),
 				},
 				InstanceStorageInfo: &ec2.InstanceStorageInfo{},
+				ProcessorInfo: &ec2.ProcessorInfo{
+					SupportedArchitectures: []*string{aws.String("x86_64")},
+				},
 			},
 			{
 				InstanceType: aws.String("m5d.4xlarge"),
@@ -68,6 +77,21 @@ func (mock *mockEC2) DescribeInstanceTypesPages(_ *ec2.DescribeInstanceTypesInpu
 							SizeInGB: aws.Int64(300),
 						},
 					},
+				},
+				ProcessorInfo: &ec2.ProcessorInfo{
+					SupportedArchitectures: []*string{aws.String("x86_64")},
+				},
+			},
+			{
+				InstanceType: aws.String("m6g.xlarge"),
+				VCpuInfo: &ec2.VCpuInfo{
+					DefaultVCpus: aws.Int64(4),
+				},
+				MemoryInfo: &ec2.MemoryInfo{
+					SizeInMiB: aws.Int64(16384),
+				},
+				ProcessorInfo: &ec2.ProcessorInfo{
+					SupportedArchitectures: []*string{aws.String("arm64")},
 				},
 			},
 		},
@@ -92,6 +116,9 @@ func (mock *mockEC2) DescribeInstanceTypesPages(_ *ec2.DescribeInstanceTypesInpu
 						},
 					},
 				},
+				ProcessorInfo: &ec2.ProcessorInfo{
+					SupportedArchitectures: []*string{aws.String("x86_64")},
+				},
 			},
 			{
 				InstanceType: aws.String("r5d.xlarge"),
@@ -108,6 +135,9 @@ func (mock *mockEC2) DescribeInstanceTypesPages(_ *ec2.DescribeInstanceTypesInpu
 							SizeInGB: aws.Int64(150),
 						},
 					},
+				},
+				ProcessorInfo: &ec2.ProcessorInfo{
+					SupportedArchitectures: []*string{aws.String("x86_64")},
 				},
 			},
 			{
@@ -126,6 +156,9 @@ func (mock *mockEC2) DescribeInstanceTypesPages(_ *ec2.DescribeInstanceTypesInpu
 						},
 					},
 				},
+				ProcessorInfo: &ec2.ProcessorInfo{
+					SupportedArchitectures: []*string{aws.String("x86_64")},
+				},
 			},
 			{
 				InstanceType: aws.String("r5d.large"),
@@ -142,6 +175,9 @@ func (mock *mockEC2) DescribeInstanceTypesPages(_ *ec2.DescribeInstanceTypesInpu
 							SizeInGB: aws.Int64(75),
 						},
 					},
+				},
+				ProcessorInfo: &ec2.ProcessorInfo{
+					SupportedArchitectures: []*string{aws.String("x86_64")},
 				},
 			},
 		},
@@ -193,6 +229,7 @@ func TestInstanceInfoFromAWS(t *testing.T) {
 			InstanceType: "m4.xlarge",
 			VCPU:         4,
 			Memory:       17179869184,
+			Architecture: "amd64",
 		},
 		{
 			InstanceType:              "i3.4xlarge",
@@ -200,6 +237,13 @@ func TestInstanceInfoFromAWS(t *testing.T) {
 			Memory:                    130996502528,
 			InstanceStorageDevices:    2,
 			InstanceStorageDeviceSize: 1900 * 1000 * 1000 * 1000,
+			Architecture:              "amd64",
+		},
+		{
+			InstanceType: "m6g.xlarge",
+			VCPU:         4,
+			Memory:       17179869184,
+			Architecture: "arm64",
 		},
 	} {
 		t.Run(tc.InstanceType, func(t *testing.T) {
@@ -210,6 +254,7 @@ func TestInstanceInfoFromAWS(t *testing.T) {
 			require.Equal(t, tc.Memory, info.Memory)
 			require.Equal(t, tc.InstanceStorageDevices, info.InstanceStorageDevices)
 			require.Equal(t, tc.InstanceStorageDeviceSize, info.InstanceStorageDeviceSize)
+			require.Equal(t, tc.Architecture, info.Architecture)
 		})
 	}
 }
@@ -235,6 +280,7 @@ func TestSyntheticInstanceInfo(t *testing.T) {
 			Memory:                    17179869184,
 			InstanceStorageDevices:    0,
 			InstanceStorageDeviceSize: 0,
+			Architecture:              "amd64",
 		},
 		{
 			InstanceType:              "m5.xlarge",
@@ -242,6 +288,7 @@ func TestSyntheticInstanceInfo(t *testing.T) {
 			Memory:                    17179869184,
 			InstanceStorageDevices:    0,
 			InstanceStorageDeviceSize: 0,
+			Architecture:              "amd64",
 		},
 		{
 			InstanceType:              "m5d.xlarge",
@@ -249,6 +296,7 @@ func TestSyntheticInstanceInfo(t *testing.T) {
 			Memory:                    17179869184,
 			InstanceStorageDevices:    1,
 			InstanceStorageDeviceSize: 161061273600,
+			Architecture:              "amd64",
 		},
 		{
 			InstanceType:              "m5d.4xlarge",
@@ -256,6 +304,7 @@ func TestSyntheticInstanceInfo(t *testing.T) {
 			Memory:                    68719476736,
 			InstanceStorageDevices:    2,
 			InstanceStorageDeviceSize: 322122547200,
+			Architecture:              "amd64",
 		},
 		{
 			InstanceType:              "c5d.xlarge",
@@ -263,6 +312,7 @@ func TestSyntheticInstanceInfo(t *testing.T) {
 			Memory:                    8589934592,
 			InstanceStorageDevices:    1,
 			InstanceStorageDeviceSize: 107374182400,
+			Architecture:              "amd64",
 		},
 		{
 			InstanceType:              "r5d.large",
@@ -270,6 +320,13 @@ func TestSyntheticInstanceInfo(t *testing.T) {
 			Memory:                    17179869184,
 			InstanceStorageDevices:    1,
 			InstanceStorageDeviceSize: 80530636800,
+			Architecture:              "amd64",
+		},
+		{
+			InstanceType: "m6g.xlarge",
+			VCPU:         4,
+			Memory:       17179869184,
+			Architecture: "arm64",
 		},
 	})
 
@@ -286,6 +343,7 @@ func TestSyntheticInstanceInfo(t *testing.T) {
 				InstanceType: "m4.xlarge",
 				VCPU:         4,
 				Memory:       17179869184,
+				Architecture: "amd64",
 			},
 		},
 		{
@@ -317,6 +375,7 @@ func TestSyntheticInstanceInfo(t *testing.T) {
 				Memory:                    8589934592,
 				InstanceStorageDevices:    1,
 				InstanceStorageDeviceSize: 75 * 1024 * mebibyte,
+				Architecture:              "amd64",
 			},
 		},
 		{
@@ -328,6 +387,7 @@ func TestSyntheticInstanceInfo(t *testing.T) {
 				Memory:                    17179869184,
 				InstanceStorageDevices:    1,
 				InstanceStorageDeviceSize: 150 * 1024 * mebibyte,
+				Architecture:              "amd64",
 			},
 		},
 		{
@@ -337,6 +397,17 @@ func TestSyntheticInstanceInfo(t *testing.T) {
 				InstanceType: "<multiple>",
 				VCPU:         4,
 				Memory:       17179869184,
+				Architecture: "amd64",
+			},
+		},
+		{
+			name:          "one type with arm64",
+			instanceTypes: []string{"m6g.xlarge"},
+			expectedInstance: Instance{
+				InstanceType: "m6g.xlarge",
+				VCPU:         4,
+				Memory:       17179869184,
+				Architecture: "arm64",
 			},
 		},
 	} {
@@ -351,6 +422,7 @@ func TestSyntheticInstanceInfo(t *testing.T) {
 				require.Equal(t, tc.expectedInstance.Memory, info.Memory)
 				require.Equal(t, tc.expectedInstance.InstanceStorageDevices, info.InstanceStorageDevices)
 				require.Equal(t, tc.expectedInstance.InstanceStorageDeviceSize, info.InstanceStorageDeviceSize)
+				require.Equal(t, tc.expectedInstance.Architecture, info.Architecture)
 			}
 		})
 	}

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -118,6 +118,9 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		"amiID": func(imageName, imageOwner string) (string, error) {
 			return amiID(context.awsAdapter, imageName, imageOwner)
 		},
+		"amiIDWithArch": func(architecture, imageName, imageOwner string) (string, error) {
+			return amiID(context.awsAdapter, strings.ReplaceAll(imageName, "$ARCH", architecture), imageOwner)
+		},
 		"nodeCIDRMaxNodes":              nodeCIDRMaxNodes,
 		"nodeCIDRMaxPods":               nodeCIDRMaxPods,
 		"parseInt64":                    parseInt64,

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -118,9 +118,6 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		"amiID": func(imageName, imageOwner string) (string, error) {
 			return amiID(context.awsAdapter, imageName, imageOwner)
 		},
-		"amiIDWithArch": func(architecture, imageName, imageOwner string) (string, error) {
-			return amiID(context.awsAdapter, strings.ReplaceAll(imageName, "$ARCH", architecture), imageOwner)
-		},
 		"nodeCIDRMaxNodes":              nodeCIDRMaxNodes,
 		"nodeCIDRMaxPods":               nodeCIDRMaxPods,
 		"parseInt64":                    parseInt64,


### PR DESCRIPTION
~~This adds a template function called `amiIDWithArch` that works similar to `amdID` in that it finds an AMI ID (`ami-364sgy3` etc.) from a nicer name and an account ID.~~

Since different CPU architectures require different AMIs and different AMIs need to be called differently ~~, this function was added.~~

~~It takes an additional parameter that contains the architecture of the node pool and replaces any occurrence of `$ARCH` in the AMI's name with that value. If no such variable is defined then this works similar to `amiID`.~~

For intended usage, see this PR: https://github.com/zalando-incubator/kubernetes-on-aws/pull/5200

In a nutshell: You set the AMI similar to how we currently do it:

```yaml
kuberuntu_image_v1_21_amd64: {{ amiID zalando-ubuntu-kubernetes-production-v1.21.12-amd64-master-229 "<owner>" }}
kuberuntu_image_v1_21_arm64: {{ amiID zalando-ubuntu-kubernetes-production-v1.21.12-arm64-master-229 "<owner>" }}
```

~~The only difference is that it's not within `{{ }}` so the default is the string an not the already resolved AMI ID. This also makes it easier to overwrite the AMI in a node pool's config item because you can (must) use the name.~~

~~Secondly it contains an _optional_ `$ARCH` variable that's substituted with the node pool's architecture and works well with our new naming scheme at https://github.bus.zalan.do/teapot/kubernetes-on-ubuntu. Not specifying `$ARCH` will leave the string as is which should make the migration easy.~~

The only addition of this PR now is that it adds an `.Architecture` field to the `InstanceType` that is available in the templates. It can be used to pick the right config item (shown above) for the node pool.