### PR TITLE
flex karpenter node-pool configurations

### DIFF
--- a/api/node_pool.go
+++ b/api/node_pool.go
@@ -3,8 +3,11 @@ package api
 import (
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/pkg/kubernetes"
+	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/client-go/applyconfigurations/core/v1"
 )
 
 // NodePool describes a node pool in a kubernetes cluster.
@@ -46,4 +49,17 @@ func (np NodePool) Taints() []*corev1.Taint {
 		}
 	}
 	return taints
+}
+
+func (np NodePool) KarpenterRequirements() []v1.NodeSelectorRequirementApplyConfiguration {
+	conf, exist := np.ConfigItems["requirements"]
+	if !exist {
+		return nil
+	}
+	var requirements []v1.NodeSelectorRequirementApplyConfiguration
+	err := yaml.Unmarshal([]byte(conf), &requirements)
+	if err != nil {
+		log.Errorf("Error unmarshalling requirements: %v", err)
+	}
+	return requirements
 }

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/luci/go-render v0.0.0-20160219211803-9a04cc21af0f
+	github.com/samber/lo v1.39.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6ke
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
 github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6gto+ugjYE=
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
+github.com/samber/lo v1.39.0 h1:4gTz1wUhNYLhFSKl6O+8peW0v2F4BCY034GRpU9WnuA=
+github.com/samber/lo v1.39.0/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/registry/file.go
+++ b/registry/file.go
@@ -40,6 +40,10 @@ func (r *fileRegistry) ListClusters(_ Filter) ([]*api.Cluster, error) {
 
 	for _, cluster := range fileClusters.Clusters {
 		for _, nodePool := range cluster.NodePools {
+			if nodePool.Profile == "worker-karpenter" && len(nodePool.InstanceTypes) == 0 {
+				nodePool.InstanceType = ""
+				continue
+			}
 			if len(nodePool.InstanceTypes) == 0 {
 				return nil, fmt.Errorf("no instance types for cluster %s, pool %s", cluster.ID, nodePool.Name)
 			}


### PR DESCRIPTION
- make the instanceType column non mandatory for karpenter pools
- parse a node pool config item "requirements" to allow injecting granular karpenter pool requirements
example:
``` yaml
  - config_items:
      taints: nvidia.com/gpu=present:NoSchedule
      requirements: |
        - key: karpenter.k8s.aws/instance-gpu-manufacturer
          operator: In
          values: 
            - nvidia
    discount_strategy: null
    instance_types: null
    max_size: null
    min_size: null
    name: karpenter-gpu
    profile: worker-karpenter
```

related to https://github.com/zalando-incubator/kubernetes-on-aws/pull/7617