### PR TITLE
Add EKS Provider ID.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -94,7 +94,7 @@ func (cfg *LifecycleManagerConfig) ParseFlags() string {
 	kingpin.Flag(
 		"provider",
 		"Cloud provider. Defaults to single provider \"zalando-aws\".",
-	).Default(defaultProvider).EnumsVar(&cfg.Providers, "zalando-aws")
+	).Default(defaultProvider).EnumsVar(&cfg.Providers, "zalando-aws", "zalando-eks")
 	kingpin.Flag("config-source", "Config source specification (NAME:dir:PATH or NAME:git:URL). At least one is required.").StringsVar(&cfg.ConfigSources)
 	kingpin.Flag("directory", "Use a single directory as a config source (for local/development use)").StringVar(&cfg.Directory)
 	kingpin.Flag("concurrent-updates", "Number of updates allowed to run in parallel.").Default(defaultConcurrentUpdates).UintVar(&cfg.ConcurrentUpdates)

--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -26,8 +26,10 @@ type (
 )
 
 const (
-	// ZalandoAWS Provider is the provider ID for Zalando managed AWS clusters.
+	// ZalandoAWSProvider is the provider ID for Zalando managed AWS clusters.
 	ZalandoAWSProvider ProviderID = "zalando-aws"
+	// ZalandoEKSProvider is the provider ID for AWS EKS clusters.
+	ZalandoEKSProvider ProviderID = "zalando-eks"
 )
 
 var (


### PR DESCRIPTION
This Pull request adds the Provider ID for AWS EKS to the Cluster Lifecycle Manager (CLM). The `--provider` parameter will also accept `zalando-eks`. Implementing provisioning for EKS is left to another Pull Request, so the effect of configuring provider for `zalano-eks` will have the effect of CLM receiving an empty list of clusters from the Cluster Registry. This minimal setting will therefore allow to test and configure a deployment step of a CLM for Zalando EKS in a test cluster in our pipeline.