### PR TITLE
provisioner: add replaceAll template function

### DIFF
--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -112,6 +112,7 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		"azID":                 azID,
 		"azCount":              azCount,
 		"split":                split,
+		"replaceAll":           strings.ReplaceAll,
 		"mountUnitName":        mountUnitName,
 		"accountID":            accountID,
 		"portRanges":           portRanges,


### PR DESCRIPTION
This could be used to define a valid yaml that requires an integer value:
```yaml
spec:
  # {{ replaceAll `
  terminationGracePeriodSeconds: 30
  # ` "30" .Cluster.ConfigItems.skipper_termination_grace_period }}
```
becomes
```yaml
spec:
  # 
  terminationGracePeriodSeconds: 10
  #
```