### PR TITLE
provisioner: add list template function

### DIFF
--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -127,6 +127,7 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		"awsValidID":                            awsValidID,
 		"indent":                                sprig.GenericFuncMap()["indent"],
 		"dict":                                  dict,
+		"list":                                  list,
 		"scaleQuantity":                         scaleQuantity,
 		"instanceTypeCPUQuantity": func(instanceType string) (string, error) {
 			return instanceTypeCPUQuantity(context, instanceType)
@@ -273,6 +274,10 @@ func dict(args ...interface{}) (map[string]interface{}, error) {
 		dict[key] = args[i+1]
 	}
 	return dict, nil
+}
+
+func list(args ...interface{}) []interface{} {
+	return args
 }
 
 // accountID returns just the ID part of an account

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -1253,6 +1253,29 @@ func TestDictInvalidArgs(t *testing.T) {
 	}
 }
 
+func TestList(t *testing.T) {
+	result, err := renderSingle(
+		t,
+		`
+{{- $alist := list
+	"foo"
+	"bar"
+	1
+}}
+{{- range $i, $v := $alist }}
+{{ $i }}={{ $v }}
+{{- end }}
+`,
+		nil)
+
+	require.NoError(t, err)
+	require.EqualValues(t, `
+0=foo
+1=bar
+2=1
+`, result)
+}
+
 func TestScaleQuantity(t *testing.T) {
 	for _, tc := range []struct {
 		name     string


### PR DESCRIPTION
This is useful for defining a fixed list instead of splitting a comma-separated string.

See also previous #711