### PR TITLE
cloudformation: retry failed stack updates when stack was updating

### DIFF
--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -747,7 +747,7 @@ func isStackNoUpdateNeededErr(err error) bool {
 // describes a failure because the stack is currently updating.
 func isStackUpdateInProgressErr(err error) bool {
 	if awsErr, ok := err.(awserr.Error); ok {
-		if awsErr.Code() == cloudformationValidationErr && (strings.Contains(awsErr.Message(), "UPDATE_IN_PROGRESS") || strings.Contains(awsErr.Message(), "UPDATE_COMPLETE_CLEANUP_IN_PROGRESS")) {
+		if awsErr.Code() == cloudformationValidationErr && (strings.Contains(awsErr.Message(), cloudformation.ResourceStatusUpdateInProgress) || strings.Contains(awsErr.Message(), cloudformation.StackStatusUpdateCompleteCleanupInProgress)) {
 			return true
 		}
 	}


### PR DESCRIPTION
Catches the `UPDATE_IN_PROGRESS` and `UPDATE_COMPLETE_CLEANUP_IN_PROGRESS` errors and retries **every CF stack update** for up to 5 minutes with exponential backoff.

There's actually two changes in here. The other changes is a related refactoring extracting the part where it handles the error gracefully when the stack template didn't change. Check out the commits individually to see it better.

Better implementation for https://github.com/zalando-incubator/kubernetes-on-aws/pull/5677/files

TODO:
* Rollback https://github.com/zalando-incubator/kubernetes-on-aws/pull/5677/files after this is merged