### PR TITLE
Drop legacy values

### DIFF
--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -264,10 +264,6 @@ func (p *clusterpyProvisioner) Provision(ctx context.Context, logger *log.Entry,
 	}
 
 	values := map[string]interface{}{
-		// TODO(tech-debt): custom legacy value
-		"node_labels": fmt.Sprintf("lifecycle-status=%s", lifecycleStatusReady),
-		// TODO(tech-debt): custom legacy value
-		"apiserver_count":           "1",
 		subnetsValueKey:             azInfo.SubnetsByAZ(),
 		availabilityZonesValueKey:   azInfo.AvailabilityZones(),
 		"hosted_zone":               hostedZone,


### PR DESCRIPTION
Drop legacy values removed from kubernetes-on-aws templates.

Depends on these changes being fully rolled out:

* [x] https://github.com/zalando-incubator/kubernetes-on-aws/pull/6468
* [x] https://github.com/zalando-incubator/kubernetes-on-aws/pull/6469
