### PR TITLE
all: fix golangci-lint errors

### DIFF
--- a/controller/cluster_list.go
+++ b/controller/cluster_list.go
@@ -82,9 +82,8 @@ func (clusterList *ClusterList) UpdateAvailable(configSource channel.ConfigSourc
 			return true
 		} else if pi < pj {
 			return false
-		} else {
-			return pendingUpdate[i].lastProcessed.Before(pendingUpdate[j].lastProcessed)
 		}
+		return pendingUpdate[i].lastProcessed.Before(pendingUpdate[j].lastProcessed)
 	})
 	clusterList.pendingUpdate = pendingUpdate
 }

--- a/pkg/aws/instance_info.go
+++ b/pkg/aws/instance_info.go
@@ -124,34 +124,33 @@ func (types *InstanceTypes) SyntheticInstanceInfo(instanceTypes []string) (Insta
 		return Instance{}, fmt.Errorf("no instance types provided")
 	} else if len(instanceTypes) == 1 {
 		return types.InstanceInfo(instanceTypes[0])
-	} else {
-		first, err := types.InstanceInfo(instanceTypes[0])
+	}
+
+	first, err := types.InstanceInfo(instanceTypes[0])
+	if err != nil {
+		return Instance{}, err
+	}
+
+	result := Instance{
+		InstanceType:              "<multiple>",
+		VCPU:                      first.VCPU,
+		Memory:                    first.Memory,
+		InstanceStorageDevices:    first.InstanceStorageDevices,
+		InstanceStorageDeviceSize: first.InstanceStorageDeviceSize,
+		Architecture:              first.Architecture,
+	}
+	for _, instanceType := range instanceTypes[1:] {
+		info, err := types.InstanceInfo(instanceType)
 		if err != nil {
 			return Instance{}, err
 		}
 
-		result := Instance{
-			InstanceType:              first.InstanceType,
-			VCPU:                      first.VCPU,
-			Memory:                    first.Memory,
-			InstanceStorageDevices:    first.InstanceStorageDevices,
-			InstanceStorageDeviceSize: first.InstanceStorageDeviceSize,
-			Architecture:              first.Architecture,
-		}
-		for _, instanceType := range instanceTypes[1:] {
-			info, err := types.InstanceInfo(instanceType)
-			if err != nil {
-				return Instance{}, err
-			}
-
-			result.VCPU = min(result.VCPU, info.VCPU)
-			result.Memory = min(result.Memory, info.Memory)
-			result.InstanceStorageDeviceSize = min(result.InstanceStorageDeviceSize, info.InstanceStorageDeviceSize)
-			result.InstanceStorageDevices = min(result.InstanceStorageDevices, info.InstanceStorageDevices)
-		}
-		result.InstanceType = "<multiple>"
-		return result, nil
+		result.VCPU = min(result.VCPU, info.VCPU)
+		result.Memory = min(result.Memory, info.Memory)
+		result.InstanceStorageDeviceSize = min(result.InstanceStorageDeviceSize, info.InstanceStorageDeviceSize)
+		result.InstanceStorageDevices = min(result.InstanceStorageDevices, info.InstanceStorageDevices)
 	}
+	return result, nil
 }
 
 // getCompatibleCPUArchitecture returns a single compatible CPU architecture. It's either `amd64` or `arm64`.


### PR DESCRIPTION
Fixes "indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)"