### PR TITLE
fix linter errors

### DIFF
--- a/controller/cluster_list.go
+++ b/controller/cluster_list.go
@@ -94,7 +94,7 @@ func updateBlocked(cluster *api.Cluster) bool {
 }
 
 func (clusterList *ClusterList) updateClusters(configSource channel.ConfigSource, availableClusters []*api.Cluster) {
-	availableClusterIds := make(map[string]bool)
+	availableClusterIDs := make(map[string]bool)
 
 	for _, cluster := range availableClusters {
 		if cluster.LifecycleStatus == statusDecommissioned {
@@ -107,7 +107,7 @@ func (clusterList *ClusterList) updateClusters(configSource channel.ConfigSource
 			continue
 		}
 
-		availableClusterIds[cluster.ID] = true
+		availableClusterIDs[cluster.ID] = true
 
 		currentVersion := api.ParseVersion(cluster.Status.CurrentVersion)
 
@@ -157,7 +157,7 @@ func (clusterList *ClusterList) updateClusters(configSource channel.ConfigSource
 			continue
 		}
 
-		if _, ok := availableClusterIds[id]; !ok {
+		if _, ok := availableClusterIDs[id]; !ok {
 			delete(clusterList.clusters, id)
 		}
 	}

--- a/controller/cluster_list_test.go
+++ b/controller/cluster_list_test.go
@@ -113,7 +113,7 @@ func TestUpdateIgnoresClusters(t *testing.T) {
 	}
 }
 
-func allClusterIds(clusterList *ClusterList) []string {
+func allClusterIDs(clusterList *ClusterList) []string {
 	var clusters []*ClusterInfo
 	var result []string
 	for {
@@ -152,11 +152,11 @@ func TestUpdateAddsNewClusters(t *testing.T) {
 
 	// One new cluster
 	clusterList.UpdateAvailable(MockChannelSource(false, false), []*api.Cluster{cluster1})
-	require.Equal(t, []string{cluster1.ID}, allClusterIds(clusterList))
+	require.Equal(t, []string{cluster1.ID}, allClusterIDs(clusterList))
 
 	// Another new cluster
 	clusterList.UpdateAvailable(MockChannelSource(false, false), []*api.Cluster{cluster1, cluster2})
-	require.Equal(t, []string{cluster2.ID, cluster1.ID}, allClusterIds(clusterList))
+	require.Equal(t, []string{cluster2.ID, cluster1.ID}, allClusterIDs(clusterList))
 }
 
 func TestUpdateUpdatesExistingClusters(t *testing.T) {
@@ -193,7 +193,7 @@ func TestUpdateUpdatesExistingClusters(t *testing.T) {
 	require.Nil(t, clusterList.SelectNext(dummyCancelFunc))
 	clusterList.UpdateAvailable(MockChannelSource(false, false), []*api.Cluster{updated})
 
-	assert.Equal(t, []string{cluster.ID}, allClusterIds(clusterList))
+	assert.Equal(t, []string{cluster.ID}, allClusterIDs(clusterList))
 }
 
 func sortedStrings(s []string) []string {
@@ -249,10 +249,10 @@ func TestUpdateDeletesUnusedClusters(t *testing.T) {
 	clusterList := NewClusterList(config.DefaultFilter)
 
 	clusterList.UpdateAvailable(MockChannelSource(false, false), []*api.Cluster{cluster1, cluster2})
-	require.Equal(t, []string{cluster1.ID, cluster2.ID}, sortedStrings(allClusterIds(clusterList)))
+	require.Equal(t, []string{cluster1.ID, cluster2.ID}, sortedStrings(allClusterIDs(clusterList)))
 
 	clusterList.UpdateAvailable(MockChannelSource(false, false), []*api.Cluster{cluster2})
-	require.Equal(t, []string{cluster2.ID}, allClusterIds(clusterList))
+	require.Equal(t, []string{cluster2.ID}, allClusterIDs(clusterList))
 }
 
 func TestClusterPriority(t *testing.T) {
@@ -299,11 +299,11 @@ func TestClusterPriority(t *testing.T) {
 		clusterList := NewClusterList(config.DefaultFilter)
 
 		clusterList.UpdateAvailable(MockChannelSource(false, false), clusters)
-		assert.Equal(t, []string{pendingUpdate.ID, decommissionRequested.ID, normal.ID}, allClusterIds(clusterList))
+		assert.Equal(t, []string{pendingUpdate.ID, decommissionRequested.ID, normal.ID}, allClusterIDs(clusterList))
 
 		// add normal2, it should now be updated before normal1
 		clusterList.UpdateAvailable(MockChannelSource(false, false), append(clusters, normal2))
-		assert.Equal(t, []string{pendingUpdate.ID, decommissionRequested.ID, normal2.ID, normal.ID}, allClusterIds(clusterList))
+		assert.Equal(t, []string{pendingUpdate.ID, decommissionRequested.ID, normal2.ID, normal.ID}, allClusterIDs(clusterList))
 	}
 }
 
@@ -357,7 +357,7 @@ func TestClusterLastUpdated(t *testing.T) {
 
 	// the same order should be preserved for next update attempts
 	clusterList.UpdateAvailable(MockChannelSource(false, false), clusters)
-	require.Equal(t, []string{next2.Cluster.ID, next1.Cluster.ID, next3.Cluster.ID}, allClusterIds(clusterList))
+	require.Equal(t, []string{next2.Cluster.ID, next1.Cluster.ID, next3.Cluster.ID}, allClusterIDs(clusterList))
 }
 
 func TestProcessingClusterNotDeleted(t *testing.T) {

--- a/pkg/updatestrategy/aws_asg.go
+++ b/pkg/updatestrategy/aws_asg.go
@@ -305,7 +305,7 @@ func (n *ASGNodePoolsBackend) Terminate(_ context.Context, node *Node, decrement
 				},
 			},
 		}
-		err := n.ec2Client.DescribeTagsPages(params, func(resp *ec2.DescribeTagsOutput, lastPage bool) bool {
+		err := n.ec2Client.DescribeTagsPages(params, func(resp *ec2.DescribeTagsOutput, _ bool) bool {
 			for _, tag := range resp.Tags {
 				if aws.StringValue(tag.Key) == ec2AutoscalingGroupTagKey {
 					asgName = aws.StringValue(tag.Value)
@@ -442,7 +442,7 @@ func (n *ASGNodePoolsBackend) getNodePoolASGs(nodePool *api.NodePool) ([]*autosc
 	}
 
 	var asgs []*autoscaling.Group
-	err := n.asgClient.DescribeAutoScalingGroupsPages(params, func(resp *autoscaling.DescribeAutoScalingGroupsOutput, lastPage bool) bool {
+	err := n.asgClient.DescribeAutoScalingGroupsPages(params, func(resp *autoscaling.DescribeAutoScalingGroupsOutput, _ bool) bool {
 		for _, group := range resp.AutoScalingGroups {
 			if asgHasAllTags(expectedTags, group.Tags) {
 				asgs = append(asgs, group)
@@ -535,7 +535,7 @@ func (n *ASGNodePoolsBackend) getInstancesToUpdate(asg *autoscaling.Group) (map[
 	}
 
 	// figure out if instance types or spotness changed
-	err := n.ec2Client.DescribeInstancesPages(describeParams, func(output *ec2.DescribeInstancesOutput, lastPage bool) bool {
+	err := n.ec2Client.DescribeInstancesPages(describeParams, func(output *ec2.DescribeInstancesOutput, _ bool) bool {
 		for _, reservation := range output.Reservations {
 			for _, instance := range reservation.Instances {
 				_, typeValid := launchParams.instanceTypes[aws.StringValue(instance.InstanceType)]

--- a/pkg/updatestrategy/aws_ec2.go
+++ b/pkg/updatestrategy/aws_ec2.go
@@ -154,7 +154,7 @@ func (n *EC2NodePoolBackend) getInstances(filters []*ec2.Filter) ([]*ec2.Instanc
 	}
 
 	instances := make([]*ec2.Instance, 0)
-	err := n.ec2Client.DescribeInstancesPagesWithContext(context.TODO(), params, func(output *ec2.DescribeInstancesOutput, lastPage bool) bool {
+	err := n.ec2Client.DescribeInstancesPagesWithContext(context.TODO(), params, func(output *ec2.DescribeInstancesOutput, _ bool) bool {
 		for _, reservation := range output.Reservations {
 			for _, instance := range reservation.Instances {
 				switch aws.StringValue(instance.State.Name) {

--- a/pkg/updatestrategy/aws_ec2.go
+++ b/pkg/updatestrategy/aws_ec2.go
@@ -243,13 +243,13 @@ func (n *EC2NodePoolBackend) decommission(ctx context.Context, filters []*ec2.Fi
 		return nil
 	}
 
-	instanceIds := make([]*string, 0, len(instances))
+	instanceIDs := make([]*string, 0, len(instances))
 	for _, instance := range instances {
-		instanceIds = append(instanceIds, instance.InstanceId)
+		instanceIDs = append(instanceIDs, instance.InstanceId)
 	}
 
 	params := &ec2.TerminateInstancesInput{
-		InstanceIds: instanceIds,
+		InstanceIds: instanceIDs,
 	}
 	_, err = n.ec2Client.TerminateInstancesWithContext(ctx, params)
 	if err != nil {

--- a/pkg/updatestrategy/drain_test.go
+++ b/pkg/updatestrategy/drain_test.go
@@ -199,7 +199,7 @@ func TestTerminateNodeCancelled(t *testing.T) {
 			drainConfig: &DrainConfig{},
 		}
 
-		evictPod = func(_ context.Context, client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
+		evictPod = func(_ context.Context, _ kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
 			atomic.AddInt32(&evictCount, 1)
 			return nil
 		}
@@ -271,7 +271,7 @@ func TestTerminateNodeCancelled(t *testing.T) {
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())
-		deletePod = func(_ context.Context, client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
+		deletePod = func(_ context.Context, _ kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
 			atomic.AddInt32(&deleteCount, 1)
 			cancel()
 			return nil

--- a/pkg/updatestrategy/drain_test.go
+++ b/pkg/updatestrategy/drain_test.go
@@ -199,7 +199,7 @@ func TestTerminateNodeCancelled(t *testing.T) {
 			drainConfig: &DrainConfig{},
 		}
 
-		evictPod = func(_ context.Context, _ kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
+		evictPod = func(_ context.Context, _ kubernetes.Interface, _ *log.Entry, _ v1.Pod) error {
 			atomic.AddInt32(&evictCount, 1)
 			return nil
 		}
@@ -271,7 +271,7 @@ func TestTerminateNodeCancelled(t *testing.T) {
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())
-		deletePod = func(_ context.Context, _ kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
+		deletePod = func(_ context.Context, _ kubernetes.Interface, _ *log.Entry, _ v1.Pod) error {
 			atomic.AddInt32(&deleteCount, 1)
 			cancel()
 			return nil

--- a/pkg/updatestrategy/drain_test.go
+++ b/pkg/updatestrategy/drain_test.go
@@ -37,7 +37,7 @@ func evictPodFailPDB(_ context.Context, _ kubernetes.Interface, _ *log.Entry, _ 
 }
 
 func TestTerminateNode(t *testing.T) {
-	evictPod = func(ctx context.Context, client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
+	evictPod = func(ctx context.Context, client kubernetes.Interface, _ *log.Entry, pod v1.Pod) error {
 		return removePod(ctx, client, pod)
 	}
 
@@ -199,7 +199,7 @@ func TestTerminateNodeCancelled(t *testing.T) {
 			drainConfig: &DrainConfig{},
 		}
 
-		evictPod = func(ctx context.Context, client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
+		evictPod = func(_ context.Context, client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
 			atomic.AddInt32(&evictCount, 1)
 			return nil
 		}
@@ -222,7 +222,7 @@ func TestTerminateNodeCancelled(t *testing.T) {
 		// evicted in parallel.
 		blockHelper.Add(2)
 
-		evictPod = func(ctx context.Context, client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
+		evictPod = func(ctx context.Context, client kubernetes.Interface, _ *log.Entry, pod v1.Pod) error {
 			// unblock so we can be cancelled
 			blockHelper.Done()
 			// wait until we're unblocked
@@ -271,7 +271,7 @@ func TestTerminateNodeCancelled(t *testing.T) {
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())
-		deletePod = func(ctx context.Context, client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
+		deletePod = func(_ context.Context, client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
 			atomic.AddInt32(&deleteCount, 1)
 			cancel()
 			return nil

--- a/pkg/updatestrategy/node_pool_manager_test.go
+++ b/pkg/updatestrategy/node_pool_manager_test.go
@@ -368,7 +368,7 @@ func TestCordonNode(t *testing.T) {
 }
 
 func TestScalePool(tt *testing.T) {
-	evictPod = func(ctx context.Context, client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
+	evictPod = func(_ context.Context, client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
 		return nil
 	}
 

--- a/pkg/updatestrategy/node_pool_manager_test.go
+++ b/pkg/updatestrategy/node_pool_manager_test.go
@@ -368,7 +368,7 @@ func TestCordonNode(t *testing.T) {
 }
 
 func TestScalePool(tt *testing.T) {
-	evictPod = func(_ context.Context, _ kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
+	evictPod = func(_ context.Context, _ kubernetes.Interface, _ *log.Entry, _ v1.Pod) error {
 		return nil
 	}
 

--- a/pkg/updatestrategy/node_pool_manager_test.go
+++ b/pkg/updatestrategy/node_pool_manager_test.go
@@ -368,7 +368,7 @@ func TestCordonNode(t *testing.T) {
 }
 
 func TestScalePool(tt *testing.T) {
-	evictPod = func(_ context.Context, client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
+	evictPod = func(_ context.Context, _ kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
 		return nil
 	}
 

--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -360,7 +360,7 @@ func (a *awsAdapter) ListStacks(includeTags, excludeTags map[string]string) ([]*
 	params := &cloudformation.DescribeStacksInput{}
 
 	stacks := make([]*cloudformation.Stack, 0)
-	err := a.cloudformationClient.DescribeStacksPages(params, func(resp *cloudformation.DescribeStacksOutput, lastPage bool) bool {
+	err := a.cloudformationClient.DescribeStacksPages(params, func(resp *cloudformation.DescribeStacksOutput, _ bool) bool {
 		for _, stack := range resp.Stacks {
 			if cloudformationHasTags(includeTags, stack.Tags) && cloudformationDoesNotHaveTags(excludeTags, stack.Tags) {
 				stacks = append(stacks, stack)

--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -563,7 +563,7 @@ func (a *awsAdapter) GetCertificates() ([]*certs.CertificateSummary, error) {
 		},
 	}
 	acmSummaries := make([]*acm.CertificateSummary, 0)
-	err := a.acmClient.ListCertificatesPages(params, func(page *acm.ListCertificatesOutput, lastPage bool) bool {
+	err := a.acmClient.ListCertificatesPages(params, func(page *acm.ListCertificatesOutput, _ bool) bool {
 		acmSummaries = append(acmSummaries, page.CertificateSummaryList...)
 		return true
 	})

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -214,8 +214,8 @@ func (p *clusterpyProvisioner) Provision(ctx context.Context, logger *log.Entry,
 	subnets = filterSubnets(subnets, subnetNot(isCustomSubnet))
 
 	// if subnets are defined in the config items, filter the subnet list
-	if subnetIds, ok := cluster.ConfigItems[subnetsConfigItemKey]; ok {
-		ids := strings.Split(subnetIds, ",")
+	if subnetIDs, ok := cluster.ConfigItems[subnetsConfigItemKey]; ok {
+		ids := strings.Split(subnetIDs, ",")
 		subnets = filterSubnets(subnets, subnetIDIncluded(ids))
 		if len(subnets) != len(ids) {
 			return fmt.Errorf("invalid or unknown subnets; desired %v", ids)

--- a/provisioner/clusterpy_test.go
+++ b/provisioner/clusterpy_test.go
@@ -146,7 +146,7 @@ func TestFilterSubnets(tt *testing.T) {
 		for _, tc := range []struct {
 			msg             string
 			subnets         []*ec2.Subnet
-			subnetIds       []string
+			subnetIDs       []string
 			expectedSubnets []*ec2.Subnet
 		}{
 
@@ -160,7 +160,7 @@ func TestFilterSubnets(tt *testing.T) {
 						SubnetId: aws.String("id-2"),
 					},
 				},
-				subnetIds: []string{"id-1"},
+				subnetIDs: []string{"id-1"},
 				expectedSubnets: []*ec2.Subnet{
 					{
 						SubnetId: aws.String("id-1"),
@@ -174,12 +174,12 @@ func TestFilterSubnets(tt *testing.T) {
 						SubnetId: aws.String("id-1"),
 					},
 				},
-				subnetIds:       []string{"id-2"},
+				subnetIDs:       []string{"id-2"},
 				expectedSubnets: nil,
 			},
 		} {
 			tt.Run(tc.msg, func(t *testing.T) {
-				subnets := filterSubnets(tc.subnets, subnetIDIncluded(tc.subnetIds))
+				subnets := filterSubnets(tc.subnets, subnetIDIncluded(tc.subnetIDs))
 				require.EqualValues(t, tc.expectedSubnets, subnets)
 			})
 		}
@@ -498,7 +498,7 @@ func TestWaitForAPIServer(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(tc.responseCode)
 			}))
 			defer ts.Close()

--- a/provisioner/remote_files_test.go
+++ b/provisioner/remote_files_test.go
@@ -172,7 +172,7 @@ func TestMakeArchive(t *testing.T) {
 			Encrypted:   true,
 		},
 	} {
-		t.Run(tc.Message, func(_ *testing.T) {
+		t.Run(tc.Message, func(t *testing.T) {
 			testKMSClient := &testKMSClient{}
 			archive, err := makeArchive(
 				makeTestInput(tc.Path, tc.Data, tc.Permissions, tc.Encrypted),

--- a/provisioner/remote_files_test.go
+++ b/provisioner/remote_files_test.go
@@ -172,7 +172,7 @@ func TestMakeArchive(t *testing.T) {
 			Encrypted:   true,
 		},
 	} {
-		t.Run(tc.Message, func(tt *testing.T) {
+		t.Run(tc.Message, func(_ *testing.T) {
 			testKMSClient := &testKMSClient{}
 			archive, err := makeArchive(
 				makeTestInput(tc.Path, tc.Data, tc.Permissions, tc.Encrypted),


### PR DESCRIPTION
## Summary of Changes

1. Renames unused parameters to _
2. Renames symbols as suggested by the linter errors


## Background
In another patch, `golangci-lint` was reporting the following:
```
pkg/updatestrategy/aws_asg.go:308:83: unused-parameter: parameter 'lastPage' seems to be unused, consider removing or renaming it as _ (revive)
		err := n.ec2Client.DescribeTagsPages(params, func(resp *ec2.DescribeTagsOutput, lastPage bool) bool {
		                                                                                ^
pkg/updatestrategy/aws_ec2.go:246:2: var-naming: var instanceIds should be instanceIDs (revive)
	instanceIds := make([]*string, 0, len(instances))
	^
pkg/updatestrategy/aws_asg.go:445:116: unused-parameter: parameter 'lastPage' seems to be unused, consider removing or renaming it as _ (revive)
	err := n.asgClient.DescribeAutoScalingGroupsPages(params, func(resp *autoscaling.DescribeAutoScalingGroupsOutput, lastPage bool) bool {
	                                                                                                                  ^
pkg/updatestrategy/aws_asg.go:538:102: unused-parameter: parameter 'lastPage' seems to be unused, consider removing or renaming it as _ (revive)
	err := n.ec2Client.DescribeInstancesPages(describeParams, func(output *ec2.DescribeInstancesOutput, lastPage bool) bool {
	                                                                                                    ^
pkg/updatestrategy/node_pool_manager_test.go:371:18: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
	evictPod = func(ctx context.Context, client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
	                ^
pkg/updatestrategy/drain_test.go:40:68: unused-parameter: parameter 'logger' seems to be unused, consider removing or renaming it as _ (revive)
	evictPod = func(ctx context.Context, client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
	                                                                  ^
pkg/updatestrategy/drain_test.go:202:19: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
		evictPod = func(ctx context.Context, client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
		                ^
pkg/updatestrategy/drain_test.go:225:69: unused-parameter: parameter 'logger' seems to be unused, consider removing or renaming it as _ (revive)
		evictPod = func(ctx context.Context, client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
		                                                                  ^
pkg/updatestrategy/drain_test.go:274:20: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
		deletePod = func(ctx context.Context, client kubernetes.Interface, logger *log.Entry, pod v1.Pod) error {
09/02/2024 14:31:07 		                 ^
provisioner/remote_files_test.go:175:26: unused-parameter: parameter 'tt' seems to be unused, consider removing or renaming it as _ (revive)
		t.Run(tc.Message, func(tt *testing.T) {
		                       ^
provisioner/clusterpy_test.go:501:74: unused-parameter: parameter 'r' seems to be unused, consider removing or renaming it as _ (revive)
			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
			                                                                      ^
provisioner/clusterpy_test.go:149:4: var-naming: struct field subnetIds should be subnetIDs (revive)
			subnetIds       []string
			^
provisioner/clusterpy.go:217:5: var-naming: var subnetIds should be subnetIDs (revive)
	if subnetIds, ok := cluster.ConfigItems[subnetsConfigItemKey]; ok {
	   ^
controller/cluster_list.go:97:2: var-naming: var availableClusterIds should be availableClusterIDs (revive)
	availableClusterIds := make(map[string]bool)
	^
controller/cluster_list_test.go:116:6: var-naming: func allClusterIds should be allClusterIDs (revive)
func allClusterIds(clusterList *ClusterList) []string {
     ^

```