### PR TITLE
Support more nodes based on Pod CIDR size

### DIFF
--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -118,7 +118,14 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		"amiID": func(imageName, imageOwner string) (string, error) {
 			return amiID(context.awsAdapter, imageName, imageOwner)
 		},
-		"nodeCIDRMaxNodes":              nodeCIDRMaxNodes,
+		// TODO: this function is kept for backward compatibility while
+		// the the use of `nodeCIDRMaxNodesPodCIDR` is being rolled out
+		// to all channels of kubernetes-on-aws. After a full rollout
+		// this can be dropped.
+		"nodeCIDRMaxNodes": func(maskSize int64, reserved int64) (int64, error) {
+			return nodeCIDRMaxNodes(16, maskSize, reserved)
+		},
+		"nodeCIDRMaxNodesPodCIDR":       nodeCIDRMaxNodes,
 		"nodeCIDRMaxPods":               nodeCIDRMaxPods,
 		"parseInt64":                    parseInt64,
 		"generateJWKSDocument":          generateJWKSDocument,
@@ -535,13 +542,17 @@ func checkCIDRMaxSize(maskSize int64) error {
 	return nil
 }
 
-func nodeCIDRMaxNodes(maskSize int64, reserved int64) (int64, error) {
+func nodeCIDRMaxNodes(podCIDRMaskSize, maskSize int64, reserved int64) (int64, error) {
+	if podCIDRMaskSize < 14 || podCIDRMaskSize > 16 {
+		return 0, fmt.Errorf("invalid for podCIDRMaskSize: %d", podCIDRMaskSize)
+	}
+
 	err := checkCIDRMaxSize(maskSize)
 	if err != nil {
 		return 0, err
 	}
 
-	return 2<<(maskSize-16-1) - reserved, nil
+	return 2<<(maskSize-podCIDRMaskSize-1) - reserved, nil
 }
 
 func nodeCIDRMaxPods(maskSize int64, extraCapacity int64) (int64, error) {


### PR DESCRIPTION
For enabling more than 1019 nodes in our Kubernetes infrastructure we have made it possible to change the default pod cidr from `10.2.0.0/16` to `10.2.0.0/15`: https://github.com/zalando-incubator/kubernetes-on-aws/pull/5405

However we forgot to allow the cluster-autoscaler to scale beyond the 1019 node limit.

This PR fixes this by:
1. Introducing a new function `nodeCIDRMaxNodesPodCIDR` for calculating the number of nodes based on podCIDR mask size, node mask size and potential reserved capacity.
2. "Deprecating" the former version of the function called `nodeCIDRMaxNodes` which had the podCIDR mask size hardcoded.

With this we can change the usage of `nodeCIDRMaxNodes` to `nodeCIDRMaxNodesPodCIDR` here: https://github.com/zalando-incubator/kubernetes-on-aws/blob/87d5861f145b54ed9120f60a299c0d760ac951a4/cluster/manifests/kube-cluster-autoscaler/daemonset.yaml#L54 and eventually remove the function `nodeCIDRMaxNodes` when it's not used anymore.