### PR TITLE
add template functions for dynamic resource scaling

### DIFF
--- a/provisioner/clusterpy_test.go
+++ b/provisioner/clusterpy_test.go
@@ -345,7 +345,7 @@ func TestParseDeletions(t *testing.T) {
 		},
 	}
 
-	deletions, err := parseDeletions(cfg, exampleCluster, nil, nil)
+	deletions, err := parseDeletions(cfg, exampleCluster, nil, nil, nil)
 	require.NoError(t, err)
 	require.EqualValues(t, expected, deletions)
 }

--- a/provisioner/remote_files.go
+++ b/provisioner/remote_files.go
@@ -13,17 +13,19 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/channel"
+	awsUtils "github.com/zalando-incubator/cluster-lifecycle-manager/pkg/aws"
 	"gopkg.in/yaml.v2"
 )
 
 const kmsKeyPrefix = "arn:aws:kms"
 
 type FilesRenderer struct {
-	awsAdapter *awsAdapter
-	cluster    *api.Cluster
-	config     channel.Config
-	directory  string
-	nodePool   *api.NodePool
+	awsAdapter    *awsAdapter
+	cluster       *api.Cluster
+	config        channel.Config
+	directory     string
+	nodePool      *api.NodePool
+	instanceTypes *awsUtils.InstanceTypes
 }
 
 func (f *FilesRenderer) RenderAndUploadFiles(
@@ -54,6 +56,7 @@ func (f *FilesRenderer) RenderAndUploadFiles(
 		f.nodePool,
 		values,
 		f.awsAdapter,
+		f.instanceTypes,
 	)
 	if err != nil {
 		return "", err

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -149,11 +149,11 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		"indent":                                sprig.GenericFuncMap()["indent"],
 		"dict":                                  dict,
 		"scaleQuantity":                         scaleQuantity,
-		"instanceTypeCPU": func(instanceType string) (string, error) {
-			return instanceTypeCPU(context, instanceType)
+		"instanceTypeCPUQuantity": func(instanceType string) (string, error) {
+			return instanceTypeCPUQuantity(context, instanceType)
 		},
-		"instanceTypeMemory": func(instanceType string) (string, error) {
-			return instanceTypeMemory(context, instanceType)
+		"instanceTypeMemoryQuantity": func(instanceType string) (string, error) {
+			return instanceTypeMemoryQuantity(context, instanceType)
 		},
 	}
 
@@ -786,8 +786,8 @@ func awsValidID(id string) string {
 	return strings.Replace(id, ":", "__", -1)
 }
 
-// instanceTypeCPU returns the vCPUs of an instance type provided as k8sresource.Quantity represented as string
-func instanceTypeCPU(context *templateContext, instanceType string) (string, error) {
+// instanceTypeCPUQuantity returns the vCPUs of an instance type provided as k8sresource.Quantity represented as string
+func instanceTypeCPUQuantity(context *templateContext, instanceType string) (string, error) {
 	// get the instance type info
 	instanceTypeInfo, err := context.instanceTypes.InstanceInfo(instanceType)
 
@@ -800,8 +800,8 @@ func instanceTypeCPU(context *templateContext, instanceType string) (string, err
 	return cpu, nil
 }
 
-// instanceTypeMemory returns the memory of an instance type provided as k8sresource.Quantity represented as string
-func instanceTypeMemory(context *templateContext, instanceType string) (string, error) {
+// instanceTypeMemoryQuantity returns the memory of an instance type provided as k8sresource.Quantity represented as string
+func instanceTypeMemoryQuantity(context *templateContext, instanceType string) (string, error) {
 	// get the instance type info
 	instanceTypeInfo, err := context.instanceTypes.InstanceInfo(instanceType)
 

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -780,36 +780,45 @@ func awsValidID(id string) string {
 // divideInstanceResourcesInRatio takes in an instance type and a ratio and returns the result of applying
 // the ratio on the instance CPU and Memory sizes.
 // The ratio must be a positive number and less than 1.
+// The resourceType must be either 'cpu' or 'memory'.
 // The result is rounded down to the nearest integer, to avoid overcommitting resources.
 // The units for CPU and memory are millicores and mebibytes (MiB) respectively.
-func divideInstanceResourcesInRatio(adapter *awsAdapter, instanceType string, ratio float32) (cpu, memory int, err error) {
+func divideInstanceResourcesInRatio(adapter *awsAdapter, instanceType string, resourceType string, ratio float32) (dividedResource int, err error) {
 	if adapter == nil || adapter.ec2Client == nil {
-		return 0, 0, fmt.Errorf("the ec2 client is not available")
+		return 0, fmt.Errorf("the ec2 client is not available")
 	}
 
 	// validate the ratio
 	if ratio <= 0 {
-		return 0, 0, fmt.Errorf("ratio must be a positive number")
+		return 0, fmt.Errorf("ratio must be a positive number")
 	} else if ratio > 1 {
-		return 0, 0, fmt.Errorf("ratio must be less than 1")
+		return 0, fmt.Errorf("ratio must be less than 1")
 	} else if ratio == 1 {
-		return 0, 0, fmt.Errorf("ratio cannot be 1, cannot use all resources of an instance")
+		return 0, fmt.Errorf("ratio cannot be 1, cannot use all resources of an instance")
+	}
+
+	// validate the resourceType
+	if resourceType != "cpu" && resourceType != "memory" {
+		return 0, fmt.Errorf("resourceType must be either 'cpu' or 'memory'")
 	}
 
 	// get the instance type info
 	input := ec2.DescribeInstanceTypesInput{InstanceTypes: awsUtil.StringSlice([]string{instanceType})}
 	output, err := adapter.ec2Client.DescribeInstanceTypes(&input)
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to describe instance type %s: %v", instanceType, err)
+		return 0, fmt.Errorf("failed to describe instance type %s: %v", instanceType, err)
 	}
 	if len(output.InstanceTypes) != 1 {
-		return 0, 0, fmt.Errorf("no instance type found with name: %s", instanceType)
+		return 0, fmt.Errorf("no instance type found with name: %s", instanceType)
 	}
 	instanceTypeInfo := output.InstanceTypes[0]
 
 	// calculate the CPU and memory sizes
-	cpu = int(float32(*instanceTypeInfo.VCpuInfo.DefaultVCpus) * ratio)
-	memory = int(float32(*instanceTypeInfo.MemoryInfo.SizeInMiB) * ratio)
+	if resourceType == "cpu" {
+		return int(float32(*instanceTypeInfo.VCpuInfo.DefaultVCpus) * ratio), nil
+	} else if resourceType == "memory" {
+		return int(float32(*instanceTypeInfo.MemoryInfo.SizeInMiB) * ratio), nil
+	}
 
-	return cpu, memory, nil
+	return 0, fmt.Errorf("failed to calculate the %s size of instance type %s", resourceType, instanceType)
 }

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -795,7 +795,7 @@ func instanceTypeCPUQuantity(context *templateContext, instanceType string) (str
 		return "", err
 	}
 
-	cpu := fmt.Sprintf("%v", instanceTypeInfo.VCPU)
+	cpu := fmt.Sprintf("%d", instanceTypeInfo.VCPU)
 
 	return cpu, nil
 }

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -37,6 +37,8 @@ const (
 	labelsConfigItem = "labels"
 	taintsConfigItem = "taints"
 	dedicatedLabel   = "dedicated"
+
+	giga = 1024 * 1024 * 1024
 )
 
 type templateContext struct {
@@ -788,33 +790,30 @@ func awsValidID(id string) string {
 
 // instanceTypeCPU returns the vCPUs of an instance type provided as k8sresource.Quantity represented as string
 func instanceTypeCPU(context *templateContext, instanceType string) (string, error) {
-	var cpu k8sresource.Quantity
-
 	// get the instance type info
 	instanceTypeInfo, err := context.instanceTypes.InstanceInfo(instanceType)
 
 	if err != nil {
-		return cpu.String(), err
+		return "", err
 	}
 
-	cpu.Set(instanceTypeInfo.VCPU)
+	cpu := fmt.Sprintf("%v", instanceTypeInfo.VCPU)
 
-	return cpu.String(), nil
+	return cpu, nil
 }
 
 // instanceTypeMemory returns the memory of an instance type provided as k8sresource.Quantity represented as string
 func instanceTypeMemory(context *templateContext, instanceType string) (string, error) {
-	var memory k8sresource.Quantity
-
 	// get the instance type info
 	instanceTypeInfo, err := context.instanceTypes.InstanceInfo(instanceType)
 
 	if err != nil {
-		return memory.String(), err
+		return "", err
 	}
 
-	memory.SetScaled(instanceTypeInfo.Memory, k8sresource.Mega)
-	return memory.String(), nil
+	memory := fmt.Sprintf("%v%s", instanceTypeInfo.Memory/giga, "Gi")
+
+	return memory, nil
 }
 
 // scaleQuantity scales a k8sresource.Quantity by a factor, represented as string

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
 	awsUtils "github.com/zalando-incubator/cluster-lifecycle-manager/pkg/aws"
-	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 )
 
 func render(_ *testing.T, templates map[string]string, templateName string, data interface{}, adapter *awsAdapter, instanceTypes *awsUtils.InstanceTypes) (string, error) {
@@ -1232,56 +1231,56 @@ func TestDictInvalidArgs(t *testing.T) {
 func TestScaleQuantity(t *testing.T) {
 	for _, tc := range []struct {
 		name     string
-		quantity k8sresource.Quantity
+		quantity string
 		factor   float32
-		expected k8sresource.Quantity
+		expected string
 	}{
 		{
 			name:     "whole CPU scaled by whole",
-			quantity: k8sresource.MustParse("1.0"),
+			quantity: "1",
 			factor:   2.0,
-			expected: k8sresource.MustParse("2.0"),
+			expected: "2",
 		},
 		{
 			name:     "whole CPU scaled by fraction",
-			quantity: k8sresource.MustParse("10"),
+			quantity: "10",
 			factor:   0.5,
-			expected: k8sresource.MustParse("5"),
+			expected: "5",
 		},
 		{
 			name:     "fraction CPU scaled by whole",
-			quantity: k8sresource.MustParse("256m"),
+			quantity: "256m",
 			factor:   2.0,
-			expected: k8sresource.MustParse("512m"),
+			expected: "512m",
 		},
 		{
 			name:     "fraction CPU scaled by fraction",
-			quantity: k8sresource.MustParse("256m"),
+			quantity: "256m",
 			factor:   0.5,
-			expected: k8sresource.MustParse("128m"),
+			expected: "128m",
 		},
 		{
 			name:     "memory scaled by whole",
-			quantity: k8sresource.MustParse("1Gi"),
+			quantity: "1Gi",
 			factor:   2.0,
-			expected: k8sresource.MustParse("2Gi"),
+			expected: "2Gi",
 		},
 		{
 			name:     "memory scaled by fraction",
-			quantity: k8sresource.MustParse("1Gi"),
+			quantity: "1Gi",
 			factor:   0.5,
-			expected: k8sresource.MustParse("512Mi"),
+			expected: "512Mi",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			result, err := scaleQuantity(tc.quantity, tc.factor)
 			require.NoError(t, err)
-			require.EqualValues(t, tc.expected.String(), result.String())
+			require.EqualValues(t, tc.expected, result)
 		})
 	}
 }
 
 func TestScaleQuantityError(t *testing.T) {
-	_, err := scaleQuantity(k8sresource.MustParse("1.0"), -1.0)
+	_, err := scaleQuantity("1.0", -1.0)
 	require.Error(t, err)
 }


### PR DESCRIPTION
Adds the following template functions:

1. `scaleQuantity` - which scales a Kubernetes [resource.Quantity](https://pkg.go.dev/k8s.io/apimachinery/pkg/api/resource#Quantity) type represented as a `string` by a `float32` factor.
2. `instanceTypeCPUQuantity` - which returns vCPU count of an EC2 instance as Kubernetes resource.Quantity type represented as a `string`.
3. `instanceTypeMemoryQuantity` - which returns memory (in MiB) of an EC2 instance as Kubernetes resource.Quantity type represented as a `string`.

Also does the following refactoring:

1. Calls `NewInstanceTypesFromAWS` from `prepareProvision` instead of `Provision` function and it also returns the same to be used in `Provision` as well. This is a single in-memory representation of `instanceTypes` data that will be shared everywhere.
2. Extends `renderSingleTemplate` to receive the in-memory data for `instanceTypes` used to create the `TemplateContext`.
3. Extends `renderTemplate` to receive the same `instanceTypes` data.
4. Updates all instances in the code that use `renderTemplate` and `renderSingleTemplate` functions to ensure they receive the right data.
5. Moves `instanceTypes` field from `AWSNodePoolProvisioner` to `NodePoolTemplateRenderer` so both provisioners can use the same data in their rendering functions.
6. Extends `FilesRenderer` to include `instanceTypes` field that is passed onto rendering functions. This data is received from the `Provision` function.

The motivation is to be able to slice instance resources of an instance type given. This will then be used to size VPA limits for daemonsets. This is especially useful for master node daemonset VPA sizing in test clusters where we have very small instances where some pods cannot run sometimes because of overcommitted CPU.

Addresses Issue: https://github.bus.zalan.do/teapot/issues/issues/3469

The supporting PR in `kubernetes-on-aws` which demonstrates the usage of these new template functions: https://github.com/zalando-incubator/kubernetes-on-aws/pull/6931