### PR TITLE
Create S3 bucket before creating etcd stack.

### DIFF
--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -144,12 +144,6 @@ func (a *awsAdapter) VerifyAccount(accountID string) error {
 func (a *awsAdapter) applyClusterStack(stackName, stackTemplate string, cluster *api.Cluster, s3BucketName string) error {
 	var templateURL string
 	if len(stackTemplate) > stackMaxSize {
-		// create S3 bucket if it doesn't exist
-		err := a.createS3Bucket(s3BucketName)
-		if err != nil {
-			return err
-		}
-
 		// Upload the stack template to S3
 		result, err := a.s3Uploader.Upload(&s3manager.UploadInput{
 			Bucket: aws.String(s3BucketName),

--- a/provisioner/aws_test.go
+++ b/provisioner/aws_test.go
@@ -288,7 +288,7 @@ func TestGetDefaultVPC(t *testing.T) {
 }
 
 func TestCreateS3Client(t *testing.T) {
-	var tests = [] struct {
+	var tests = []struct {
 		bucketName string
 	}{
 		{""},

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -292,9 +292,13 @@ func (p *clusterpyProvisioner) Provision(ctx context.Context, logger *log.Entry,
 		return err
 	}
 
-	// create bucket name with aws account ID to ensure uniqueness across
-	// accounts.
+	// create S3 bucket with AWS account ID to ensure uniqueness across
+	// accounts
 	bucketName := fmt.Sprintf(clmCFBucketPattern, strings.TrimPrefix(cluster.InfrastructureAccount, "aws:"), cluster.Region)
+	err = awsAdapter.createS3Bucket(bucketName)
+	if err != nil {
+		return err
+	}
 
 	// create or update the etcd stack
 	if p.manageEtcdStack {


### PR DESCRIPTION
 The etcd provisioner function uploads the certificates to S3, therefore the CLM S3 bucket needs to exist _before_ creating the etcd cluster.

Signed-off-by: rreis <rodrigo@zalando.de>