### PR TITLE
Build multi-arch image for CLM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
-FROM registry.opensource.zalan.do/library/alpine-3.13:latest as kubectl_download
+ARG BASE_IMAGE=registry.opensource.zalan.do/library/alpine-3:latest
+FROM ${BASE_IMAGE} as kubectl_download
+
+ARG TARGETARCH
 
 RUN apk add --no-cache --update curl tar coreutils && \
-    curl -L -s --fail https://dl.k8s.io/v1.21.5/kubernetes-client-linux-amd64.tar.gz -o kubernetes-client-linux-amd64.tar.gz && \
-    echo "0bd3f5a4141bf3aaf8045a9ec302561bb70f6b9a7d988bc617370620d0dbadef947e1c8855cda0347d1dd1534332ee17a950cac5a8fcb78f2c3e38c62058abde kubernetes-client-linux-amd64.tar.gz" | sha512sum -c - && \
-    tar xvf kubernetes-client-linux-amd64.tar.gz --strip-components 3 kubernetes/client/bin/ && \
-    rm kubernetes-client-linux-amd64.tar.gz
+    if [ "${TARGETARCH}" == "" ]; then TARGETARCH=amd64; fi; \
+    curl -L -s --fail "https://dl.k8s.io/v1.22.17/kubernetes-client-linux-${TARGETARCH}.tar.gz" -o "kubernetes-client-linux-${TARGETARCH}.tar.gz" && \
+    printf "fe9fb234653435f75f2de968914b64a1096eceb5014c45d4d1a678b781f3c00aa40420a7421f156daee50350a2b6f91e55a913854bea08d0d0f2c9e3788fe325 kubernetes-client-linux-amd64.tar.gz\n01ee050d537b5e6867fdec635b874e45d5c250ed9d05174024dc4d8bb785173001b2f28fbb0534094a57c0a2bc2f2090040ef1419316963691dc69bbe82c8c37 kubernetes-client-linux-arm64.tar.gz" | grep "${TARGETARCH}" | sha512sum -c - && \
+    tar xvf "kubernetes-client-linux-${TARGETARCH}.tar.gz" --strip-components 3 kubernetes/client/bin/ && \
+    rm "kubernetes-client-linux-${TARGETARCH}.tar.gz"
 
-FROM registry.opensource.zalan.do/library/alpine-3.13:latest
+FROM ${BASE_IMAGE}
 LABEL maintainer="Team Teapot @ Zalando SE <team-teapot@zalando.de>"
+
+ARG TARGETARCH
 
 # install dependencies
 RUN apk add --no-cache ca-certificates openssl git openssh-client && \
@@ -16,7 +22,7 @@ RUN apk add --no-cache ca-certificates openssl git openssh-client && \
 COPY --from=kubectl_download /kubectl /usr/local/bin/
 
 # add binary
-ADD build/linux/clm /
+ADD build/linux/${TARGETARCH}/clm /
 
 CMD ["--help"]
 ENTRYPOINT ["/clm"]

--- a/delivery.yaml
+++ b/delivery.yaml
@@ -30,3 +30,17 @@ pipeline:
         VERSION=$CDP_BUILD_VERSION
       fi
       IMAGE=$IMAGE VERSION=$VERSION make build.push
+  - desc: Build and push image to Zalando's registry
+    cmd: |
+      if [[ $CDP_TARGET_BRANCH == master && ! $CDP_PULL_REQUEST_NUMBER ]]; then
+        VERSION=$(git describe --tags --always --dirty)
+      else
+        VERSION=$CDP_BUILD_VERSION
+      fi
+
+      IMAGE=container-registry-test.zalando.net/teapot/cluster-lifecycle-manager
+      make build.linux.amd64 build.linux.arm64
+
+      docker buildx create --config /etc/cdp-buildkitd.toml --driver-opt network=host --bootstrap --use
+      docker buildx build --rm --build-arg BASE_IMAGE=container-registry.zalando.net/library/alpine-3:latest -t "${IMAGE}:${VERSION}" --platform linux/amd64,linux/arm64 --push .
+      cdp-promote-image "${IMAGE}:${VERSION}"


### PR DESCRIPTION
This adds multi-arch build for CLM to avoid depending on the legacy open source registry.

Further we can use the new dependency support for Zalando ECR based images to trigger the internal deployment.

* It also updates `kubectl` in the image to v1.22.17 as we run that in all clusters by now.