### PR TITLE
config: move provider id enum into config package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,14 @@ import (
 	"github.com/zalando-incubator/cluster-lifecycle-manager/pkg/updatestrategy"
 )
 
+// A provider ID is a string that identifies a cluster provider.
+type ProviderID string
+
+const (
+	// ZalandoAWS Provider is the provider ID for Zalando managed AWS clusters.
+	ZalandoAWSProvider ProviderID = "zalando-aws"
+)
+
 const (
 	defaultInterval                         = "10m"
 	defaultListener                         = ":9090"
@@ -27,7 +35,6 @@ const (
 	defaultDrainForceEvictInterval          = "5m"
 	defaultDrainPollInterval                = "30s"
 	defaultUpdateStrategy                   = "clc"
-	defaultProvider                         = "zalando-aws"
 )
 
 var defaultWorkdir = path.Join(os.TempDir(), "clm-workdir")
@@ -94,7 +101,7 @@ func (cfg *LifecycleManagerConfig) ParseFlags() string {
 	kingpin.Flag(
 		"provider",
 		"Cloud provider. Defaults to single provider \"zalando-aws\".",
-	).Default(defaultProvider).EnumsVar(&cfg.Providers, "zalando-aws")
+	).Default(string(ZalandoAWSProvider)).EnumsVar(&cfg.Providers, string(ZalandoAWSProvider))
 	kingpin.Flag("config-source", "Config source specification (NAME:dir:PATH or NAME:git:URL). At least one is required.").StringsVar(&cfg.ConfigSources)
 	kingpin.Flag("directory", "Use a single directory as a config source (for local/development use)").StringVar(&cfg.Directory)
 	kingpin.Flag("concurrent-updates", "Number of updates allowed to run in parallel.").Default(defaultConcurrentUpdates).UintVar(&cfg.ConcurrentUpdates)

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -102,7 +102,7 @@ func NewClusterpyProvisioner(execManager *command.ExecManager, tokenSource oauth
 }
 
 func (p *clusterpyProvisioner) Supports(cluster *api.Cluster) bool {
-	return cluster.Provider == string(ZalandoAWSProvider)
+	return cluster.Provider == string(config.ZalandoAWSProvider)
 }
 
 func (p *clusterpyProvisioner) updateDefaults(cluster *api.Cluster, channelConfig channel.Config, adapter *awsAdapter, instanceTypes *awsUtils.InstanceTypes) error {

--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -12,9 +12,6 @@ import (
 )
 
 type (
-	// A provider ID is a string that identifies a cluster provider.
-	ProviderID string
-
 	// Options is the options that can be passed to a provisioner when initialized.
 	Options struct {
 		DryRun          bool
@@ -23,11 +20,6 @@ type (
 		RemoveVolumes   bool
 		ManageEtcdStack bool
 	}
-)
-
-const (
-	// ZalandoAWS Provider is the provider ID for Zalando managed AWS clusters.
-	ZalandoAWSProvider ProviderID = "zalando-aws"
 )
 
 var (


### PR DESCRIPTION
Move enum into config package to avoid import cycle and eliminate duplicate string literals.

Follow up on https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/765/files#r1601499528