### PR TITLE
Revert "provisioner: remove deprecated fields (#745)"

### DIFF
--- a/provisioner/clusterpy_test.go
+++ b/provisioner/clusterpy_test.go
@@ -47,11 +47,11 @@ post_apply:
 
 	deletionsContent2 = `
 pre_apply:
-- name: {{.Cluster.Alias}}-pre
+- name: {{.Alias}}-pre
   namespace: templated
   kind: deployment
 post_apply:
-- name: {{.Cluster.Alias}}-post
+- name: {{.Alias}}-post
   namespace: templated
   kind: deployment
 `


### PR DESCRIPTION
This reverts commit 9b60c7325726edec6f3c2c130585f061459cca6e (#745).

Due to https://github.com/zalando-incubator/kubernetes-on-aws/pull/7108