### PR TITLE
Introduce sumQuantities template function

### DIFF
--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -127,6 +127,7 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		"indexedList":                   indexedList,
 		"zoneDistributedNodePoolGroups": zoneDistributedNodePoolGroups,
 		"certificateExpiry":             certificateExpiry,
+		"sumQuantities":                 sumQuantities,
 	}
 
 	content, ok := context.fileData[file]
@@ -674,4 +675,17 @@ func certificateExpiry(certificate string) (string, error) {
 		return "", err
 	}
 	return expiry.UTC().Format(time.RFC3339), nil
+}
+
+func sumQuantities(quantities ...string) (string, error) {
+	var result k8sresource.Quantity
+	for _, quantity := range quantities {
+		q, err := k8sresource.ParseQuantity(quantity)
+		if err != nil {
+			return "", err
+		}
+		result.Add(q)
+	}
+
+	return result.String(), nil
 }

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -905,3 +905,53 @@ CWeOoA==
 	require.NoError(t, err)
 	require.Equal(t, "2022-06-10T10:06:43Z", res)
 }
+
+func TestSubQuantity(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		template string
+		expected string
+	}{
+		{
+			name:     "whole CPU add fraction",
+			template: `{{ sumQuantities "2" "256m" }}`,
+			expected: "2256m",
+		},
+		{
+			name:     "whole CPU add fraction sub whole",
+			template: `{{ sumQuantities "2" "256m" "-1" }}`,
+			expected: "1256m",
+		},
+		{
+			name:     "whole CPU add fraction add whole",
+			template: `{{ sumQuantities "2" "256m" "1" }}`,
+			expected: "3256m",
+		},
+		{
+			name:     "whole CPU sub fraction",
+			template: `{{ sumQuantities "2" "-256m" }}`,
+			expected: "1744m",
+		},
+		{
+			name:     "whole CPU sub fraction sub whole CPU",
+			template: `{{ sumQuantities "2" "-256m" "-1" }}`,
+			expected: "744m",
+		},
+		{
+			name:     "Gi sub Mi",
+			template: `{{ sumQuantities "2Gi" "-512Mi" }}`,
+			expected: "1536Mi",
+		},
+		{
+			name:     "Gi sub Ki",
+			template: `{{ sumQuantities "2Gi" "-1024Ki" }}`,
+			expected: "2047Mi",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := renderSingle(t, tc.template, nil)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, res)
+		})
+	}
+}


### PR DESCRIPTION
This introduces a ~`subQuantity`~ `sumQuantities` template function which can take any number of Quantity type arguments and ~subtract~ sum them ~from each other~.

Example: You have 1 CPU and want to subtract some milicores: `sumQuantities "1" "- 518m" "-10m" = "472m"`

It is needed for this: https://github.com/zalando-incubator/kubernetes-on-aws/pull/5212