### PR TITLE
provisioner: remove deprecated fields (take 2)

### DIFF
--- a/provisioner/clusterpy_test.go
+++ b/provisioner/clusterpy_test.go
@@ -47,11 +47,11 @@ post_apply:
 
 	deletionsContent2 = `
 pre_apply:
-- name: {{.Alias}}-pre
+- name: {{.Cluster.Alias}}-pre
   namespace: templated
   kind: deployment
 post_apply:
-- name: {{.Alias}}-post
+- name: {{.Cluster.Alias}}-post
   namespace: templated
   kind: deployment
 `

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -51,21 +51,6 @@ type templateContext struct {
 }
 
 type templateData struct {
-	// From api.Cluster, TODO: drop after we migrate all Kubernetes manifests
-	Alias                 string
-	APIServerURL          string
-	Channel               string
-	ConfigItems           map[string]string
-	CriticalityLevel      int32
-	Environment           string
-	ID                    string
-	InfrastructureAccount string
-	LifecycleStatus       string
-	LocalID               string
-	NodePools             []*api.NodePool
-	Region                string
-	Owner                 string
-
 	// Available everywhere
 	Cluster *api.Cluster
 
@@ -74,12 +59,6 @@ type templateData struct {
 
 	// Available in node pool templates
 	NodePool *api.NodePool
-
-	// User data (deprecated, TODO: move to .Values.UserData)
-	UserData string
-
-	// Path to the generated files uploaded to S3 (deprecated, TODO: move to .Values.S3GeneratedFilesPath)
-	S3GeneratedFilesPath string
 }
 
 func newTemplateContext(fileData map[string][]byte, cluster *api.Cluster, nodePool *api.NodePool, values map[string]interface{}, adapter *awsAdapter, instanceTypes *awsUtils.InstanceTypes) *templateContext {
@@ -168,30 +147,9 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 	var out bytes.Buffer
 
 	data := &templateData{
-		Alias:                 context.cluster.Alias,
-		APIServerURL:          context.cluster.APIServerURL,
-		Channel:               context.cluster.Channel,
-		ConfigItems:           context.cluster.ConfigItems,
-		CriticalityLevel:      context.cluster.CriticalityLevel,
-		Environment:           context.cluster.Environment,
-		ID:                    context.cluster.ID,
-		InfrastructureAccount: context.cluster.InfrastructureAccount,
-		LifecycleStatus:       context.cluster.LifecycleStatus,
-		LocalID:               context.cluster.LocalID,
-		NodePools:             context.cluster.NodePools,
-		Region:                context.cluster.Region,
-		Owner:                 context.cluster.Owner,
-		Cluster:               context.cluster,
-		Values:                context.values,
-		NodePool:              context.nodePool,
-	}
-
-	if ud, ok := context.values[userDataValuesKey]; ok {
-		data.UserData = ud.(string)
-	}
-
-	if s3path, ok := context.values[s3GeneratedFilesPathValuesKey]; ok {
-		data.S3GeneratedFilesPath = s3path.(string)
+		Cluster:  context.cluster,
+		Values:   context.values,
+		NodePool: context.nodePool,
 	}
 
 	err = t.Execute(&out, data)


### PR DESCRIPTION
Cluster templates were updated to use proper accessors:
* https://github.com/zalando-incubator/kubernetes-on-aws/pull/6627
* https://github.com/zalando-incubator/kubernetes-on-aws/pull/6808
* https://github.com/zalando-incubator/kubernetes-on-aws/pull/6819

- [x] requires internal manifests update

See previous #734