### PR TITLE
Reduce dependabot frequency to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,7 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-  #   interval: monthly
-    interval: daily
-    time: "07:00"
+    interval: weekly
   open-pull-requests-limit: 10
   groups:
     all-go-mod-patch-and-minor:


### PR DESCRIPTION
After #786 we get daily updates because of patch updates of e.g. aws-sdk-go: #788 , #787 

This seem like too much toil, so let's reduce the cadence of updates to weekly after we have verified the grouping of updates work.