### PR TITLE
Update etcd stack handling.

### DIFF
--- a/channel/combined.go
+++ b/channel/combined.go
@@ -116,6 +116,14 @@ func (c *combinedConfig) StackManifest(manifestName string) (Manifest, error) {
 	return mainConfig.StackManifest(manifestName)
 }
 
+func (c *combinedConfig) EtcdManifest(manifestName string) (Manifest, error) {
+	mainConfig, err := c.mainConfig()
+	if err != nil {
+		return Manifest{}, err
+	}
+	return mainConfig.EtcdManifest(manifestName)
+}
+
 func (c *combinedConfig) NodePoolManifest(profileName string, manifestName string) (Manifest, error) {
 	mainConfig, err := c.mainConfig()
 	if err != nil {

--- a/channel/combined_test.go
+++ b/channel/combined_test.go
@@ -58,6 +58,7 @@ func TestCombinedSource(t *testing.T) {
 			"cluster/manifests/example2/deployment.yaml": "example2-deployment-main",
 			"cluster/manifests/deletions.yaml":           "deletions",
 			"cluster/node-pools/example/main.yaml":       "node-pool",
+			"cluster/etcd/stack.yaml":       			  "etcd",
 			"cluster/config-defaults.yaml":               "defaults",
 			"cluster/stack.yaml":                         "stack",
 		})
@@ -85,6 +86,10 @@ func TestCombinedSource(t *testing.T) {
 	stack, err := config.StackManifest("stack.yaml")
 	require.NoError(t, err)
 	require.Equal(t, expectedManifest("main", "cluster/stack.yaml", "stack"), stack)
+
+	etcdStack, err := config.EtcdManifest("stack.yaml")
+	require.NoError(t, err)
+	require.Equal(t, expectedManifest("main", "cluster/etcd/stack.yaml", "etcd"), etcdStack)
 
 	pool, err := config.NodePoolManifest("example", "main.yaml")
 	require.NoError(t, err)

--- a/channel/combined_test.go
+++ b/channel/combined_test.go
@@ -58,7 +58,7 @@ func TestCombinedSource(t *testing.T) {
 			"cluster/manifests/example2/deployment.yaml": "example2-deployment-main",
 			"cluster/manifests/deletions.yaml":           "deletions",
 			"cluster/node-pools/example/main.yaml":       "node-pool",
-			"cluster/etcd/stack.yaml":       			  "etcd",
+			"cluster/etcd/stack.yaml":                    "etcd",
 			"cluster/config-defaults.yaml":               "defaults",
 			"cluster/stack.yaml":                         "stack",
 		})

--- a/channel/config_source.go
+++ b/channel/config_source.go
@@ -40,6 +40,7 @@ type Component struct {
 
 type Config interface {
 	StackManifest(manifestName string) (Manifest, error)
+	EtcdManifest(manifestName string) (Manifest, error)
 	NodePoolManifest(profileName string, manifestName string) (Manifest, error)
 	DefaultsManifests() ([]Manifest, error)
 	DeletionsManifests() ([]Manifest, error)

--- a/channel/simple_config.go
+++ b/channel/simple_config.go
@@ -1,7 +1,6 @@
 package channel
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -37,7 +36,7 @@ func NewSimpleConfig(sourceName string, baseDir string, allowDelete bool) (*Simp
 
 func (c *SimpleConfig) readManifest(manifestDirectory string, name string) (Manifest, error) {
 	filePath := path.Join(c.baseDir, manifestDirectory, name)
-	res, err := ioutil.ReadFile(filePath)
+	res, err := os.ReadFile(filePath)
 	if err != nil {
 		return Manifest{}, err
 	}
@@ -85,7 +84,7 @@ func (c *SimpleConfig) Components() ([]Component, error) {
 	var result []Component
 
 	componentsDir := path.Join(c.baseDir, configRoot, manifestsDir)
-	components, err := ioutil.ReadDir(componentsDir)
+	components, err := os.ReadDir(componentsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
@@ -100,7 +99,7 @@ func (c *SimpleConfig) Components() ([]Component, error) {
 		var manifests []Manifest
 
 		componentDir := path.Join(componentsDir, component.Name())
-		files, err := ioutil.ReadDir(componentDir)
+		files, err := os.ReadDir(componentDir)
 		if err != nil {
 			return nil, err
 		}

--- a/channel/simple_config.go
+++ b/channel/simple_config.go
@@ -11,6 +11,7 @@ import (
 const (
 	configRoot    = "cluster"
 	poolConfigDir = "node-pools"
+	etcdConfigDir = "etcd"
 	defaultsFile  = "config-defaults.yaml"
 	manifestsDir  = "manifests"
 	deletionsFile = "deletions.yaml"
@@ -48,6 +49,10 @@ func (c *SimpleConfig) readManifest(manifestDirectory string, name string) (Mani
 
 func (c *SimpleConfig) StackManifest(manifestName string) (Manifest, error) {
 	return c.readManifest(configRoot, manifestName)
+}
+
+func (c *SimpleConfig) EtcdManifest(manifestName string) (Manifest, error) {
+	return c.readManifest(path.Join(configRoot, etcdConfigDir), manifestName)
 }
 
 func (c *SimpleConfig) NodePoolManifest(profileName string, manifestName string) (Manifest, error) {

--- a/channel/test_util.go
+++ b/channel/test_util.go
@@ -1,7 +1,6 @@
 package channel
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -10,7 +9,7 @@ import (
 )
 
 func createTempDir(t *testing.T) string {
-	res, err := ioutil.TempDir("", t.Name())
+	res, err := os.MkdirTemp("", t.Name())
 	require.NoError(t, err)
 	return res
 }
@@ -37,7 +36,7 @@ func setupConfig(t *testing.T, baseDir string, manifests map[string]string) {
 		err := os.MkdirAll(path.Dir(fullpath), 0755)
 		require.NoError(t, err)
 
-		err = ioutil.WriteFile(fullpath, []byte(contents), 0644)
+		err = os.WriteFile(fullpath, []byte(contents), 0644)
 		require.NoError(t, err)
 	}
 }

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -144,6 +144,10 @@ func (c *mockConfig) StackManifest(manifestName string) (channel.Manifest, error
 	return c.mockManifest, nil
 }
 
+func (c *mockConfig) EtcdManifest(manifestName string) (channel.Manifest, error) {
+	return c.mockManifest, nil
+}
+
 func (c *mockConfig) NodePoolManifest(profileName string, manifestName string) (channel.Manifest, error) {
 	return c.mockManifest, nil
 }

--- a/pkg/credentials-loader/platformiam/file.go
+++ b/pkg/credentials-loader/platformiam/file.go
@@ -2,7 +2,7 @@ package platformiam
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"time"
 
@@ -43,7 +43,7 @@ type tokenSource source
 type clientCredentialsSource source
 
 func readFileContent(path string) (string, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/credentials-loader/platformiam/file_test.go
+++ b/pkg/credentials-loader/platformiam/file_test.go
@@ -1,7 +1,6 @@
 package platformiam
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -17,13 +16,13 @@ var (
 )
 
 func CreateTempTokenFiles() {
-	_ = ioutil.WriteFile("foo-token-type", []byte("Bearer"), 0644)
-	_ = ioutil.WriteFile("foo-token-secret", []byte(testToken), 0644)
+	_ = os.WriteFile("foo-token-type", []byte("Bearer"), 0644)
+	_ = os.WriteFile("foo-token-secret", []byte(testToken), 0644)
 }
 
 func CreateTempClientCredentialsFiles() {
-	_ = ioutil.WriteFile("bar-client-secret", []byte("HksjnJHhhjshd"), 0644)
-	_ = ioutil.WriteFile("bar-client-id", []byte("foo-bar"), 0644)
+	_ = os.WriteFile("bar-client-secret", []byte("HksjnJHhhjshd"), 0644)
+	_ = os.WriteFile("bar-client-id", []byte("foo-bar"), 0644)
 }
 
 func DeleteTempTokenFiles() {

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	providerID                         = "zalando-aws"
-	etcdStackFileName                  = "etcd-stack.yaml"
+	etcdStackFileName                  = "stack.yaml"
 	clusterStackFileName               = "cluster.yaml"
 	etcdStackName                      = "etcd-cluster-etcd"
 	defaultNamespace                   = "default"
@@ -391,7 +391,7 @@ func (p *clusterpyProvisioner) Provision(ctx context.Context, logger *log.Entry,
 }
 
 func createOrUpdateEtcdStack(ctx context.Context, config channel.Config, cluster *api.Cluster, values map[string]interface{}, etcdKmsKeyARN string, adapter *awsAdapter) error {
-	template, err := config.StackManifest(etcdStackFileName)
+	template, err := config.EtcdManifest(etcdStackFileName)
 	if err != nil {
 		return err
 	}

--- a/provisioner/clusterpy_test.go
+++ b/provisioner/clusterpy_test.go
@@ -282,6 +282,10 @@ func (c *mockConfig) StackManifest(manifestName string) (channel.Manifest, error
 	return channel.Manifest{}, errors.New("unsupported: StackManifest")
 }
 
+func (c *mockConfig) EtcdManifest(manifestName string) (channel.Manifest, error) {
+	return channel.Manifest{}, errors.New("unsupported: EtcdManifest")
+}
+
 func (c *mockConfig) NodePoolManifest(profileName string, manifestName string) (channel.Manifest, error) {
 	return channel.Manifest{}, errors.New("unsupported: NodePoolManifest")
 }

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -332,24 +332,26 @@ type SGIngressRange struct {
 //
 // "10.0.0.0/8:4180-4181,0.0.0.0/0:4190,udp:0.0.0.0/0:53" would result in the ingress ranges:
 // [
-//   {
-//     CIDR: "10.0.0.0/8",
-//     FromPort: 4180,
-//     ToPort: 4181,
-//     Protocol: "tcp",
-//   },
-//   {
-//     CIDR: "0.0.0.0/0",
-//     FromPort: 4190,
-//     ToPort: 4190,
-//     Protocol: "tcp",
-//   },
-//   {
-//     CIDR: "0.0.0.0/0",
-//     FromPort: 53,
-//     ToPort: 53,
-//     Protocol: "udp",
-//   },
+//
+//	{
+//	  CIDR: "10.0.0.0/8",
+//	  FromPort: 4180,
+//	  ToPort: 4181,
+//	  Protocol: "tcp",
+//	},
+//	{
+//	  CIDR: "0.0.0.0/0",
+//	  FromPort: 4190,
+//	  ToPort: 4190,
+//	  Protocol: "tcp",
+//	},
+//	{
+//	  CIDR: "0.0.0.0/0",
+//	  FromPort: 53,
+//	  ToPort: 53,
+//	  Protocol: "udp",
+//	},
+//
 // ]
 func sgIngressRanges(ranges string) ([]SGIngressRange, error) {
 	rangesL := strings.Split(ranges, ",")
@@ -639,9 +641,10 @@ func poolsDistributed(dedicated string, pools []*api.NodePool) bool {
 
 // azDistributedNodePoolGroups returns a list of node pool groups (using the dedicated label) that are safe to use
 // with even pod spreading. Currently this is the case iff all node pools with this dedicated label
-//  - are correctly configured with regards to the labels and taints
-//  - don't have AZ restrictions
-//  - use the worker-splitaz profile.
+//   - are correctly configured with regards to the labels and taints
+//   - don't have AZ restrictions
+//   - use the worker-splitaz profile.
+//
 // The default pool is represented with an empty string as the key.
 func zoneDistributedNodePoolGroups(nodePools []*api.NodePool) map[string]bool {
 	poolGroups := make(map[string][]*api.NodePool)

--- a/registry/file.go
+++ b/registry/file.go
@@ -2,7 +2,7 @@ package registry
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
@@ -28,7 +28,7 @@ func NewFileRegistry(filePath string) Registry {
 }
 
 func (r *fileRegistry) ListClusters(filter Filter) ([]*api.Cluster, error) {
-	fileContent, err := ioutil.ReadFile(r.filePath)
+	fileContent, err := os.ReadFile(r.filePath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Updates handling of the ETCD stack. Adds a method to get the ETCD manifest from the updated location (see https://github.com/zalando-incubator/kubernetes-on-aws/pull/5321).

Additionally fixes some linting issue, mostly related with `io/ioutil` package.

We can only merge this Pull Request after https://github.com/zalando-incubator/kubernetes-on-aws/pull/5321 is merged/applied to `stable`.

Signed-off-by: rreis <rodrigo@zalando.de>