### PR TITLE
provisioner: update split template function logic for empty input

### DIFF
--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -276,6 +276,9 @@ func azCount(subnets map[string]string) int {
 
 // split is a template function that takes a string and a separator and returns the splitted parts.
 func split(s string, d string) []string {
+	if s == "" {
+		return nil
+	}
 	return strings.Split(s, d)
 }
 

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -180,6 +180,38 @@ func TestAZCountNoSubnets(t *testing.T) {
 	require.EqualValues(t, "0", result)
 }
 
+func TestSplit(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		result, err := renderSingle(
+			t,
+			`{{ range $index, $element := split .Values.data "," }}{{ $index }}={{ $element}}{{end}}`,
+			"")
+
+		require.NoError(t, err)
+		require.Equal(t, "", result)
+	})
+
+	t.Run("single", func(t *testing.T) {
+		result, err := renderSingle(
+			t,
+			`{{ range $index, $element := split .Values.data "," }}{{ $index }}={{ $element}}{{end}}`,
+			"foo")
+
+		require.NoError(t, err)
+		require.Equal(t, "0=foo", result)
+	})
+
+	t.Run("multiple", func(t *testing.T) {
+		result, err := renderSingle(
+			t,
+			`{{ range $index, $element := split .Values.data "," }}{{ $index }}={{ $element}}{{end}}`,
+			"foo,bar")
+
+		require.NoError(t, err)
+		require.Equal(t, "0=foo1=bar", result)
+	})
+}
+
 func TestMountUnitName(t *testing.T) {
 	result, err := renderSingle(
 		t,


### PR DESCRIPTION
Splitting empty string intuitively should produce zero parts.

Stdlib strings.Split returns s if s does not contain d therefore strings.Split("", ",") returns one part [""].

This should simplify a common pattern:
```
{{ if ne .ConfigItems.foo "" }}
{{ range $bar := split .ConfigItems.foo "," }}
  - "{{ $bar }}"
{{ end }}
{{ end }}
```
to
```
{{ range $bar := split .ConfigItems.foo "," }}
  - "{{ $bar }}"
{{ end }}
```