### PR TITLE
Make etcd stack name configurable via config item

### DIFF
--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -37,7 +37,8 @@ const (
 	providerID                         = "zalando-aws"
 	etcdStackFileName                  = "stack.yaml"
 	clusterStackFileName               = "cluster.yaml"
-	etcdStackName                      = "etcd-cluster-etcd"
+	etcdStackNameDefault               = "etcd-cluster-etcd"
+	etcdStackNameConfigItemKey         = "etcd_stack_name"
 	defaultNamespace                   = "default"
 	tagNameKubernetesClusterPrefix     = "kubernetes.io/cluster/"
 	subnetELBRoleTagName               = "kubernetes.io/role/elb"
@@ -416,8 +417,14 @@ func createOrUpdateEtcdStack(
 		return err
 	}
 
+	etcdStackName := etcdStackNameDefault
+
+	if v, ok := cluster.ConfigItems[etcdStackNameConfigItemKey]; ok {
+		etcdStackName = v
+	}
+
 	values = util.CopyValues(values)
-	err = populateEncryptedEtcdValues(adapter, cluster, etcdKmsKeyARN, values)
+	err = populateEncryptedEtcdValues(adapter, etcdStackName, cluster, etcdKmsKeyARN, values)
 	if err != nil {
 		return err
 	}

--- a/provisioner/legacy_etcd.go
+++ b/provisioner/legacy_etcd.go
@@ -17,7 +17,7 @@ import (
 // we run. Unfortunately it's pretty much unavoidable because we rely on the KMS-encrypted config items inside the launch template, and if we
 // didn't do this, every run would create new ciphertext for the same plaintext value and then trigger a rolling update. We can drop it and switch
 // to a saner scheme (same as what we do with Kubernetes) once we migrate away from Taupage, and then this whole mess can be dropped.
-func populateEncryptedEtcdValues(adapter *awsAdapter, cluster *api.Cluster, etcdKMSKeyARN string, values map[string]interface{}) error {
+func populateEncryptedEtcdValues(adapter *awsAdapter, etcdStackName string, cluster *api.Cluster, etcdKMSKeyARN string, values map[string]interface{}) error {
 	stack, err := adapter.getStackByName(etcdStackName)
 	if err != nil && !isDoesNotExistsErr(err) {
 		return err


### PR DESCRIPTION
This makes the etcd stack name configurable via the `etcd_stack_name` configItem. The purpose of this is to allow setting up a custom etcd cluster for testing.