### PR TITLE
Add MemoryFraction function to InstanceInfo

### DIFF
--- a/pkg/aws/instance_info.go
+++ b/pkg/aws/instance_info.go
@@ -35,6 +35,10 @@ func (i Instance) AvailableStorage(instanceStorageScaleFactor float64, rootVolum
 	return int64(instanceStorageScaleFactor * float64(i.InstanceStorageDevices*i.InstanceStorageDeviceSize))
 }
 
+func (i Instance) MemoryFraction(percent int64) int64 {
+	return percent * i.Memory / 100
+}
+
 type InstanceTypes struct {
 	instances map[string]Instance
 }

--- a/pkg/aws/instance_info_test.go
+++ b/pkg/aws/instance_info_test.go
@@ -448,3 +448,16 @@ func TestSyntheticInstanceInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestMemoryFraction(t *testing.T) {
+	instance := Instance{
+		InstanceType:              "<multiple>",
+		VCPU:                      2,
+		Memory:                    8589934592,
+		InstanceStorageDevices:    1,
+		InstanceStorageDeviceSize: 75 * 1024 * mebibyte,
+		Architecture:              "amd64",
+	}
+
+	require.Equal(t, int64(4294967296), instance.MemoryFraction(50))
+}


### PR DESCRIPTION
This adds a `MemoryFraction` method which allows parsing a fraction (whole number between `0-100`) and get the percentage of instance memory in bytes returned.

This is useful for calculation e.g. 50% of memory of a master node and set this as the limit for the kube-apiserver pod: https://github.com/zalando-incubator/kubernetes-on-aws/pull/5722