### PR TITLE
Revert "Remove Taupage specific code."

### DIFF
--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -3,6 +3,7 @@ package provisioner
 import (
 	"context"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
@@ -480,6 +481,18 @@ func (a *awsAdapter) resolveKeyID(keyID string) (string, error) {
 	}
 
 	return aws.StringValue(output.KeyMetadata.Arn), nil
+}
+
+// kmsEncryptForTaupage encrypts a string using a Taupage-compatible format (aws:kms:…)
+func (a *awsAdapter) kmsEncryptForTaupage(keyID string, value string) (string, error) {
+	output, err := a.kmsClient.Encrypt(&kms.EncryptInput{
+		KeyId:     aws.String(keyID),
+		Plaintext: []byte(value),
+	})
+	if err != nil {
+		return "", err
+	}
+	return "aws:kms:" + base64.StdEncoding.EncodeToString(output.CiphertextBlob), nil
 }
 
 // createS3Bucket creates an s3 bucket if it doesn't exist.

--- a/provisioner/aws_test.go
+++ b/provisioner/aws_test.go
@@ -537,6 +537,42 @@ func (mock mockKMSAPI) DescribeKey(input *kms.DescribeKeyInput) (*kms.DescribeKe
 	}, nil
 }
 
+func TestKMSEncryptForTaupage(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		fail bool
+	}{
+		{
+			name: "encryption succeeds",
+			fail: false,
+		},
+		{
+			name: "encryption fails",
+			fail: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			adapter := awsAdapter{
+				kmsClient: mockKMSAPI{
+					expectedKeyID: "key-id",
+					expectedValue: []byte("test"),
+					encryptResult: []byte("foobar"),
+					fail:          tc.fail,
+				},
+			}
+
+			result, err := adapter.kmsEncryptForTaupage("key-id", "test")
+
+			if tc.fail {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, "aws:kms:Zm9vYmFy", result)
+			}
+		})
+	}
+}
+
 func TestKMSKeyARN(t *testing.T) {
 	for _, tc := range []struct {
 		name string

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -411,6 +411,11 @@ func createOrUpdateEtcdStack(
 	}
 
 	values = util.CopyValues(values)
+	err = populateEncryptedEtcdValues(adapter, cluster, etcdKmsKeyARN, values)
+	if err != nil {
+		return err
+	}
+
 	renderer := &FilesRenderer{
 		awsAdapter: adapter,
 		cluster:    cluster,

--- a/provisioner/legacy_etcd.go
+++ b/provisioner/legacy_etcd.go
@@ -1,0 +1,135 @@
+package provisioner
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
+	yaml "gopkg.in/yaml.v2"
+)
+
+// populateEncryptedEtcdValues is a horrible hack that is needed to avoid doing an update of the Taupage-based CloudFormation stack every time
+// we run. Unfortunately it's pretty much unavoidable because we rely on the KMS-encrypted config items inside the launch template, and if we
+// didn't do this, every run would create new ciphertext for the same plaintext value and then trigger a rolling update. We can drop it and switch
+// to a saner scheme (same as what we do with Kubernetes) once we migrate away from Taupage, and then this whole mess can be dropped.
+func populateEncryptedEtcdValues(adapter *awsAdapter, cluster *api.Cluster, etcdKMSKeyARN string, values map[string]interface{}) error {
+	stack, err := adapter.getStackByName(etcdStackName)
+	if err != nil && !isDoesNotExistsErr(err) {
+		return err
+	}
+
+	// Some config items are stored as encoded, some not. Since this whole thing is _very_ temporary, let's just manually
+	// convert them into the correct representation instead of coming up with weird template functions.
+	etcdConfigItems := map[string]string{}
+	for ci, encoded := range map[string]bool{
+		"etcd_scalyr_key":         false,
+		"etcd_client_server_cert": true,
+		"etcd_client_server_key":  true,
+		"etcd_client_ca_cert":     true,
+	} {
+		currentValue := cluster.ConfigItems[ci]
+		if encoded {
+			decoded, err := base64.StdEncoding.DecodeString(currentValue)
+			if err != nil {
+				return err
+			}
+			currentValue = string(decoded)
+		}
+		etcdConfigItems[ci] = currentValue
+	}
+
+	// Try to reload the values from the existing launch template
+	if stack != nil {
+		for _, output := range stack.Outputs {
+			if aws.StringValue(output.OutputKey) == "LaunchTemplateId" {
+				launchTemplateID := aws.StringValue(output.OutputValue)
+
+				versions, err := adapter.ec2Client.DescribeLaunchTemplateVersions(&ec2.DescribeLaunchTemplateVersionsInput{
+					LaunchTemplateId: aws.String(launchTemplateID),
+					Versions:         []*string{aws.String("$Latest")},
+				})
+				if err != nil {
+					return err
+				}
+
+				if len(versions.LaunchTemplateVersions) != 1 {
+					return fmt.Errorf("expected 1 version in launch template %s, found %d", launchTemplateID, len(versions.LaunchTemplateVersions))
+				}
+
+				userData, err := base64.StdEncoding.DecodeString(aws.StringValue(versions.LaunchTemplateVersions[0].LaunchTemplateData.UserData))
+				if err != nil {
+					return err
+				}
+
+				if bytes.HasPrefix(userData, []byte("#taupage-ami-config")) {
+					var result struct {
+						Environment struct {
+							ClientCert string `yaml:"CLIENT_CERT"`
+							ClientKey  string `yaml:"CLIENT_KEY"`
+							ClientCA   string `yaml:"CLIENT_TRUSTED_CA"`
+						} `yaml:"environment"`
+						ScalyrKey string `yaml:"scalyr_account_key"`
+					}
+					err = yaml.Unmarshal(userData, &result)
+					if err != nil {
+						return err
+					}
+
+					for k, v := range map[string]string{
+						"etcd_client_server_cert": result.Environment.ClientCert,
+						"etcd_client_server_key":  result.Environment.ClientKey,
+						"etcd_client_ca_cert":     result.Environment.ClientCA,
+						"etcd_scalyr_key":         result.ScalyrKey,
+					} {
+						decrypted, err := decryptTaupageKMSValue(adapter, v)
+						if err != nil {
+							return err
+						}
+
+						if etcdConfigItems[k] == decrypted {
+							// Keep the existing value
+							values[k] = v
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Fill in the missing config items
+	for _, ci := range []string{"etcd_client_server_cert", "etcd_client_server_key", "etcd_client_ca_cert", "etcd_scalyr_key"} {
+		if _, ok := values[ci]; ok {
+			continue
+		}
+
+		encrypted, err := adapter.kmsEncryptForTaupage(etcdKMSKeyARN, etcdConfigItems[ci])
+		if err != nil {
+			return fmt.Errorf("failed to encrypt value for '%s': %w", ci, err)
+		}
+		values[ci] = encrypted
+	}
+
+	return nil
+}
+
+func decryptTaupageKMSValue(adapter *awsAdapter, value string) (string, error) {
+	if value == "" {
+		return "", nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(value, "aws:kms:"))
+	if err != nil {
+		return "", err
+	}
+	decrypted, err := adapter.kmsClient.Decrypt(&kms.DecryptInput{
+		CiphertextBlob: decoded,
+	})
+	if err != nil {
+		return "", err
+	}
+	return string(decrypted.Plaintext), nil
+}


### PR DESCRIPTION
Reverts zalando-incubator/cluster-lifecycle-manager#613

Broke provisioning:

```
cluster-lifecycle-manager-668d6bb794-dkcwb cluster-lifecycle-manager time="2022-09-22T16:06:38Z" level=error msg="Failed to process cluster: template: main/cluster/etcd/stack.yaml:48:44: executing \"main/cluster/etcd/stack.yaml\" at <.Values.etcd_scalyr_key>: map has no entry for key \"etcd_scalyr_key\"" cluster=zalon-kub-test worker=97
```