### PR TITLE
Fix missing KMS key from node pools.

### DIFF
--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -234,6 +234,11 @@ func (p *AWSNodePoolProvisioner) prepareCloudInit(nodePool *api.NodePool, values
 		poolKind = "worker"
 	}
 
+	kmsKey, err := getPKIKMSKey(p.awsAdapter, p.cluster.LocalID, keyName)
+	if err != nil {
+		return "", err
+	}
+
 	renderer := &FilesRenderer{
 		awsAdapter: p.awsAdapter,
 		cluster:    p.cluster,
@@ -242,7 +247,7 @@ func (p *AWSNodePoolProvisioner) prepareCloudInit(nodePool *api.NodePool, values
 		nodePool:   nodePool,
 	}
 
-	s3Path, err := renderer.RenderAndUploadFiles(values, p.bucketName, keyName)
+	s3Path, err := renderer.RenderAndUploadFiles(values, p.bucketName, kmsKey)
 	if err != nil {
 		return "", err
 	}

--- a/provisioner/remote_files.go
+++ b/provisioner/remote_files.go
@@ -32,11 +32,6 @@ func (f *FilesRenderer) RenderAndUploadFiles(
 	bucketName string,
 	kmsKey string,
 ) (string, error) {
-
-	if !strings.HasPrefix(kmsKey, kmsKeyPrefix) {
-		return "", fmt.Errorf("invalid KMS key: %s", kmsKey)
-	}
-
 	var (
 		manifest channel.Manifest
 		err      error
@@ -90,6 +85,10 @@ func (f *FilesRenderer) RenderAndUploadFiles(
 }
 
 func makeArchive(input string, kmsKey string, kmsClient kmsiface.KMSAPI) ([]byte, error) {
+	if !strings.HasPrefix(kmsKey, kmsKeyPrefix) {
+		return nil, fmt.Errorf("invalid KMS key: %s", kmsKey)
+	}
+
 	var data remoteData
 	err := yaml.UnmarshalStrict([]byte(input), &data)
 	if err != nil {

--- a/provisioner/remote_files.go
+++ b/provisioner/remote_files.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"path"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
@@ -15,6 +16,8 @@ import (
 	"github.com/zalando-incubator/cluster-lifecycle-manager/channel"
 	"gopkg.in/yaml.v2"
 )
+
+const kmsKeyPrefix = "arn:aws:kms"
 
 type FilesRenderer struct {
 	awsAdapter *awsAdapter
@@ -29,6 +32,10 @@ func (f *FilesRenderer) RenderAndUploadFiles(
 	bucketName string,
 	kmsKey string,
 ) (string, error) {
+
+	if !strings.HasPrefix(kmsKey, kmsKeyPrefix) {
+		return "", fmt.Errorf("invalid KMS key: %s", kmsKey)
+	}
 
 	var (
 		manifest channel.Manifest

--- a/provisioner/remote_files_test.go
+++ b/provisioner/remote_files_test.go
@@ -132,7 +132,7 @@ func TestRenderAndUploadFiles(t *testing.T) {
 		s3Location, err := renderer.RenderAndUploadFiles(
 			map[string]interface{}{},
 			testBucket,
-			"test-key",
+			"arn:aws:kms:eu-central-1:xxxxxx:key/97sdhf9hsd978f",
 		)
 
 		if err != nil {

--- a/provisioner/remote_files_test.go
+++ b/provisioner/remote_files_test.go
@@ -174,7 +174,11 @@ func TestMakeArchive(t *testing.T) {
 	} {
 		t.Run(tc.Message, func(tt *testing.T) {
 			testKMSClient := &testKMSClient{}
-			archive, err := makeArchive(makeTestInput(tc.Path, tc.Data, tc.Permissions, tc.Encrypted), "test-key", testKMSClient)
+			archive, err := makeArchive(
+				makeTestInput(tc.Path, tc.Data, tc.Permissions, tc.Encrypted),
+				"arn:aws:kms:eu-central-1:xxxxxx:key/97sdhf9hsd978f",
+				testKMSClient,
+			)
 			require.NoError(t, err)
 			buffer := bytes.NewBuffer(archive)
 			gzr, err := gzip.NewReader(buffer)


### PR DESCRIPTION
This PR fixes getting the KMS Key for node pools, which was missing from https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/608

Signed-off-by: rreis <rodrigo@zalando.de>