### PR TITLE
remove etcd_client_tls_enabled config-item reference

### DIFF
--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -52,7 +52,6 @@ const (
 	etcdClientCAConfigItem          = "etcd_client_ca_cert"
 	etcdClientKeyConfigItem         = "etcd_client_server_key"
 	etcdClientCertificateConfigItem = "etcd_client_server_cert"
-	etcdClientTLSEnabledConfigItem  = "etcd_client_tls_enabled"
 	etcdImageConfigItem             = "etcd_image"
 
 	applicationTagKey = "application"


### PR DESCRIPTION
This configuration item has been deprecated and removed from the infrastructure and no longer needed. TLS is enabled by default in all etcd clusters.