### PR TITLE
provisioner: add json template function

### DIFF
--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/binary"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -113,6 +114,7 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		"azID":                 azID,
 		"azCount":              azCount,
 		"split":                split,
+		"json":                 parseJSON,
 		"mountUnitName":        mountUnitName,
 		"accountID":            accountID,
 		"portRanges":           portRanges,
@@ -292,6 +294,11 @@ func accountID(account string) (string, error) {
 		return "", fmt.Errorf("invalid account (expected type:id): %s", account)
 	}
 	return items[1], nil
+}
+
+func parseJSON(input string) (result interface{}, err error) {
+	err = json.Unmarshal([]byte(input), &result)
+	return
 }
 
 type HostPort struct {

--- a/provisioner/testdata/json.expected.yaml
+++ b/provisioner/testdata/json.expected.yaml
@@ -1,0 +1,53 @@
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "stable"
+  namespace: kube-system
+  labels:
+    application: app
+    version: "v1"
+spec:
+
+  selector:
+    matchLabels:
+      deployment: "stable"
+  template:
+    spec:
+      containers:
+        - name: app
+          args:
+            - -log-level=info
+
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "alpha"
+  namespace: kube-system
+  labels:
+    application: app
+    version: "v2"
+spec:
+
+  replicas: 1
+
+  selector:
+    matchLabels:
+      deployment: "alpha"
+  template:
+    spec:
+      containers:
+        - name: app
+          args:
+            - -log-level=info
+
+
+            - -foo=bar
+
+            - -baz=qux
+
+
+

--- a/provisioner/testdata/json.template.yaml
+++ b/provisioner/testdata/json.template.yaml
@@ -1,0 +1,32 @@
+{{ range json `[
+  {"name": "stable", "version": "v1"},
+  {"name": "alpha", "version": "v2", "replicas": 1, "args": ["-foo=bar", "-baz=qux"]}
+]` }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "{{ .name }}"
+  namespace: kube-system
+  labels:
+    application: app
+    version: "{{ .version }}"
+spec:
+{{ if index . "replicas" }}
+  replicas: {{ .replicas }}
+{{ end }}
+  selector:
+    matchLabels:
+      deployment: "{{ .name }}"
+  template:
+    spec:
+      containers:
+        - name: app
+          args:
+            - -log-level=info
+{{ if index . "args" }}
+{{ range .args }}
+            - {{ . }}
+{{ end }}
+{{ end }}
+{{ end }}


### PR DESCRIPTION
This change adds `json` function that enables use of json-formatted strings in templates.

This could be used to define structured configuration values or repeated chunks in templates that require modification of several values, see provisiner/testdata/json.template.yaml for an example use.