### PR TITLE
update karpenter manifest management

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -203,12 +203,16 @@ func (c *ClientsCollection) Get(ctx context.Context, kind, namespace, name strin
 	return client.Get(ctx, name, options, subresources...)
 }
 
-func (c *ClientsCollection) Exists(ctx context.Context, kind, namespace, name string, options metav1.GetOptions, subresources ...string) bool {
+func (c *ClientsCollection) Exists(ctx context.Context, kind, namespace, name string, options metav1.GetOptions, subresources ...string) (bool, error) {
 	_, err := c.Get(ctx, kind, namespace, name, options, subresources...)
-	if err != nil { // TODO: check for specific error
-		return false
+
+	if apierrors.IsNotFound(err) {
+		return false, nil
 	}
-	return true
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (c *ClientsCollection) List(ctx context.Context, kind, namespace string, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -203,6 +203,14 @@ func (c *ClientsCollection) Get(ctx context.Context, kind, namespace, name strin
 	return client.Get(ctx, name, options, subresources...)
 }
 
+func (c *ClientsCollection) Exists(ctx context.Context, kind, namespace, name string, options metav1.GetOptions, subresources ...string) bool {
+	_, err := c.Get(ctx, kind, namespace, name, options, subresources...)
+	if err != nil { // TODO: check for specific error
+		return false
+	}
+	return true
+}
+
 func (c *ClientsCollection) List(ctx context.Context, kind, namespace string, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 	client, err := c.getResourceClient(kind, namespace)
 	if err != nil {

--- a/pkg/updatestrategy/aws_ec2.go
+++ b/pkg/updatestrategy/aws_ec2.go
@@ -2,19 +2,32 @@ package updatestrategy
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"strings"
 	"time"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/pkg/errors"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
+	"github.com/zalando-incubator/cluster-lifecycle-manager/pkg/kubernetes"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/pkg/util"
 )
 
-const karpenterProvisionerTag = "karpenter.sh/provisioner-name"
+const (
+	karpenterProvisionerTag          = "karpenter.sh/provisioner-name"
+	karpenterNodePoolTag             = "karpenter.sh/nodepool"
+	karpenterProvisionerResource     = "provisioners.karpenter.sh"
+	karpenterAWSNodeTemplateResource = "awsnodetemplates.karpenter.k8s.aws"
+	karpenterNodePoolResource        = "nodepools.karpenter.sh"
+	KarpenterEC2NodeClassResource    = "ec2nodeclasses.karpenter.k8s.aws"
+	crd                              = "CustomResourceDefinition"
+)
 
 type InstanceConfig struct {
 	UserData string
@@ -53,32 +66,22 @@ func NoopNodePoolConfigGetter(context.Context, *api.NodePool) (*InstanceConfig, 
 	return nil, nil
 }
 
-func WithConfigGetter(g NodePoolConfigGetter) Option {
-	return func(b *EC2NodePoolBackend) {
-		b.configGetter = g
-	}
-}
-
 // EC2NodePoolBackend defines a node pool consisting of EC2 instances
 // managed externally by some component e.g. Karpenter.
 type EC2NodePoolBackend struct {
-	ec2Client    ec2iface.EC2API
-	clusterID    string
-	configGetter NodePoolConfigGetter
+	*KarpenterCRDNameResolver
+	ec2Client ec2iface.EC2API
+	clusterID string
 }
 
 // NewEC2NodePoolBackend initializes a new EC2NodePoolBackend for
 // the given clusterID and AWS session and.
-func NewEC2NodePoolBackend(clusterID string, sess *session.Session, opts ...Option) *EC2NodePoolBackend {
-	b := &EC2NodePoolBackend{
-		ec2Client:    ec2.New(sess),
-		clusterID:    clusterID,
-		configGetter: NoopNodePoolConfigGetter,
+func NewEC2NodePoolBackend(clusterID string, sess *session.Session, crdResolver *KarpenterCRDNameResolver) *EC2NodePoolBackend {
+	return &EC2NodePoolBackend{
+		ec2Client:                ec2.New(sess),
+		clusterID:                clusterID,
+		KarpenterCRDNameResolver: crdResolver,
 	}
-	for _, opt := range opts {
-		opt(b)
-	}
-	return b
 }
 
 // Get gets the EC2 instances matching to the node pool by looking at node pool
@@ -93,7 +96,7 @@ func (n *EC2NodePoolBackend) Get(ctx context.Context, nodePool *api.NodePool) (*
 	}
 
 	nodes := make([]*Node, 0)
-	nodePoolConfig, err := n.configGetter(ctx, nodePool)
+	nodePoolConfig, err := n.NodePoolConfigGetter(ctx, nodePool) // in case of decommission nodePoolConfig is nil, and all nodes are deleted anyway
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +141,7 @@ func (n *EC2NodePoolBackend) filterWithNodePool(nodePool *api.NodePool) []*ec2.F
 			},
 		},
 		{
-			Name: aws.String("tag:" + nodePoolTag),
+			Name: aws.String("tag:" + nodePoolTag), // TODO: this needs to be conditional
 			Values: []*string{
 				aws.String(nodePool.Name),
 			},
@@ -212,6 +215,7 @@ func (n *EC2NodePoolBackend) DecommissionNodePool(ctx context.Context, nodePool 
 }
 
 func (n *EC2NodePoolBackend) DecommissionKarpenterNodes(ctx context.Context) error {
+
 	return n.decommission(ctx, []*ec2.Filter{
 		{
 			Name: aws.String("tag:" + clusterIDTagPrefix + n.clusterID),
@@ -222,7 +226,7 @@ func (n *EC2NodePoolBackend) DecommissionKarpenterNodes(ctx context.Context) err
 		{
 			Name: aws.String("tag-key"),
 			Values: []*string{
-				aws.String(karpenterProvisionerTag),
+				aws.String(n.getInstanceTag()),
 			},
 		},
 	})
@@ -268,4 +272,94 @@ func (n *EC2NodePoolBackend) decommission(ctx context.Context, filters []*ec2.Fi
 			return fmt.Errorf("context cancelled while waiting for instance termination: %w", ctx.Err())
 		}
 	}
+}
+
+type KarpenterCRDNameResolver struct {
+	NodePoolCRDName string
+	k8sClients      *kubernetes.ClientsCollection
+}
+
+func NewKarpenterCRDResolver(ctx context.Context, k8sClients *kubernetes.ClientsCollection) (*KarpenterCRDNameResolver, error) {
+	exists, err := k8sClients.Exists(ctx, crd, "", karpenterNodePoolResource, v1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		return &KarpenterCRDNameResolver{
+			NodePoolCRDName: karpenterNodePoolResource,
+			k8sClients:      k8sClients,
+		}, nil
+	}
+	return &KarpenterCRDNameResolver{
+		NodePoolCRDName: karpenterProvisionerResource,
+		k8sClients:      k8sClients,
+	}, nil
+}
+
+func (r *KarpenterCRDNameResolver) NodeTemplateCRDName() string {
+	switch r.NodePoolCRDName {
+	case karpenterNodePoolResource:
+		return KarpenterEC2NodeClassResource
+	default:
+		return karpenterAWSNodeTemplateResource
+	}
+}
+
+func (r *KarpenterCRDNameResolver) referenceFieldName() string {
+	switch r.NodePoolCRDName {
+	case karpenterNodePoolResource:
+		return "nodeClassRef"
+	default:
+		return "providerRef"
+	}
+}
+
+func (r *KarpenterCRDNameResolver) getAMIsFromSpec(spec interface{}) string {
+	switch r.NodePoolCRDName {
+	case karpenterNodePoolResource:
+		amiSelectorTerms := spec.(map[string]interface{})["amiSelectorTerms"].([]interface{})
+		var amis []string
+		for _, amiSelectorTerm := range amiSelectorTerms {
+			if amiSelectorTerm.(map[string]interface{})["id"] != nil {
+				amis = append(amis, amiSelectorTerm.(map[string]interface{})["id"].(string))
+			}
+		}
+		return strings.Join(amis, ",")
+	default:
+		return spec.(map[string]interface{})["amiSelector"].(map[string]interface{})["aws-ids"].(string)
+	}
+}
+
+func (r *KarpenterCRDNameResolver) getInstanceTag() string {
+	switch r.NodePoolCRDName {
+	case karpenterNodePoolResource:
+		return karpenterNodePoolTag
+	default:
+		return karpenterProvisionerTag
+	}
+}
+
+func (r *KarpenterCRDNameResolver) NodePoolConfigGetter(ctx context.Context, nodePool *api.NodePool) (*InstanceConfig, error) {
+	// CLM assumes that the node pool name is used for both the node-pool and the node-template that it references
+	NodeTemplate, err := r.k8sClients.Get(ctx, r.NodeTemplateCRDName(), "", nodePool.Name, v1.GetOptions{})
+	//if apierrors.IsNotFound(err) {
+	//	// the node pool have been deleted. thus the
+	//	return nil, nil
+	//}
+	if err != nil {
+		return nil, err
+	}
+	spec, ok := NodeTemplate.Object["spec"]
+	if !ok {
+		return nil, errors.New("could not find spec in the %s object" + r.NodeTemplateCRDName())
+	}
+	tags := make(map[string]string)
+	for k, v := range spec.(map[string]interface{})["tags"].(map[string]interface{}) {
+		tags[k] = v.(string)
+	}
+	return &InstanceConfig{
+		UserData: base64.StdEncoding.EncodeToString([]byte(spec.(map[string]interface{})["userData"].(string))),
+		ImageID:  r.getAMIsFromSpec(spec),
+		Tags:     tags,
+	}, nil
 }

--- a/pkg/util/generics.go
+++ b/pkg/util/generics.go
@@ -1,5 +1,7 @@
 package util
 
+import "sync"
+
 func Contains[T comparable](s []T, e T) bool {
 	for _, v := range s {
 		if v == e {
@@ -7,4 +9,25 @@ func Contains[T comparable](s []T, e T) bool {
 		}
 	}
 	return false
+}
+
+type LazyOf[T any] struct {
+	New   func() (T, error)
+	once  sync.Once
+	value T
+}
+
+func (l *LazyOf[T]) Value() (T, error) {
+	var err error
+	if l.New != nil {
+		l.once.Do(func() {
+			l.value, err = l.New()
+			l.New = nil
+		})
+	}
+	return l.value, err
+}
+
+func NewLazyOf[T any](newfunc func() (T, error)) *LazyOf[T] {
+	return &LazyOf[T]{New: newfunc}
 }

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -849,8 +849,9 @@ func (p *clusterpyProvisioner) prepareProvision(logger *log.Entry, cluster *api.
 	if err != nil {
 		return nil, nil, err
 	}
+	crdResolver := NewKarpenterCRDResolver(context.Background(), k8sClients)
 	additionalBackends := map[string]updatestrategy.ProviderNodePoolsBackend{
-		karpenterNodePoolProfile: updatestrategy.NewEC2NodePoolBackend(cluster.ID, adapter.session, updatestrategy.WithConfigGetter(KarpenterNodePoolConfigGetter(k8sClients))),
+		karpenterNodePoolProfile: updatestrategy.NewEC2NodePoolBackend(cluster.ID, adapter.session, updatestrategy.WithConfigGetter(crdResolver.ConfigGetter(k8sClients))),
 	}
 
 	asgBackend := updatestrategy.NewASGNodePoolsBackend(cluster.ID, adapter.session)

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -855,7 +855,7 @@ func (p *clusterpyProvisioner) prepareProvision(logger *log.Entry, cluster *api.
 	if err != nil {
 		return nil, nil, err
 	}
-	// TODO: lazy init, better error handling for the resolver and use a universal karpenter tag for decommission 'karpenter.sh/managed-by'
+
 	additionalBackends := map[string]updatestrategy.ProviderNodePoolsBackend{
 		karpenterNodePoolProfile: updatestrategy.NewEC2NodePoolBackend(cluster.ID, adapter.session, func() (*updatestrategy.KarpenterCRDNameResolver, error) {
 			return updatestrategy.NewKarpenterCRDResolver(context.Background(), k8sClients)


### PR DESCRIPTION
CLM had the CRDs for karpenter hardcoded.
these strings are used to query k8s api server searching for node pools to be cleaned up
the karpenter API is now upgraded from alpha to beta and thus the CRDs have been renamed and their structure have slightly changed

in this PR is adding support for both versions of karpenter (depends on a config_item)