### PR TITLE
Update generated code after go-swagger update

### DIFF
--- a/pkg/cluster-registry/client/clusters/create_cluster_responses.go
+++ b/pkg/cluster-registry/client/clusters/create_cluster_responses.go
@@ -103,6 +103,11 @@ func (o *CreateClusterCreated) IsCode(code int) bool {
 	return code == 201
 }
 
+// Code gets the status code for the create cluster created response
+func (o *CreateClusterCreated) Code() int {
+	return 201
+}
+
 func (o *CreateClusterCreated) Error() string {
 	return fmt.Sprintf("[POST /kubernetes-clusters][%d] createClusterCreated  %+v", 201, o.Payload)
 }
@@ -164,6 +169,11 @@ func (o *CreateClusterBadRequest) IsServerError() bool {
 // IsCode returns true when this create cluster bad request response a status code equal to that given
 func (o *CreateClusterBadRequest) IsCode(code int) bool {
 	return code == 400
+}
+
+// Code gets the status code for the create cluster bad request response
+func (o *CreateClusterBadRequest) Code() int {
+	return 400
 }
 
 func (o *CreateClusterBadRequest) Error() string {
@@ -228,6 +238,11 @@ func (o *CreateClusterUnauthorized) IsCode(code int) bool {
 	return code == 401
 }
 
+// Code gets the status code for the create cluster unauthorized response
+func (o *CreateClusterUnauthorized) Code() int {
+	return 401
+}
+
 func (o *CreateClusterUnauthorized) Error() string {
 	return fmt.Sprintf("[POST /kubernetes-clusters][%d] createClusterUnauthorized ", 401)
 }
@@ -277,6 +292,11 @@ func (o *CreateClusterForbidden) IsServerError() bool {
 // IsCode returns true when this create cluster forbidden response a status code equal to that given
 func (o *CreateClusterForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the create cluster forbidden response
+func (o *CreateClusterForbidden) Code() int {
+	return 403
 }
 
 func (o *CreateClusterForbidden) Error() string {
@@ -330,6 +350,11 @@ func (o *CreateClusterConflict) IsCode(code int) bool {
 	return code == 409
 }
 
+// Code gets the status code for the create cluster conflict response
+func (o *CreateClusterConflict) Code() int {
+	return 409
+}
+
 func (o *CreateClusterConflict) Error() string {
 	return fmt.Sprintf("[POST /kubernetes-clusters][%d] createClusterConflict ", 409)
 }
@@ -380,6 +405,11 @@ func (o *CreateClusterInternalServerError) IsServerError() bool {
 // IsCode returns true when this create cluster internal server error response a status code equal to that given
 func (o *CreateClusterInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the create cluster internal server error response
+func (o *CreateClusterInternalServerError) Code() int {
+	return 500
 }
 
 func (o *CreateClusterInternalServerError) Error() string {

--- a/pkg/cluster-registry/client/clusters/delete_cluster_responses.go
+++ b/pkg/cluster-registry/client/clusters/delete_cluster_responses.go
@@ -102,6 +102,11 @@ func (o *DeleteClusterNoContent) IsCode(code int) bool {
 	return code == 204
 }
 
+// Code gets the status code for the delete cluster no content response
+func (o *DeleteClusterNoContent) Code() int {
+	return 204
+}
+
 func (o *DeleteClusterNoContent) Error() string {
 	return fmt.Sprintf("[DELETE /kubernetes-clusters/{cluster_id}][%d] deleteClusterNoContent ", 204)
 }
@@ -152,6 +157,11 @@ func (o *DeleteClusterBadRequest) IsServerError() bool {
 // IsCode returns true when this delete cluster bad request response a status code equal to that given
 func (o *DeleteClusterBadRequest) IsCode(code int) bool {
 	return code == 400
+}
+
+// Code gets the status code for the delete cluster bad request response
+func (o *DeleteClusterBadRequest) Code() int {
+	return 400
 }
 
 func (o *DeleteClusterBadRequest) Error() string {
@@ -216,6 +226,11 @@ func (o *DeleteClusterUnauthorized) IsCode(code int) bool {
 	return code == 401
 }
 
+// Code gets the status code for the delete cluster unauthorized response
+func (o *DeleteClusterUnauthorized) Code() int {
+	return 401
+}
+
 func (o *DeleteClusterUnauthorized) Error() string {
 	return fmt.Sprintf("[DELETE /kubernetes-clusters/{cluster_id}][%d] deleteClusterUnauthorized ", 401)
 }
@@ -266,6 +281,11 @@ func (o *DeleteClusterForbidden) IsServerError() bool {
 // IsCode returns true when this delete cluster forbidden response a status code equal to that given
 func (o *DeleteClusterForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the delete cluster forbidden response
+func (o *DeleteClusterForbidden) Code() int {
+	return 403
 }
 
 func (o *DeleteClusterForbidden) Error() string {
@@ -330,6 +350,11 @@ func (o *DeleteClusterNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the delete cluster not found response
+func (o *DeleteClusterNotFound) Code() int {
+	return 404
+}
+
 func (o *DeleteClusterNotFound) Error() string {
 	return fmt.Sprintf("[DELETE /kubernetes-clusters/{cluster_id}][%d] deleteClusterNotFound ", 404)
 }
@@ -380,6 +405,11 @@ func (o *DeleteClusterInternalServerError) IsServerError() bool {
 // IsCode returns true when this delete cluster internal server error response a status code equal to that given
 func (o *DeleteClusterInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the delete cluster internal server error response
+func (o *DeleteClusterInternalServerError) Code() int {
+	return 500
 }
 
 func (o *DeleteClusterInternalServerError) Error() string {

--- a/pkg/cluster-registry/client/clusters/get_cluster_responses.go
+++ b/pkg/cluster-registry/client/clusters/get_cluster_responses.go
@@ -97,6 +97,11 @@ func (o *GetClusterOK) IsCode(code int) bool {
 	return code == 200
 }
 
+// Code gets the status code for the get cluster o k response
+func (o *GetClusterOK) Code() int {
+	return 200
+}
+
 func (o *GetClusterOK) Error() string {
 	return fmt.Sprintf("[GET /kubernetes-clusters/{cluster_id}][%d] getClusterOK  %+v", 200, o.Payload)
 }
@@ -159,6 +164,11 @@ func (o *GetClusterUnauthorized) IsCode(code int) bool {
 	return code == 401
 }
 
+// Code gets the status code for the get cluster unauthorized response
+func (o *GetClusterUnauthorized) Code() int {
+	return 401
+}
+
 func (o *GetClusterUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /kubernetes-clusters/{cluster_id}][%d] getClusterUnauthorized ", 401)
 }
@@ -208,6 +218,11 @@ func (o *GetClusterForbidden) IsServerError() bool {
 // IsCode returns true when this get cluster forbidden response a status code equal to that given
 func (o *GetClusterForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the get cluster forbidden response
+func (o *GetClusterForbidden) Code() int {
+	return 403
 }
 
 func (o *GetClusterForbidden) Error() string {
@@ -261,6 +276,11 @@ func (o *GetClusterNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the get cluster not found response
+func (o *GetClusterNotFound) Code() int {
+	return 404
+}
+
 func (o *GetClusterNotFound) Error() string {
 	return fmt.Sprintf("[GET /kubernetes-clusters/{cluster_id}][%d] getClusterNotFound ", 404)
 }
@@ -311,6 +331,11 @@ func (o *GetClusterInternalServerError) IsServerError() bool {
 // IsCode returns true when this get cluster internal server error response a status code equal to that given
 func (o *GetClusterInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the get cluster internal server error response
+func (o *GetClusterInternalServerError) Code() int {
+	return 500
 }
 
 func (o *GetClusterInternalServerError) Error() string {

--- a/pkg/cluster-registry/client/clusters/list_clusters_responses.go
+++ b/pkg/cluster-registry/client/clusters/list_clusters_responses.go
@@ -95,6 +95,11 @@ func (o *ListClustersOK) IsCode(code int) bool {
 	return code == 200
 }
 
+// Code gets the status code for the list clusters o k response
+func (o *ListClustersOK) Code() int {
+	return 200
+}
+
 func (o *ListClustersOK) Error() string {
 	return fmt.Sprintf("[GET /kubernetes-clusters][%d] listClustersOK  %+v", 200, o.Payload)
 }
@@ -157,6 +162,11 @@ func (o *ListClustersUnauthorized) IsCode(code int) bool {
 	return code == 401
 }
 
+// Code gets the status code for the list clusters unauthorized response
+func (o *ListClustersUnauthorized) Code() int {
+	return 401
+}
+
 func (o *ListClustersUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /kubernetes-clusters][%d] listClustersUnauthorized ", 401)
 }
@@ -206,6 +216,11 @@ func (o *ListClustersForbidden) IsServerError() bool {
 // IsCode returns true when this list clusters forbidden response a status code equal to that given
 func (o *ListClustersForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the list clusters forbidden response
+func (o *ListClustersForbidden) Code() int {
+	return 403
 }
 
 func (o *ListClustersForbidden) Error() string {
@@ -258,6 +273,11 @@ func (o *ListClustersInternalServerError) IsServerError() bool {
 // IsCode returns true when this list clusters internal server error response a status code equal to that given
 func (o *ListClustersInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the list clusters internal server error response
+func (o *ListClustersInternalServerError) Code() int {
+	return 500
 }
 
 func (o *ListClustersInternalServerError) Error() string {

--- a/pkg/cluster-registry/client/clusters/update_cluster_responses.go
+++ b/pkg/cluster-registry/client/clusters/update_cluster_responses.go
@@ -97,6 +97,11 @@ func (o *UpdateClusterOK) IsCode(code int) bool {
 	return code == 200
 }
 
+// Code gets the status code for the update cluster o k response
+func (o *UpdateClusterOK) Code() int {
+	return 200
+}
+
 func (o *UpdateClusterOK) Error() string {
 	return fmt.Sprintf("[PATCH /kubernetes-clusters/{cluster_id}][%d] updateClusterOK  %+v", 200, o.Payload)
 }
@@ -159,6 +164,11 @@ func (o *UpdateClusterUnauthorized) IsCode(code int) bool {
 	return code == 401
 }
 
+// Code gets the status code for the update cluster unauthorized response
+func (o *UpdateClusterUnauthorized) Code() int {
+	return 401
+}
+
 func (o *UpdateClusterUnauthorized) Error() string {
 	return fmt.Sprintf("[PATCH /kubernetes-clusters/{cluster_id}][%d] updateClusterUnauthorized ", 401)
 }
@@ -208,6 +218,11 @@ func (o *UpdateClusterForbidden) IsServerError() bool {
 // IsCode returns true when this update cluster forbidden response a status code equal to that given
 func (o *UpdateClusterForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the update cluster forbidden response
+func (o *UpdateClusterForbidden) Code() int {
+	return 403
 }
 
 func (o *UpdateClusterForbidden) Error() string {
@@ -261,6 +276,11 @@ func (o *UpdateClusterNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the update cluster not found response
+func (o *UpdateClusterNotFound) Code() int {
+	return 404
+}
+
 func (o *UpdateClusterNotFound) Error() string {
 	return fmt.Sprintf("[PATCH /kubernetes-clusters/{cluster_id}][%d] updateClusterNotFound ", 404)
 }
@@ -311,6 +331,11 @@ func (o *UpdateClusterInternalServerError) IsServerError() bool {
 // IsCode returns true when this update cluster internal server error response a status code equal to that given
 func (o *UpdateClusterInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the update cluster internal server error response
+func (o *UpdateClusterInternalServerError) Code() int {
+	return 500
 }
 
 func (o *UpdateClusterInternalServerError) Error() string {

--- a/pkg/cluster-registry/client/config_items/add_or_update_config_item_responses.go
+++ b/pkg/cluster-registry/client/config_items/add_or_update_config_item_responses.go
@@ -97,6 +97,11 @@ func (o *AddOrUpdateConfigItemOK) IsCode(code int) bool {
 	return code == 200
 }
 
+// Code gets the status code for the add or update config item o k response
+func (o *AddOrUpdateConfigItemOK) Code() int {
+	return 200
+}
+
 func (o *AddOrUpdateConfigItemOK) Error() string {
 	return fmt.Sprintf("[PUT /kubernetes-clusters/{cluster_id}/config-items/{config_key}][%d] addOrUpdateConfigItemOK  %+v", 200, o.Payload)
 }
@@ -158,6 +163,11 @@ func (o *AddOrUpdateConfigItemBadRequest) IsServerError() bool {
 // IsCode returns true when this add or update config item bad request response a status code equal to that given
 func (o *AddOrUpdateConfigItemBadRequest) IsCode(code int) bool {
 	return code == 400
+}
+
+// Code gets the status code for the add or update config item bad request response
+func (o *AddOrUpdateConfigItemBadRequest) Code() int {
+	return 400
 }
 
 func (o *AddOrUpdateConfigItemBadRequest) Error() string {
@@ -222,6 +232,11 @@ func (o *AddOrUpdateConfigItemUnauthorized) IsCode(code int) bool {
 	return code == 401
 }
 
+// Code gets the status code for the add or update config item unauthorized response
+func (o *AddOrUpdateConfigItemUnauthorized) Code() int {
+	return 401
+}
+
 func (o *AddOrUpdateConfigItemUnauthorized) Error() string {
 	return fmt.Sprintf("[PUT /kubernetes-clusters/{cluster_id}/config-items/{config_key}][%d] addOrUpdateConfigItemUnauthorized ", 401)
 }
@@ -271,6 +286,11 @@ func (o *AddOrUpdateConfigItemForbidden) IsServerError() bool {
 // IsCode returns true when this add or update config item forbidden response a status code equal to that given
 func (o *AddOrUpdateConfigItemForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the add or update config item forbidden response
+func (o *AddOrUpdateConfigItemForbidden) Code() int {
+	return 403
 }
 
 func (o *AddOrUpdateConfigItemForbidden) Error() string {
@@ -323,6 +343,11 @@ func (o *AddOrUpdateConfigItemInternalServerError) IsServerError() bool {
 // IsCode returns true when this add or update config item internal server error response a status code equal to that given
 func (o *AddOrUpdateConfigItemInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the add or update config item internal server error response
+func (o *AddOrUpdateConfigItemInternalServerError) Code() int {
+	return 500
 }
 
 func (o *AddOrUpdateConfigItemInternalServerError) Error() string {

--- a/pkg/cluster-registry/client/config_items/delete_config_item_responses.go
+++ b/pkg/cluster-registry/client/config_items/delete_config_item_responses.go
@@ -102,6 +102,11 @@ func (o *DeleteConfigItemNoContent) IsCode(code int) bool {
 	return code == 204
 }
 
+// Code gets the status code for the delete config item no content response
+func (o *DeleteConfigItemNoContent) Code() int {
+	return 204
+}
+
 func (o *DeleteConfigItemNoContent) Error() string {
 	return fmt.Sprintf("[DELETE /kubernetes-clusters/{cluster_id}/config-items/{config_key}][%d] deleteConfigItemNoContent ", 204)
 }
@@ -152,6 +157,11 @@ func (o *DeleteConfigItemBadRequest) IsServerError() bool {
 // IsCode returns true when this delete config item bad request response a status code equal to that given
 func (o *DeleteConfigItemBadRequest) IsCode(code int) bool {
 	return code == 400
+}
+
+// Code gets the status code for the delete config item bad request response
+func (o *DeleteConfigItemBadRequest) Code() int {
+	return 400
 }
 
 func (o *DeleteConfigItemBadRequest) Error() string {
@@ -216,6 +226,11 @@ func (o *DeleteConfigItemUnauthorized) IsCode(code int) bool {
 	return code == 401
 }
 
+// Code gets the status code for the delete config item unauthorized response
+func (o *DeleteConfigItemUnauthorized) Code() int {
+	return 401
+}
+
 func (o *DeleteConfigItemUnauthorized) Error() string {
 	return fmt.Sprintf("[DELETE /kubernetes-clusters/{cluster_id}/config-items/{config_key}][%d] deleteConfigItemUnauthorized ", 401)
 }
@@ -265,6 +280,11 @@ func (o *DeleteConfigItemForbidden) IsServerError() bool {
 // IsCode returns true when this delete config item forbidden response a status code equal to that given
 func (o *DeleteConfigItemForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the delete config item forbidden response
+func (o *DeleteConfigItemForbidden) Code() int {
+	return 403
 }
 
 func (o *DeleteConfigItemForbidden) Error() string {
@@ -318,6 +338,11 @@ func (o *DeleteConfigItemNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the delete config item not found response
+func (o *DeleteConfigItemNotFound) Code() int {
+	return 404
+}
+
 func (o *DeleteConfigItemNotFound) Error() string {
 	return fmt.Sprintf("[DELETE /kubernetes-clusters/{cluster_id}/config-items/{config_key}][%d] deleteConfigItemNotFound ", 404)
 }
@@ -368,6 +393,11 @@ func (o *DeleteConfigItemInternalServerError) IsServerError() bool {
 // IsCode returns true when this delete config item internal server error response a status code equal to that given
 func (o *DeleteConfigItemInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the delete config item internal server error response
+func (o *DeleteConfigItemInternalServerError) Code() int {
+	return 500
 }
 
 func (o *DeleteConfigItemInternalServerError) Error() string {

--- a/pkg/cluster-registry/client/infrastructure_accounts/create_infrastructure_account_responses.go
+++ b/pkg/cluster-registry/client/infrastructure_accounts/create_infrastructure_account_responses.go
@@ -103,6 +103,11 @@ func (o *CreateInfrastructureAccountCreated) IsCode(code int) bool {
 	return code == 201
 }
 
+// Code gets the status code for the create infrastructure account created response
+func (o *CreateInfrastructureAccountCreated) Code() int {
+	return 201
+}
+
 func (o *CreateInfrastructureAccountCreated) Error() string {
 	return fmt.Sprintf("[POST /infrastructure-accounts][%d] createInfrastructureAccountCreated  %+v", 201, o.Payload)
 }
@@ -165,6 +170,11 @@ func (o *CreateInfrastructureAccountBadRequest) IsCode(code int) bool {
 	return code == 400
 }
 
+// Code gets the status code for the create infrastructure account bad request response
+func (o *CreateInfrastructureAccountBadRequest) Code() int {
+	return 400
+}
+
 func (o *CreateInfrastructureAccountBadRequest) Error() string {
 	return fmt.Sprintf("[POST /infrastructure-accounts][%d] createInfrastructureAccountBadRequest ", 400)
 }
@@ -214,6 +224,11 @@ func (o *CreateInfrastructureAccountUnauthorized) IsServerError() bool {
 // IsCode returns true when this create infrastructure account unauthorized response a status code equal to that given
 func (o *CreateInfrastructureAccountUnauthorized) IsCode(code int) bool {
 	return code == 401
+}
+
+// Code gets the status code for the create infrastructure account unauthorized response
+func (o *CreateInfrastructureAccountUnauthorized) Code() int {
+	return 401
 }
 
 func (o *CreateInfrastructureAccountUnauthorized) Error() string {
@@ -267,6 +282,11 @@ func (o *CreateInfrastructureAccountForbidden) IsCode(code int) bool {
 	return code == 403
 }
 
+// Code gets the status code for the create infrastructure account forbidden response
+func (o *CreateInfrastructureAccountForbidden) Code() int {
+	return 403
+}
+
 func (o *CreateInfrastructureAccountForbidden) Error() string {
 	return fmt.Sprintf("[POST /infrastructure-accounts][%d] createInfrastructureAccountForbidden ", 403)
 }
@@ -316,6 +336,11 @@ func (o *CreateInfrastructureAccountConflict) IsServerError() bool {
 // IsCode returns true when this create infrastructure account conflict response a status code equal to that given
 func (o *CreateInfrastructureAccountConflict) IsCode(code int) bool {
 	return code == 409
+}
+
+// Code gets the status code for the create infrastructure account conflict response
+func (o *CreateInfrastructureAccountConflict) Code() int {
+	return 409
 }
 
 func (o *CreateInfrastructureAccountConflict) Error() string {
@@ -368,6 +393,11 @@ func (o *CreateInfrastructureAccountInternalServerError) IsServerError() bool {
 // IsCode returns true when this create infrastructure account internal server error response a status code equal to that given
 func (o *CreateInfrastructureAccountInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the create infrastructure account internal server error response
+func (o *CreateInfrastructureAccountInternalServerError) Code() int {
+	return 500
 }
 
 func (o *CreateInfrastructureAccountInternalServerError) Error() string {

--- a/pkg/cluster-registry/client/infrastructure_accounts/get_infrastructure_account_responses.go
+++ b/pkg/cluster-registry/client/infrastructure_accounts/get_infrastructure_account_responses.go
@@ -97,6 +97,11 @@ func (o *GetInfrastructureAccountOK) IsCode(code int) bool {
 	return code == 200
 }
 
+// Code gets the status code for the get infrastructure account o k response
+func (o *GetInfrastructureAccountOK) Code() int {
+	return 200
+}
+
 func (o *GetInfrastructureAccountOK) Error() string {
 	return fmt.Sprintf("[GET /infrastructure-accounts/{account_id}][%d] getInfrastructureAccountOK  %+v", 200, o.Payload)
 }
@@ -159,6 +164,11 @@ func (o *GetInfrastructureAccountUnauthorized) IsCode(code int) bool {
 	return code == 401
 }
 
+// Code gets the status code for the get infrastructure account unauthorized response
+func (o *GetInfrastructureAccountUnauthorized) Code() int {
+	return 401
+}
+
 func (o *GetInfrastructureAccountUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /infrastructure-accounts/{account_id}][%d] getInfrastructureAccountUnauthorized ", 401)
 }
@@ -208,6 +218,11 @@ func (o *GetInfrastructureAccountForbidden) IsServerError() bool {
 // IsCode returns true when this get infrastructure account forbidden response a status code equal to that given
 func (o *GetInfrastructureAccountForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the get infrastructure account forbidden response
+func (o *GetInfrastructureAccountForbidden) Code() int {
+	return 403
 }
 
 func (o *GetInfrastructureAccountForbidden) Error() string {
@@ -261,6 +276,11 @@ func (o *GetInfrastructureAccountNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the get infrastructure account not found response
+func (o *GetInfrastructureAccountNotFound) Code() int {
+	return 404
+}
+
 func (o *GetInfrastructureAccountNotFound) Error() string {
 	return fmt.Sprintf("[GET /infrastructure-accounts/{account_id}][%d] getInfrastructureAccountNotFound ", 404)
 }
@@ -311,6 +331,11 @@ func (o *GetInfrastructureAccountInternalServerError) IsServerError() bool {
 // IsCode returns true when this get infrastructure account internal server error response a status code equal to that given
 func (o *GetInfrastructureAccountInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the get infrastructure account internal server error response
+func (o *GetInfrastructureAccountInternalServerError) Code() int {
+	return 500
 }
 
 func (o *GetInfrastructureAccountInternalServerError) Error() string {

--- a/pkg/cluster-registry/client/infrastructure_accounts/list_infrastructure_accounts_responses.go
+++ b/pkg/cluster-registry/client/infrastructure_accounts/list_infrastructure_accounts_responses.go
@@ -95,6 +95,11 @@ func (o *ListInfrastructureAccountsOK) IsCode(code int) bool {
 	return code == 200
 }
 
+// Code gets the status code for the list infrastructure accounts o k response
+func (o *ListInfrastructureAccountsOK) Code() int {
+	return 200
+}
+
 func (o *ListInfrastructureAccountsOK) Error() string {
 	return fmt.Sprintf("[GET /infrastructure-accounts][%d] listInfrastructureAccountsOK  %+v", 200, o.Payload)
 }
@@ -157,6 +162,11 @@ func (o *ListInfrastructureAccountsUnauthorized) IsCode(code int) bool {
 	return code == 401
 }
 
+// Code gets the status code for the list infrastructure accounts unauthorized response
+func (o *ListInfrastructureAccountsUnauthorized) Code() int {
+	return 401
+}
+
 func (o *ListInfrastructureAccountsUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /infrastructure-accounts][%d] listInfrastructureAccountsUnauthorized ", 401)
 }
@@ -206,6 +216,11 @@ func (o *ListInfrastructureAccountsForbidden) IsServerError() bool {
 // IsCode returns true when this list infrastructure accounts forbidden response a status code equal to that given
 func (o *ListInfrastructureAccountsForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the list infrastructure accounts forbidden response
+func (o *ListInfrastructureAccountsForbidden) Code() int {
+	return 403
 }
 
 func (o *ListInfrastructureAccountsForbidden) Error() string {
@@ -258,6 +273,11 @@ func (o *ListInfrastructureAccountsInternalServerError) IsServerError() bool {
 // IsCode returns true when this list infrastructure accounts internal server error response a status code equal to that given
 func (o *ListInfrastructureAccountsInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the list infrastructure accounts internal server error response
+func (o *ListInfrastructureAccountsInternalServerError) Code() int {
+	return 500
 }
 
 func (o *ListInfrastructureAccountsInternalServerError) Error() string {

--- a/pkg/cluster-registry/client/infrastructure_accounts/update_infrastructure_account_responses.go
+++ b/pkg/cluster-registry/client/infrastructure_accounts/update_infrastructure_account_responses.go
@@ -97,6 +97,11 @@ func (o *UpdateInfrastructureAccountOK) IsCode(code int) bool {
 	return code == 200
 }
 
+// Code gets the status code for the update infrastructure account o k response
+func (o *UpdateInfrastructureAccountOK) Code() int {
+	return 200
+}
+
 func (o *UpdateInfrastructureAccountOK) Error() string {
 	return fmt.Sprintf("[PATCH /infrastructure-accounts/{account_id}][%d] updateInfrastructureAccountOK  %+v", 200, o.Payload)
 }
@@ -159,6 +164,11 @@ func (o *UpdateInfrastructureAccountUnauthorized) IsCode(code int) bool {
 	return code == 401
 }
 
+// Code gets the status code for the update infrastructure account unauthorized response
+func (o *UpdateInfrastructureAccountUnauthorized) Code() int {
+	return 401
+}
+
 func (o *UpdateInfrastructureAccountUnauthorized) Error() string {
 	return fmt.Sprintf("[PATCH /infrastructure-accounts/{account_id}][%d] updateInfrastructureAccountUnauthorized ", 401)
 }
@@ -208,6 +218,11 @@ func (o *UpdateInfrastructureAccountForbidden) IsServerError() bool {
 // IsCode returns true when this update infrastructure account forbidden response a status code equal to that given
 func (o *UpdateInfrastructureAccountForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the update infrastructure account forbidden response
+func (o *UpdateInfrastructureAccountForbidden) Code() int {
+	return 403
 }
 
 func (o *UpdateInfrastructureAccountForbidden) Error() string {
@@ -261,6 +276,11 @@ func (o *UpdateInfrastructureAccountNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the update infrastructure account not found response
+func (o *UpdateInfrastructureAccountNotFound) Code() int {
+	return 404
+}
+
 func (o *UpdateInfrastructureAccountNotFound) Error() string {
 	return fmt.Sprintf("[PATCH /infrastructure-accounts/{account_id}][%d] updateInfrastructureAccountNotFound ", 404)
 }
@@ -311,6 +331,11 @@ func (o *UpdateInfrastructureAccountInternalServerError) IsServerError() bool {
 // IsCode returns true when this update infrastructure account internal server error response a status code equal to that given
 func (o *UpdateInfrastructureAccountInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the update infrastructure account internal server error response
+func (o *UpdateInfrastructureAccountInternalServerError) Code() int {
+	return 500
 }
 
 func (o *UpdateInfrastructureAccountInternalServerError) Error() string {

--- a/pkg/cluster-registry/client/node_pool_config_items/add_or_update_node_pool_config_item_responses.go
+++ b/pkg/cluster-registry/client/node_pool_config_items/add_or_update_node_pool_config_item_responses.go
@@ -97,6 +97,11 @@ func (o *AddOrUpdateNodePoolConfigItemOK) IsCode(code int) bool {
 	return code == 200
 }
 
+// Code gets the status code for the add or update node pool config item o k response
+func (o *AddOrUpdateNodePoolConfigItemOK) Code() int {
+	return 200
+}
+
 func (o *AddOrUpdateNodePoolConfigItemOK) Error() string {
 	return fmt.Sprintf("[PUT /kubernetes-clusters/{cluster_id}/node-pools/{node_pool_name}/config-items/{config_key}][%d] addOrUpdateNodePoolConfigItemOK  %+v", 200, o.Payload)
 }
@@ -158,6 +163,11 @@ func (o *AddOrUpdateNodePoolConfigItemBadRequest) IsServerError() bool {
 // IsCode returns true when this add or update node pool config item bad request response a status code equal to that given
 func (o *AddOrUpdateNodePoolConfigItemBadRequest) IsCode(code int) bool {
 	return code == 400
+}
+
+// Code gets the status code for the add or update node pool config item bad request response
+func (o *AddOrUpdateNodePoolConfigItemBadRequest) Code() int {
+	return 400
 }
 
 func (o *AddOrUpdateNodePoolConfigItemBadRequest) Error() string {
@@ -222,6 +232,11 @@ func (o *AddOrUpdateNodePoolConfigItemUnauthorized) IsCode(code int) bool {
 	return code == 401
 }
 
+// Code gets the status code for the add or update node pool config item unauthorized response
+func (o *AddOrUpdateNodePoolConfigItemUnauthorized) Code() int {
+	return 401
+}
+
 func (o *AddOrUpdateNodePoolConfigItemUnauthorized) Error() string {
 	return fmt.Sprintf("[PUT /kubernetes-clusters/{cluster_id}/node-pools/{node_pool_name}/config-items/{config_key}][%d] addOrUpdateNodePoolConfigItemUnauthorized ", 401)
 }
@@ -271,6 +286,11 @@ func (o *AddOrUpdateNodePoolConfigItemForbidden) IsServerError() bool {
 // IsCode returns true when this add or update node pool config item forbidden response a status code equal to that given
 func (o *AddOrUpdateNodePoolConfigItemForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the add or update node pool config item forbidden response
+func (o *AddOrUpdateNodePoolConfigItemForbidden) Code() int {
+	return 403
 }
 
 func (o *AddOrUpdateNodePoolConfigItemForbidden) Error() string {
@@ -323,6 +343,11 @@ func (o *AddOrUpdateNodePoolConfigItemInternalServerError) IsServerError() bool 
 // IsCode returns true when this add or update node pool config item internal server error response a status code equal to that given
 func (o *AddOrUpdateNodePoolConfigItemInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the add or update node pool config item internal server error response
+func (o *AddOrUpdateNodePoolConfigItemInternalServerError) Code() int {
+	return 500
 }
 
 func (o *AddOrUpdateNodePoolConfigItemInternalServerError) Error() string {

--- a/pkg/cluster-registry/client/node_pool_config_items/delete_node_pool_config_item_responses.go
+++ b/pkg/cluster-registry/client/node_pool_config_items/delete_node_pool_config_item_responses.go
@@ -102,6 +102,11 @@ func (o *DeleteNodePoolConfigItemNoContent) IsCode(code int) bool {
 	return code == 204
 }
 
+// Code gets the status code for the delete node pool config item no content response
+func (o *DeleteNodePoolConfigItemNoContent) Code() int {
+	return 204
+}
+
 func (o *DeleteNodePoolConfigItemNoContent) Error() string {
 	return fmt.Sprintf("[DELETE /kubernetes-clusters/{cluster_id}/node-pools/{node_pool_name}/config-items/{config_key}][%d] deleteNodePoolConfigItemNoContent ", 204)
 }
@@ -152,6 +157,11 @@ func (o *DeleteNodePoolConfigItemBadRequest) IsServerError() bool {
 // IsCode returns true when this delete node pool config item bad request response a status code equal to that given
 func (o *DeleteNodePoolConfigItemBadRequest) IsCode(code int) bool {
 	return code == 400
+}
+
+// Code gets the status code for the delete node pool config item bad request response
+func (o *DeleteNodePoolConfigItemBadRequest) Code() int {
+	return 400
 }
 
 func (o *DeleteNodePoolConfigItemBadRequest) Error() string {
@@ -216,6 +226,11 @@ func (o *DeleteNodePoolConfigItemUnauthorized) IsCode(code int) bool {
 	return code == 401
 }
 
+// Code gets the status code for the delete node pool config item unauthorized response
+func (o *DeleteNodePoolConfigItemUnauthorized) Code() int {
+	return 401
+}
+
 func (o *DeleteNodePoolConfigItemUnauthorized) Error() string {
 	return fmt.Sprintf("[DELETE /kubernetes-clusters/{cluster_id}/node-pools/{node_pool_name}/config-items/{config_key}][%d] deleteNodePoolConfigItemUnauthorized ", 401)
 }
@@ -265,6 +280,11 @@ func (o *DeleteNodePoolConfigItemForbidden) IsServerError() bool {
 // IsCode returns true when this delete node pool config item forbidden response a status code equal to that given
 func (o *DeleteNodePoolConfigItemForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the delete node pool config item forbidden response
+func (o *DeleteNodePoolConfigItemForbidden) Code() int {
+	return 403
 }
 
 func (o *DeleteNodePoolConfigItemForbidden) Error() string {
@@ -318,6 +338,11 @@ func (o *DeleteNodePoolConfigItemNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the delete node pool config item not found response
+func (o *DeleteNodePoolConfigItemNotFound) Code() int {
+	return 404
+}
+
 func (o *DeleteNodePoolConfigItemNotFound) Error() string {
 	return fmt.Sprintf("[DELETE /kubernetes-clusters/{cluster_id}/node-pools/{node_pool_name}/config-items/{config_key}][%d] deleteNodePoolConfigItemNotFound ", 404)
 }
@@ -368,6 +393,11 @@ func (o *DeleteNodePoolConfigItemInternalServerError) IsServerError() bool {
 // IsCode returns true when this delete node pool config item internal server error response a status code equal to that given
 func (o *DeleteNodePoolConfigItemInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the delete node pool config item internal server error response
+func (o *DeleteNodePoolConfigItemInternalServerError) Code() int {
+	return 500
 }
 
 func (o *DeleteNodePoolConfigItemInternalServerError) Error() string {

--- a/pkg/cluster-registry/client/node_pools/create_or_update_node_pool_responses.go
+++ b/pkg/cluster-registry/client/node_pools/create_or_update_node_pool_responses.go
@@ -97,6 +97,11 @@ func (o *CreateOrUpdateNodePoolOK) IsCode(code int) bool {
 	return code == 200
 }
 
+// Code gets the status code for the create or update node pool o k response
+func (o *CreateOrUpdateNodePoolOK) Code() int {
+	return 200
+}
+
 func (o *CreateOrUpdateNodePoolOK) Error() string {
 	return fmt.Sprintf("[PUT /kubernetes-clusters/{cluster_id}/node-pools/{node_pool_name}][%d] createOrUpdateNodePoolOK  %+v", 200, o.Payload)
 }
@@ -158,6 +163,11 @@ func (o *CreateOrUpdateNodePoolBadRequest) IsServerError() bool {
 // IsCode returns true when this create or update node pool bad request response a status code equal to that given
 func (o *CreateOrUpdateNodePoolBadRequest) IsCode(code int) bool {
 	return code == 400
+}
+
+// Code gets the status code for the create or update node pool bad request response
+func (o *CreateOrUpdateNodePoolBadRequest) Code() int {
+	return 400
 }
 
 func (o *CreateOrUpdateNodePoolBadRequest) Error() string {
@@ -222,6 +232,11 @@ func (o *CreateOrUpdateNodePoolUnauthorized) IsCode(code int) bool {
 	return code == 401
 }
 
+// Code gets the status code for the create or update node pool unauthorized response
+func (o *CreateOrUpdateNodePoolUnauthorized) Code() int {
+	return 401
+}
+
 func (o *CreateOrUpdateNodePoolUnauthorized) Error() string {
 	return fmt.Sprintf("[PUT /kubernetes-clusters/{cluster_id}/node-pools/{node_pool_name}][%d] createOrUpdateNodePoolUnauthorized ", 401)
 }
@@ -271,6 +286,11 @@ func (o *CreateOrUpdateNodePoolForbidden) IsServerError() bool {
 // IsCode returns true when this create or update node pool forbidden response a status code equal to that given
 func (o *CreateOrUpdateNodePoolForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the create or update node pool forbidden response
+func (o *CreateOrUpdateNodePoolForbidden) Code() int {
+	return 403
 }
 
 func (o *CreateOrUpdateNodePoolForbidden) Error() string {
@@ -323,6 +343,11 @@ func (o *CreateOrUpdateNodePoolInternalServerError) IsServerError() bool {
 // IsCode returns true when this create or update node pool internal server error response a status code equal to that given
 func (o *CreateOrUpdateNodePoolInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the create or update node pool internal server error response
+func (o *CreateOrUpdateNodePoolInternalServerError) Code() int {
+	return 500
 }
 
 func (o *CreateOrUpdateNodePoolInternalServerError) Error() string {

--- a/pkg/cluster-registry/client/node_pools/delete_node_pool_responses.go
+++ b/pkg/cluster-registry/client/node_pools/delete_node_pool_responses.go
@@ -102,6 +102,11 @@ func (o *DeleteNodePoolNoContent) IsCode(code int) bool {
 	return code == 204
 }
 
+// Code gets the status code for the delete node pool no content response
+func (o *DeleteNodePoolNoContent) Code() int {
+	return 204
+}
+
 func (o *DeleteNodePoolNoContent) Error() string {
 	return fmt.Sprintf("[DELETE /kubernetes-clusters/{cluster_id}/node-pools/{node_pool_name}][%d] deleteNodePoolNoContent ", 204)
 }
@@ -152,6 +157,11 @@ func (o *DeleteNodePoolBadRequest) IsServerError() bool {
 // IsCode returns true when this delete node pool bad request response a status code equal to that given
 func (o *DeleteNodePoolBadRequest) IsCode(code int) bool {
 	return code == 400
+}
+
+// Code gets the status code for the delete node pool bad request response
+func (o *DeleteNodePoolBadRequest) Code() int {
+	return 400
 }
 
 func (o *DeleteNodePoolBadRequest) Error() string {
@@ -216,6 +226,11 @@ func (o *DeleteNodePoolUnauthorized) IsCode(code int) bool {
 	return code == 401
 }
 
+// Code gets the status code for the delete node pool unauthorized response
+func (o *DeleteNodePoolUnauthorized) Code() int {
+	return 401
+}
+
 func (o *DeleteNodePoolUnauthorized) Error() string {
 	return fmt.Sprintf("[DELETE /kubernetes-clusters/{cluster_id}/node-pools/{node_pool_name}][%d] deleteNodePoolUnauthorized ", 401)
 }
@@ -265,6 +280,11 @@ func (o *DeleteNodePoolForbidden) IsServerError() bool {
 // IsCode returns true when this delete node pool forbidden response a status code equal to that given
 func (o *DeleteNodePoolForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the delete node pool forbidden response
+func (o *DeleteNodePoolForbidden) Code() int {
+	return 403
 }
 
 func (o *DeleteNodePoolForbidden) Error() string {
@@ -318,6 +338,11 @@ func (o *DeleteNodePoolNotFound) IsCode(code int) bool {
 	return code == 404
 }
 
+// Code gets the status code for the delete node pool not found response
+func (o *DeleteNodePoolNotFound) Code() int {
+	return 404
+}
+
 func (o *DeleteNodePoolNotFound) Error() string {
 	return fmt.Sprintf("[DELETE /kubernetes-clusters/{cluster_id}/node-pools/{node_pool_name}][%d] deleteNodePoolNotFound ", 404)
 }
@@ -368,6 +393,11 @@ func (o *DeleteNodePoolInternalServerError) IsServerError() bool {
 // IsCode returns true when this delete node pool internal server error response a status code equal to that given
 func (o *DeleteNodePoolInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the delete node pool internal server error response
+func (o *DeleteNodePoolInternalServerError) Code() int {
+	return 500
 }
 
 func (o *DeleteNodePoolInternalServerError) Error() string {

--- a/pkg/cluster-registry/client/node_pools/list_node_pools_responses.go
+++ b/pkg/cluster-registry/client/node_pools/list_node_pools_responses.go
@@ -95,6 +95,11 @@ func (o *ListNodePoolsOK) IsCode(code int) bool {
 	return code == 200
 }
 
+// Code gets the status code for the list node pools o k response
+func (o *ListNodePoolsOK) Code() int {
+	return 200
+}
+
 func (o *ListNodePoolsOK) Error() string {
 	return fmt.Sprintf("[GET /kubernetes-clusters/{cluster_id}/node-pools][%d] listNodePoolsOK  %+v", 200, o.Payload)
 }
@@ -157,6 +162,11 @@ func (o *ListNodePoolsUnauthorized) IsCode(code int) bool {
 	return code == 401
 }
 
+// Code gets the status code for the list node pools unauthorized response
+func (o *ListNodePoolsUnauthorized) Code() int {
+	return 401
+}
+
 func (o *ListNodePoolsUnauthorized) Error() string {
 	return fmt.Sprintf("[GET /kubernetes-clusters/{cluster_id}/node-pools][%d] listNodePoolsUnauthorized ", 401)
 }
@@ -206,6 +216,11 @@ func (o *ListNodePoolsForbidden) IsServerError() bool {
 // IsCode returns true when this list node pools forbidden response a status code equal to that given
 func (o *ListNodePoolsForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the list node pools forbidden response
+func (o *ListNodePoolsForbidden) Code() int {
+	return 403
 }
 
 func (o *ListNodePoolsForbidden) Error() string {
@@ -258,6 +273,11 @@ func (o *ListNodePoolsInternalServerError) IsServerError() bool {
 // IsCode returns true when this list node pools internal server error response a status code equal to that given
 func (o *ListNodePoolsInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the list node pools internal server error response
+func (o *ListNodePoolsInternalServerError) Code() int {
+	return 500
 }
 
 func (o *ListNodePoolsInternalServerError) Error() string {

--- a/pkg/cluster-registry/client/node_pools/update_node_pool_responses.go
+++ b/pkg/cluster-registry/client/node_pools/update_node_pool_responses.go
@@ -97,6 +97,11 @@ func (o *UpdateNodePoolOK) IsCode(code int) bool {
 	return code == 200
 }
 
+// Code gets the status code for the update node pool o k response
+func (o *UpdateNodePoolOK) Code() int {
+	return 200
+}
+
 func (o *UpdateNodePoolOK) Error() string {
 	return fmt.Sprintf("[PATCH /kubernetes-clusters/{cluster_id}/node-pools/{node_pool_name}][%d] updateNodePoolOK  %+v", 200, o.Payload)
 }
@@ -158,6 +163,11 @@ func (o *UpdateNodePoolBadRequest) IsServerError() bool {
 // IsCode returns true when this update node pool bad request response a status code equal to that given
 func (o *UpdateNodePoolBadRequest) IsCode(code int) bool {
 	return code == 400
+}
+
+// Code gets the status code for the update node pool bad request response
+func (o *UpdateNodePoolBadRequest) Code() int {
+	return 400
 }
 
 func (o *UpdateNodePoolBadRequest) Error() string {
@@ -222,6 +232,11 @@ func (o *UpdateNodePoolUnauthorized) IsCode(code int) bool {
 	return code == 401
 }
 
+// Code gets the status code for the update node pool unauthorized response
+func (o *UpdateNodePoolUnauthorized) Code() int {
+	return 401
+}
+
 func (o *UpdateNodePoolUnauthorized) Error() string {
 	return fmt.Sprintf("[PATCH /kubernetes-clusters/{cluster_id}/node-pools/{node_pool_name}][%d] updateNodePoolUnauthorized ", 401)
 }
@@ -271,6 +286,11 @@ func (o *UpdateNodePoolForbidden) IsServerError() bool {
 // IsCode returns true when this update node pool forbidden response a status code equal to that given
 func (o *UpdateNodePoolForbidden) IsCode(code int) bool {
 	return code == 403
+}
+
+// Code gets the status code for the update node pool forbidden response
+func (o *UpdateNodePoolForbidden) Code() int {
+	return 403
 }
 
 func (o *UpdateNodePoolForbidden) Error() string {
@@ -323,6 +343,11 @@ func (o *UpdateNodePoolInternalServerError) IsServerError() bool {
 // IsCode returns true when this update node pool internal server error response a status code equal to that given
 func (o *UpdateNodePoolInternalServerError) IsCode(code int) bool {
 	return code == 500
+}
+
+// Code gets the status code for the update node pool internal server error response
+func (o *UpdateNodePoolInternalServerError) Code() int {
+	return 500
 }
 
 func (o *UpdateNodePoolInternalServerError) Error() string {


### PR DESCRIPTION
Follow up to #641 where go-swagger was updated which changed some of the generated code for the cluster-registry client.
Without this the files changes during the build and the version gets the `-dirty` suffix.