### PR TITLE
deletions: add selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ pre_apply: # everything defined under here will be deleted before applying the m
   labels:
     foo: bar
   has_owner: false
+- namespace: kube-system
+  kind: deployment
+  selector: version != v1
 post_apply: # everything defined under here will be deleted after applying the manifests
 - namespace: kube-system
   kind: deployment
@@ -152,8 +155,9 @@ Whatever is defined in this file will be deleted pre/post applying the other
 manifest files, if the resource exists. If the resource has already been
 deleted previously it's treated as a no-op.
 
-A resource can be identified either by `name` or `labels`.
-It is an error if both or none of them are defined.
+A resource can be identified either by `name`,
+[`selector`](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) or
+`labels` and only one of them should be defined.
 
 `namespace` can be left out, in which case it will default to `kube-system`.
 

--- a/provisioner/clusterpy_test.go
+++ b/provisioner/clusterpy_test.go
@@ -68,6 +68,13 @@ pre_apply:
     baz: qux
   has_owner: true
 `
+
+	deletionsContent4 = `
+pre_apply:
+- namespace: kube-system
+  kind: Deployment
+  selector: version != v1
+`
 )
 
 func TestGetInfrastructureID(t *testing.T) {
@@ -249,7 +256,7 @@ func TestPropagateConfigItemsToNodePool(tt *testing.T) {
 	} {
 		cluster := &api.Cluster{
 			ConfigItems: tc.cluster,
-			NodePools:   []*api.NodePool{&api.NodePool{ConfigItems: tc.nodePool}},
+			NodePools:   []*api.NodePool{{ConfigItems: tc.nodePool}},
 		}
 
 		p := clusterpyProvisioner{}
@@ -305,6 +312,7 @@ func TestParseDeletions(t *testing.T) {
 			{Path: "deletions.yaml", Contents: []byte(deletionsContent)},
 			{Path: "deletions.yaml", Contents: []byte(deletionsContent2)},
 			{Path: "deletions.yaml", Contents: []byte(deletionsContent3)},
+			{Path: "deletions.yaml", Contents: []byte(deletionsContent4)},
 		},
 	}
 
@@ -322,6 +330,7 @@ func TestParseDeletions(t *testing.T) {
 			{Name: "foobar-pre", Namespace: "templated", Kind: "deployment"},
 			{Name: "has-no-owner-pre", HasOwner: &no, Namespace: "kube-system", Kind: "ReplicaSet", Labels: map[string]string{"foo": "bar", "baz": "qux"}},
 			{Name: "require-owner-pre", HasOwner: &yes, Namespace: "kube-system", Kind: "ReplicaSet", Labels: map[string]string{"foo": "bar", "baz": "qux"}},
+			{Namespace: "kube-system", Kind: "Deployment", Selector: "version != v1"},
 		},
 		PostApply: []*kubernetes.Resource{
 			{Name: "secretary-post", Namespace: "kube-system", Kind: "deployment"},


### PR DESCRIPTION
Adds deletion `selector` to enable set and equality-based label requirements, see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors

It could be used to create resources with dynamic name:
```yaml
# pcs.yaml
# skipper_oauth2_ui_login_hostnames: "foo.example.org=foo,foo.example.com=foo,bar.example.net=bar"

{{ $config_hash := printf "%.32s" (.ConfigItems.skipper_oauth2_ui_login_hostnames | sha256) }}

{{ range split .ConfigItems.skipper_oauth2_ui_login_hostnames "," }}
{{ $hostname := index (split . "=") 0 }}
---
apiVersion: "zalando.org/v1"
kind: PlatformCredentialsSet
metadata:
  name: "{{ $hostname }}-credentials"
  namespace: kube-system
  labels:
    type: hostname-credentials
    config-hash: {{ $config_hash }}
  ...
spec:
...
{{ end }}
```
and delete resources that do not match actual config value hash (note `!=` operator):
```yaml
# deletions.yaml

{{ $config_hash := printf "%.32s" (.ConfigItems.skipper_oauth2_ui_login_hostnames | sha256) }}

post_apply:
- kind: PlatformCredentialsSet
  namespace: kube-system
  selector: type=hostname-credentials,config-hash!={{ $config_hash }}
```

https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/656 proposes to add `sha256` function.