### PR TITLE
Show config-item failing to decrypt

### DIFF
--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -149,7 +149,7 @@ func (p *clusterpyProvisioner) decryptConfigItems(cluster *api.Cluster) error {
 	for key, item := range cluster.ConfigItems {
 		plaintext, err := p.secretDecrypter.Decrypt(item)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to decrypt config-item: %s: %w", key, err)
 		}
 		cluster.ConfigItems[key] = plaintext
 	}


### PR DESCRIPTION
Show which config-item is failing to decrypt to help debugging. Before the error just indicated that _some_ config-item decryption failed. 