### PR TITLE
Implement EKS provisioning and support multiple provisioners.

### DIFF
--- a/cmd/clm/main.go
+++ b/cmd/clm/main.go
@@ -115,39 +115,34 @@ func main() {
 
 	execManager := command.NewExecManager(cfg.ConcurrentExternalProcesses)
 
-	provisioners := map[provisioner.ProviderID]provisioner.Provisioner{}
-	for _, provider := range cfg.Providers {
-		switch provider {
-		case string(provisioner.ZalandoAWSProvider):
-			provisioners[provisioner.ZalandoAWSProvider] = provisioner.NewZalandoAWSProvisioner(
-				execManager,
-				clusterTokenSource,
-				secretDecrypter,
-				cfg.AssumedRole,
-				awsConfig,
-				&provisioner.Options{
-					DryRun:          cfg.DryRun,
-					ApplyOnly:       cfg.ApplyOnly,
-					UpdateStrategy:  cfg.UpdateStrategy,
-					RemoveVolumes:   cfg.RemoveVolumes,
-					ManageEtcdStack: cfg.ManageEtcdStack,
-				},
-			)
-		case string(provisioner.ZalandoEKSProvider):
-			provisioners[provisioner.ZalandoEKSProvider] = provisioner.NewZalandoEKSProvisioner(
-				execManager,
-				secretDecrypter,
-				cfg.AssumedRole,
-				awsConfig,
-				&provisioner.Options{
-					DryRun:         cfg.DryRun,
-					ApplyOnly:      cfg.ApplyOnly,
-					UpdateStrategy: cfg.UpdateStrategy,
-					RemoveVolumes:  cfg.RemoveVolumes,
-					Modifier:       &provisioner.ZalandoEKSModifier{},
-				},
-			)
-		}
+	provisioners := map[provisioner.ProviderID]provisioner.Provisioner{
+		provisioner.ZalandoAWSProvider: provisioner.NewZalandoAWSProvisioner(
+			execManager,
+			clusterTokenSource,
+			secretDecrypter,
+			cfg.AssumedRole,
+			awsConfig,
+			&provisioner.Options{
+				DryRun:          cfg.DryRun,
+				ApplyOnly:       cfg.ApplyOnly,
+				UpdateStrategy:  cfg.UpdateStrategy,
+				RemoveVolumes:   cfg.RemoveVolumes,
+				ManageEtcdStack: cfg.ManageEtcdStack,
+			},
+		),
+		provisioner.ZalandoEKSProvider: provisioner.NewZalandoEKSProvisioner(
+			execManager,
+			secretDecrypter,
+			cfg.AssumedRole,
+			awsConfig,
+			&provisioner.Options{
+				DryRun:         cfg.DryRun,
+				ApplyOnly:      cfg.ApplyOnly,
+				UpdateStrategy: cfg.UpdateStrategy,
+				RemoveVolumes:  cfg.RemoveVolumes,
+				Modifier:       &provisioner.ZalandoEKSModifier{},
+			},
+		),
 	}
 
 	configSource, err := setupConfigSource(execManager, cfg)

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -18,8 +18,8 @@ import (
 )
 
 const (
-	nextVersion  = "version"
-	mockProvider = "<mock>"
+	nextVersion                         = "version"
+	mockProvider provisioner.ProviderID = "<mock>"
 )
 
 var defaultLogger = log.WithFields(map[string]interface{}{})
@@ -27,7 +27,7 @@ var defaultLogger = log.WithFields(map[string]interface{}{})
 type mockProvisioner struct{}
 
 func (p *mockProvisioner) Supports(cluster *api.Cluster) bool {
-	return cluster.Provider == mockProvider
+	return cluster.Provider == string(mockProvider)
 }
 
 func (p *mockProvisioner) Provision(
@@ -115,7 +115,7 @@ func createMockRegistry(lifecycleStatus string, status *api.ClusterStatus) *mock
 		Channel:               "alpha",
 		LifecycleStatus:       lifecycleStatus,
 		Status:                status,
-		Provider:              mockProvider,
+		Provider:              string(mockProvider),
 	}
 	return &mockRegistry{theCluster: cluster}
 }
@@ -288,7 +288,7 @@ func TestProcessCluster(t *testing.T) {
 			command.NewExecManager(1),
 			ti.registry,
 			map[provisioner.ProviderID]provisioner.Provisioner{
-				provisioner.ZalandoAWSProvider: ti.provisioner,
+				mockProvider: ti.provisioner,
 			},
 			ti.channelSource,
 			ti.options,
@@ -341,7 +341,7 @@ func TestCoalesceFailures(t *testing.T) {
 			command.NewExecManager(1),
 			registry,
 			map[provisioner.ProviderID]provisioner.Provisioner{
-				"<supported>": &mockCountingErrProvisioner{},
+				mockProvider: &mockCountingErrProvisioner{},
 			},
 			MockChannelSource(false, false),
 			defaultOptions,
@@ -369,7 +369,7 @@ func TestCoalesceFailures(t *testing.T) {
 			command.NewExecManager(1),
 			registry,
 			map[provisioner.ProviderID]provisioner.Provisioner{
-				"<supported>": &mockErrProvisioner{},
+				mockProvider: &mockErrProvisioner{},
 			},
 			MockChannelSource(false, false),
 			defaultOptions,

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -30,7 +30,12 @@ func (p *mockProvisioner) Supports(cluster *api.Cluster) bool {
 	return cluster.Provider == mockProvider
 }
 
-func (p *mockProvisioner) Provision(_ context.Context, _ *log.Entry, _ *api.Cluster, _ channel.Config) error {
+func (p *mockProvisioner) Provision(
+	_ context.Context,
+	_ *log.Entry,
+	_ *api.Cluster,
+	_ channel.Config,
+) error {
 	return nil
 }
 
@@ -44,7 +49,12 @@ func (p *mockErrProvisioner) Supports(_ *api.Cluster) bool {
 	return true
 }
 
-func (p *mockErrProvisioner) Provision(_ context.Context, _ *log.Entry, _ *api.Cluster, _ channel.Config) error {
+func (p *mockErrProvisioner) Provision(
+	_ context.Context,
+	_ *log.Entry,
+	_ *api.Cluster,
+	_ channel.Config,
+) error {
 	return fmt.Errorf("failed to provision")
 }
 
@@ -58,7 +68,12 @@ func (p *mockErrCreateProvisioner) Supports(_ *api.Cluster) bool {
 	return true
 }
 
-func (p *mockErrCreateProvisioner) Provision(_ context.Context, _ *log.Entry, _ *api.Cluster, _ channel.Config) error {
+func (p *mockErrCreateProvisioner) Provision(
+	_ context.Context,
+	_ *log.Entry,
+	_ *api.Cluster,
+	_ channel.Config,
+) error {
 	return fmt.Errorf("failed to provision")
 }
 
@@ -71,7 +86,12 @@ func (p *mockCountingErrProvisioner) Supports(_ *api.Cluster) bool {
 	return true
 }
 
-func (p *mockCountingErrProvisioner) Provision(_ context.Context, _ *log.Entry, _ *api.Cluster, _ channel.Config) error {
+func (p *mockCountingErrProvisioner) Provision(
+	_ context.Context,
+	_ *log.Entry,
+	_ *api.Cluster,
+	_ channel.Config,
+) error {
 	p.attempt++
 	return fmt.Errorf("attempt %d failed to provision", p.attempt)
 }
@@ -263,7 +283,16 @@ func TestProcessCluster(t *testing.T) {
 			success:       false,
 		},
 	} {
-		controller := New(defaultLogger, command.NewExecManager(1), ti.registry, ti.provisioner, ti.channelSource, ti.options)
+		controller := New(
+			defaultLogger,
+			command.NewExecManager(1),
+			ti.registry,
+			map[provisioner.ProviderID]provisioner.Provisioner{
+				provisioner.ZalandoAWSProvider: ti.provisioner,
+			},
+			ti.channelSource,
+			ti.options,
+		)
 		err := controller.refresh()
 		assert.NoError(t, err)
 
@@ -286,7 +315,16 @@ func TestProcessCluster(t *testing.T) {
 func TestIgnoreUnsupportedProvider(t *testing.T) {
 	registry := createMockRegistry("ready", nil)
 	registry.theCluster.Provider = "<unsupported>"
-	controller := New(defaultLogger, command.NewExecManager(1), registry, &mockProvisioner{}, MockChannelSource(false, false), defaultOptions)
+	controller := New(
+		defaultLogger,
+		command.NewExecManager(1),
+		registry,
+		map[provisioner.ProviderID]provisioner.Provisioner{
+			"<supported>": &mockProvisioner{},
+		},
+		MockChannelSource(false, false),
+		defaultOptions,
+	)
 
 	err := controller.refresh()
 	require.NoError(t, err)
@@ -298,7 +336,16 @@ func TestIgnoreUnsupportedProvider(t *testing.T) {
 func TestCoalesceFailures(t *testing.T) {
 	t.Run("limits various problems", func(t *testing.T) {
 		registry := createMockRegistry("ready", nil)
-		controller := New(defaultLogger, command.NewExecManager(1), registry, &mockCountingErrProvisioner{}, MockChannelSource(false, false), defaultOptions)
+		controller := New(
+			defaultLogger,
+			command.NewExecManager(1),
+			registry,
+			map[provisioner.ProviderID]provisioner.Provisioner{
+				"<supported>": &mockCountingErrProvisioner{},
+			},
+			MockChannelSource(false, false),
+			defaultOptions,
+		)
 
 		for i := 0; i < 100; i++ {
 			err := controller.refresh()
@@ -317,7 +364,16 @@ func TestCoalesceFailures(t *testing.T) {
 
 	t.Run("compacts repeating problems", func(t *testing.T) {
 		registry := createMockRegistry("ready", nil)
-		controller := New(defaultLogger, command.NewExecManager(1), registry, &mockErrProvisioner{}, MockChannelSource(false, false), defaultOptions)
+		controller := New(
+			defaultLogger,
+			command.NewExecManager(1),
+			registry,
+			map[provisioner.ProviderID]provisioner.Provisioner{
+				"<supported>": &mockErrProvisioner{},
+			},
+			MockChannelSource(false, false),
+			defaultOptions,
+		)
 
 		for i := 0; i < 100; i++ {
 			err := controller.refresh()

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -455,7 +455,7 @@ func (k *KubeCTLRunner) KubectlExecute(ctx context.Context, args []string, stdin
 	}
 
 	newCommand := func() *exec.Cmd {
-		cmd := exec.Command("kubectl", args[1:]...)
+		cmd := exec.Command("kubectl", args[0:]...)
 		// prevent kubectl to find the in-cluster config
 		cmd.Env = []string{}
 		return cmd

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -129,8 +129,16 @@ type ClientsCollection struct {
 	Mapper        meta.RESTMapper
 }
 
-func NewClientsCollection(host string, tokenSrc oauth2.TokenSource, ca []byte) (*ClientsCollection, error) {
-	cfg := newConfig(host, tokenSrc, ca)
+// NewClientsCollection returns a collection with dynamic and typed Kubernetes
+// clients, configured for the specified host.
+//
+// caData is an optional CA certificate data for the Kubernetes API server.
+func NewClientsCollection(
+	host string,
+	tokenSrc oauth2.TokenSource,
+	caData []byte,
+) (*ClientsCollection, error) {
+	cfg := newConfig(host, tokenSrc, caData)
 	typedClient, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return nil, err
@@ -384,11 +392,18 @@ type KubeCTLRunner struct {
 	tokenSource oauth2.TokenSource
 	logger      *logrus.Entry
 	k8sAPIURL   string
-	clusterCA   []byte // TODO: eks support
+	clusterCA   []byte
 	maxRetries  uint64
 }
 
-func NewKubeCTLRunner(e *command.ExecManager, ts oauth2.TokenSource, l *logrus.Entry, k8sAPIURL string, clusterCA []byte, maxRetries uint64) *KubeCTLRunner {
+func NewKubeCTLRunner(
+	e *command.ExecManager,
+	ts oauth2.TokenSource,
+	l *logrus.Entry,
+	k8sAPIURL string,
+	maxRetries uint64,
+	clusterCA []byte,
+) *KubeCTLRunner {
 	return &KubeCTLRunner{
 		execManager: e,
 		tokenSource: ts,
@@ -405,35 +420,42 @@ func (k *KubeCTLRunner) KubectlExecute(ctx context.Context, args []string, stdin
 		return "", err
 	}
 
-	// if EKS write CA
-	tmpfile, err := os.CreateTemp("", "cluster_*.ca.crt")
-	if err != nil {
-		return "", err
-	}
-	defer os.Remove(tmpfile.Name())
-
-	_, err = tmpfile.Write(k.clusterCA)
-	if err != nil {
-		return "", err
-	}
-
-	err = tmpfile.Close()
-	if err != nil {
-		return "", err
-	}
-
-	args = append([]string{
-		"kubectl",
+	kubeCtlOpts := []string{
 		fmt.Sprintf("--server=%s", k.k8sAPIURL),
 		fmt.Sprintf("--token=%s", token.AccessToken),
-		fmt.Sprintf("--certificate-authority=%s", tmpfile.Name()), // TODO: eks
-	}, args...)
+	}
+
+	// Use custom CA if provided
+	if len(k.clusterCA) != 0 {
+		tmpfile, err := os.CreateTemp("", "cluster_*.ca.crt")
+		if err != nil {
+			return "", err
+		}
+		defer os.Remove(tmpfile.Name())
+
+		_, err = tmpfile.Write(k.clusterCA)
+		if err != nil {
+			return "", err
+		}
+
+		err = tmpfile.Close()
+		if err != nil {
+			return "", err
+		}
+
+		kubeCtlOpts = append(
+			kubeCtlOpts,
+			fmt.Sprintf("--certificate-authority=%s", tmpfile.Name()),
+		)
+	}
+
+	args = append(kubeCtlOpts, args...)
 	if stdin != "" {
 		args = append(args, "-f", "-")
 	}
 
 	newCommand := func() *exec.Cmd {
-		cmd := exec.Command(args[0], args[1:]...)
+		cmd := exec.Command("kubectl", args[1:]...)
 		// prevent kubectl to find the in-cluster config
 		cmd.Env = []string{}
 		return cmd

--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -34,7 +34,6 @@ import (
 	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
 	awsutil "github.com/zalando-incubator/kube-ingress-aws-controller/aws"
 	"github.com/zalando-incubator/kube-ingress-aws-controller/certs"
-	"golang.org/x/oauth2"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -100,14 +99,13 @@ type awsAdapter struct {
 	eksClient            eksiface.EKSAPI
 	region               string
 	apiServer            string
-	tokenSrc             oauth2.TokenSource
 	dryRun               bool
 	logger               *log.Entry
 	kmsClient            kmsiface.KMSAPI
 }
 
 // newAWSAdapter initializes a new awsAdapter.
-func newAWSAdapter(logger *log.Entry, apiServer string, region string, sess *session.Session, tokenSrc oauth2.TokenSource, dryRun bool) (*awsAdapter, error) {
+func newAWSAdapter(logger *log.Entry, apiServer string, region string, sess *session.Session, dryRun bool) *awsAdapter {
 	return &awsAdapter{
 		session:              sess,
 		cloudformationClient: cloudformation.New(sess),
@@ -120,11 +118,10 @@ func newAWSAdapter(logger *log.Entry, apiServer string, region string, sess *ses
 		eksClient:            eks.New(sess),
 		region:               region,
 		apiServer:            apiServer,
-		tokenSrc:             tokenSrc,
 		dryRun:               dryRun,
 		logger:               logger,
 		kmsClient:            kms.New(sess),
-	}, nil
+	}
 }
 
 func (a *awsAdapter) VerifyAccount(accountID string) error {

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -664,15 +664,10 @@ func (p *clusterpyProvisioner) decommission(
 ) error {
 	logger.Infof("Decommissioning cluster: %s (%s)", cluster.Alias, cluster.ID)
 
-	awsAdapter, err := p.setupAWSAdapter(logger, cluster)
-	if err != nil {
-		return err
-	}
-
 	// scale down kube-system deployments
 	// This is done to ensure controllers stop running so they don't
 	// recreate resources we delete in the next step
-	err = backoff.Retry(
+	err := backoff.Retry(
 		func() error {
 			err := p.downscaleDeployments(
 				ctx,

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -63,7 +63,6 @@ const (
 )
 
 type clusterpyProvisioner struct {
-	provider          ProviderID
 	awsConfig         *aws.Config
 	execManager       *command.ExecManager
 	secretDecrypter   decrypter.Decrypter
@@ -81,10 +80,6 @@ type clusterpyProvisioner struct {
 type manifestPackage struct {
 	name      string
 	manifests []string
-}
-
-func (p *clusterpyProvisioner) Supports(cluster *api.Cluster) bool {
-	return cluster.Provider == string(p.provider)
 }
 
 func (p *clusterpyProvisioner) updateDefaults(cluster *api.Cluster, channelConfig channel.Config, adapter *awsAdapter, instanceTypes *awsUtils.InstanceTypes) error {
@@ -162,10 +157,6 @@ func (p *clusterpyProvisioner) provision(
 	cluster *api.Cluster,
 	channelConfig channel.Config,
 ) error {
-	if !p.Supports(cluster) {
-		return ErrProviderNotSupported
-	}
-
 	// fetch instance data that will be used by all the render functions
 	instanceTypes, err := awsUtils.NewInstanceTypesFromAWS(awsAdapter.ec2Client)
 	if err != nil {
@@ -670,10 +661,6 @@ func (p *clusterpyProvisioner) decommission(
 	cluster *api.Cluster,
 	caData []byte,
 ) error {
-	if !p.Supports(cluster) {
-		return ErrProviderNotSupported
-	}
-
 	logger.Infof("Decommissioning cluster: %s (%s)", cluster.Alias, cluster.ID)
 
 	awsAdapter, err := p.setupAWSAdapter(logger, cluster)

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -387,12 +387,13 @@ func (p *clusterpyProvisioner) provision(
 		return err
 	}
 
-	// err = nodePoolGroups["masters"].provisionNodePoolGroup(ctx, values, updater, cluster, p.applyOnly)
-	// if err != nil {
-	// 	return err
-	// }
+	if p.manageMasterNodes {
+		err = nodePoolGroups["masters"].provisionNodePoolGroup(ctx, values, updater, cluster, p.applyOnly)
+		if err != nil {
+			return err
+		}
+	}
 
-	// TODO: EKS?
 	err = nodePoolGroups["workers"].provisionNodePoolGroup(ctx, values, updater, cluster, p.applyOnly)
 	if err != nil {
 		return err

--- a/provisioner/clusterpy_test.go
+++ b/provisioner/clusterpy_test.go
@@ -524,7 +524,7 @@ func TestProvisionDoesNotSupportProvider(t *testing.T) {
 		Provider: "zalando-eks",
 	}
 
-	p := clusterpyProvisioner{}
+	p := ZalandoEKSProvisioner{}
 	err := p.Provision(context.TODO(), nil, cluster, nil)
 	assert.Equal(t, ErrProviderNotSupported, err)
 }
@@ -533,7 +533,7 @@ func TestDecommissionDoesNotSupportProvider(t *testing.T) {
 		Provider: "zalando-eks",
 	}
 
-	p := clusterpyProvisioner{}
+	p := ZalandoEKSProvisioner{}
 	err := p.Decommission(context.TODO(), nil, cluster)
 	assert.Equal(t, ErrProviderNotSupported, err)
 }

--- a/provisioner/clusterpy_test.go
+++ b/provisioner/clusterpy_test.go
@@ -524,16 +524,17 @@ func TestProvisionDoesNotSupportProvider(t *testing.T) {
 		Provider: "zalando-eks",
 	}
 
-	p := ZalandoEKSProvisioner{}
+	p := ZalandoAWSProvisioner{}
 	err := p.Provision(context.TODO(), nil, cluster, nil)
 	assert.Equal(t, ErrProviderNotSupported, err)
 }
+
 func TestDecommissionDoesNotSupportProvider(t *testing.T) {
 	cluster := &api.Cluster{
 		Provider: "zalando-eks",
 	}
 
-	p := ZalandoEKSProvisioner{}
+	p := ZalandoAWSProvisioner{}
 	err := p.Decommission(context.TODO(), nil, cluster)
 	assert.Equal(t, ErrProviderNotSupported, err)
 }

--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -159,12 +159,28 @@ type KarpenterNodePoolProvisioner struct {
 	k8sClients *kubernetes.ClientsCollection
 }
 
-func NewKarpenterNodePoolProvisioner(n NodePoolTemplateRenderer, e *command.ExecManager, ts oauth2.TokenSource, clusterCA []byte) (*KarpenterNodePoolProvisioner, error) {
-	c, err := kubernetes.NewClientsCollection(n.cluster.APIServerURL, ts, clusterCA)
+func NewKarpenterNodePoolProvisioner(
+	n NodePoolTemplateRenderer,
+	e *command.ExecManager,
+	ts oauth2.TokenSource,
+	options *PostOptions,
+) (*KarpenterNodePoolProvisioner, error) {
+	var caData []byte
+	if options != nil && len(options.CAData) > 0 {
+		caData = options.CAData
+	}
+	c, err := kubernetes.NewClientsCollection(n.cluster.APIServerURL, ts, caData)
 	if err != nil {
 		return nil, err
 	}
-	k := kubernetes.NewKubeCTLRunner(e, ts, n.logger, n.cluster.APIServerURL, clusterCA, maxApplyRetries)
+	k := kubernetes.NewKubeCTLRunner(
+		e,
+		ts,
+		n.logger,
+		n.cluster.APIServerURL,
+		maxApplyRetries,
+		caData,
+	)
 	return &KarpenterNodePoolProvisioner{
 		NodePoolTemplateRenderer: n,
 		k8sClients:               c,

--- a/provisioner/stdout.go
+++ b/provisioner/stdout.go
@@ -21,7 +21,12 @@ func (p *stdoutProvisioner) Supports(_ *api.Cluster) bool {
 }
 
 // Provision mocks provisioning a cluster.
-func (p *stdoutProvisioner) Provision(_ context.Context, logger *log.Entry, cluster *api.Cluster, _ channel.Config) error {
+func (p *stdoutProvisioner) Provision(
+	_ context.Context,
+	logger *log.Entry,
+	cluster *api.Cluster,
+	_ channel.Config,
+) error {
 	logger.Infof("stdout: Provisioning cluster %s.", cluster.ID)
 
 	return nil

--- a/provisioner/zalando_aws.go
+++ b/provisioner/zalando_aws.go
@@ -56,6 +56,10 @@ func (z *ZalandoAWSProvisioner) Provision(
 	cluster *api.Cluster,
 	channelConfig channel.Config,
 ) error {
+	if !z.Supports(cluster) {
+		return ErrProviderNotSupported
+	}
+
 	awsAdapter, err := z.setupAWSAdapter(logger, cluster)
 	if err != nil {
 		return fmt.Errorf("failed to setup AWS Adapter: %v", err)
@@ -83,6 +87,10 @@ func (z *ZalandoAWSProvisioner) Decommission(
 	logger *log.Entry,
 	cluster *api.Cluster,
 ) error {
+	if !z.Supports(cluster) {
+		return ErrProviderNotSupported
+	}
+
 	awsAdapter, err := z.setupAWSAdapter(logger, cluster)
 	if err != nil {
 		return fmt.Errorf("failed to setup AWS Adapter: %v", err)

--- a/provisioner/zalando_aws.go
+++ b/provisioner/zalando_aws.go
@@ -34,6 +34,7 @@ func NewZalandoAWSProvisioner(
 			assumedRole:       assumedRole,
 			execManager:       execManager,
 			secretDecrypter:   secretDecrypter,
+			tokenSource:       tokenSource,
 			manageMasterNodes: true,
 		},
 	}
@@ -77,15 +78,15 @@ func (z *ZalandoAWSProvisioner) Provision(
 }
 
 // Decommission decommissions a cluster provisioned in AWS.
-func (p *ZalandoAWSProvisioner) Decommission(
+func (z *ZalandoAWSProvisioner) Decommission(
 	ctx context.Context,
 	logger *log.Entry,
 	cluster *api.Cluster,
 ) error {
-	awsAdapter, err := p.setupAWSAdapter(logger, cluster)
+	awsAdapter, err := z.setupAWSAdapter(logger, cluster)
 	if err != nil {
 		return fmt.Errorf("failed to setup AWS Adapter: %v", err)
 	}
 
-	return p.decommission(ctx, logger, awsAdapter, p.tokenSource, cluster, nil)
+	return z.decommission(ctx, logger, awsAdapter, z.tokenSource, cluster, nil)
 }

--- a/provisioner/zalando_aws.go
+++ b/provisioner/zalando_aws.go
@@ -29,7 +29,6 @@ func NewZalandoAWSProvisioner(
 ) Provisioner {
 	provisioner := &ZalandoAWSProvisioner{
 		clusterpyProvisioner: clusterpyProvisioner{
-			provider:          ZalandoAWSProvider,
 			awsConfig:         awsConfig,
 			assumedRole:       assumedRole,
 			execManager:       execManager,
@@ -48,6 +47,10 @@ func NewZalandoAWSProvisioner(
 	}
 
 	return provisioner
+}
+
+func (z *ZalandoAWSProvisioner) Supports(cluster *api.Cluster) bool {
+	return cluster.Provider == string(ZalandoAWSProvider)
 }
 
 func (z *ZalandoAWSProvisioner) Provision(

--- a/provisioner/zalando_eks.go
+++ b/provisioner/zalando_eks.go
@@ -33,7 +33,6 @@ func NewZalandoEKSProvisioner(
 ) Provisioner {
 	provisioner := &ZalandoEKSProvisioner{
 		clusterpyProvisioner: clusterpyProvisioner{
-			provider:          ZalandoEKSProvider,
 			awsConfig:         awsConfig,
 			assumedRole:       assumedRole,
 			execManager:       execManager,
@@ -52,6 +51,10 @@ func NewZalandoEKSProvisioner(
 	}
 
 	return provisioner
+}
+
+func (z *ZalandoEKSProvisioner) Supports(cluster *api.Cluster) bool {
+	return cluster.Provider == string(ZalandoEKSProvider)
 }
 
 func (z *ZalandoEKSProvisioner) Provision(

--- a/provisioner/zalando_eks.go
+++ b/provisioner/zalando_eks.go
@@ -60,6 +60,10 @@ func (z *ZalandoEKSProvisioner) Provision(
 	cluster *api.Cluster,
 	channelConfig channel.Config,
 ) error {
+	if !z.Supports(cluster) {
+		return ErrProviderNotSupported
+	}
+
 	awsAdapter, err := z.setupAWSAdapter(logger, cluster)
 	if err != nil {
 		return fmt.Errorf("failed to setup AWS Adapter: %v", err)
@@ -88,6 +92,10 @@ func (z *ZalandoEKSProvisioner) Decommission(
 	logger *log.Entry,
 	cluster *api.Cluster,
 ) error {
+	if !z.Supports(cluster) {
+		return ErrProviderNotSupported
+	}
+
 	logger.Infof(
 		"Decommissioning EKS cluster: %s (%s)",
 		cluster.Alias,

--- a/provisioner/zalando_eks.go
+++ b/provisioner/zalando_eks.go
@@ -1,0 +1,170 @@
+package provisioner
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	log "github.com/sirupsen/logrus"
+	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
+	"github.com/zalando-incubator/cluster-lifecycle-manager/channel"
+	"github.com/zalando-incubator/cluster-lifecycle-manager/pkg/aws/eks"
+	"github.com/zalando-incubator/cluster-lifecycle-manager/pkg/decrypter"
+	"github.com/zalando-incubator/cluster-lifecycle-manager/pkg/util/command"
+)
+
+type (
+	ZalandoEKSProvisioner struct {
+		clusterpyProvisioner
+	}
+
+	ZalandoEKSModifier struct{}
+)
+
+// NewZalandoEKSProvisioner returns a new provisioner capable of provisioning
+// EKS clusters by passing its location and and IAM role to use.
+func NewZalandoEKSProvisioner(
+	execManager *command.ExecManager,
+	secretDecrypter decrypter.Decrypter,
+	assumedRole string,
+	awsConfig *aws.Config,
+	options *Options,
+) Provisioner {
+	provisioner := &ZalandoEKSProvisioner{
+		clusterpyProvisioner: clusterpyProvisioner{
+			provider:          ZalandoEKSProvider,
+			awsConfig:         awsConfig,
+			assumedRole:       assumedRole,
+			execManager:       execManager,
+			secretDecrypter:   secretDecrypter,
+			manageMasterNodes: false,
+			manageEtcdStack:   false,
+		},
+	}
+
+	if options != nil {
+		provisioner.dryRun = options.DryRun
+		provisioner.applyOnly = options.ApplyOnly
+		provisioner.updateStrategy = options.UpdateStrategy
+		provisioner.removeVolumes = options.RemoveVolumes
+		provisioner.modifier = options.Modifier
+	}
+
+	return provisioner
+}
+
+func (z *ZalandoEKSProvisioner) Provision(
+	ctx context.Context,
+	logger *log.Entry,
+	cluster *api.Cluster,
+	channelConfig channel.Config,
+) error {
+	awsAdapter, err := z.setupAWSAdapter(logger, cluster)
+	if err != nil {
+		return fmt.Errorf("failed to setup AWS Adapter: %v", err)
+	}
+
+	eksTokenSource := eks.NewTokenSource(awsAdapter.session, eksID(cluster.ID))
+
+	logger.Infof(
+		"clusterpy: Prepare for provisioning EKS cluster %s (%s)..",
+		cluster.ID,
+		cluster.LifecycleStatus,
+	)
+
+	return z.provision(
+		ctx,
+		logger,
+		awsAdapter,
+		eksTokenSource,
+		cluster,
+		channelConfig,
+	)
+}
+
+func (z *ZalandoEKSProvisioner) Decommission(
+	ctx context.Context,
+	logger *log.Entry,
+	cluster *api.Cluster,
+) error {
+	logger.Infof(
+		"Decommissioning EKS cluster: %s (%s)",
+		cluster.Alias,
+		cluster.ID,
+	)
+
+	awsAdapter, err := z.setupAWSAdapter(logger, cluster)
+	if err != nil {
+		return err
+	}
+	clusterInfo, err := awsAdapter.GetEKSClusterCA(cluster)
+	if err != nil {
+		return err
+	}
+	caData, err := base64.StdEncoding.DecodeString(
+		clusterInfo.CertificateAuthority,
+	)
+	if err != nil {
+		return err
+	}
+
+	cluster.APIServerURL = clusterInfo.Endpoint
+	tokenSource := eks.NewTokenSource(awsAdapter.session, eksID(cluster.ID))
+
+	return z.decommission(
+		ctx,
+		logger,
+		awsAdapter,
+		tokenSource,
+		cluster,
+		caData,
+	)
+}
+
+func (z *ZalandoEKSModifier) GetPostOptions(
+	adapter *awsAdapter,
+	cluster *api.Cluster,
+	cloudFormationOutput map[string]string,
+) (*PostOptions, error) {
+	res := &PostOptions{}
+
+	clusterInfo, err := adapter.GetEKSClusterCA(cluster)
+	if err != nil {
+		return nil, err
+	}
+	decodedCA, err := base64.StdEncoding.DecodeString(
+		clusterInfo.CertificateAuthority,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	res.APIServerURL = clusterInfo.Endpoint
+	res.CAData = decodedCA
+	res.ConfigItems = map[string]string{
+		"eks_endpoint":                  clusterInfo.Endpoint,
+		"eks_certficate_authority_data": clusterInfo.CertificateAuthority,
+	}
+
+	subnets := map[string]string{}
+	for key, az := range map[string]string{
+		"EKSSubneta": "eu-central-1a",
+		"EKSSubnetb": "eu-central-1b",
+		"EKSSubnetc": "eu-central-1c",
+	} {
+		if v, ok := cloudFormationOutput[key]; ok {
+			subnets[az] = v
+		}
+	}
+	if len(subnets) > 0 {
+		res.AZInfo = &AZInfo{
+			subnets: subnets,
+		}
+		res.TemplateValues = map[string]interface{}{
+			subnetsValueKey: subnets,
+		}
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
This Pull Request updates the `eks-support` branch with the following changes:

* Updates the CLM entry point support both Zalando AWS end EKS provisioning. I replaced the main provisioner instance with a map of provisioners. This map replaces the single `provisioner` parameter in the control loop, while command line picks the provisioner based on the specified provider.
* Splits EKS and self-managed provisioning in two `structs`: `ZalandoAWSProvisioner` and `ZalandoEKSProvisioner`:
    *  `ZalandoAWSProvisioner`: just calls the provisioning/decommissioning methods of `clusterPyProvisioner`.
    *  `ZalandoEKSProvisioner`: creates the EKS token source before calling provisioning/decommissioning methods of `clusterPyProvisioner`. Additionally for decommissioning passes the specific Certificate Authority data.
* Adds a `ProvisionModifier` interface. EKS Provisioning implements this interface, and the `clusterPyProvisioner` calls back `GetPostOptions`. When provisioning EKS, only after this stage it is possible to know some configuration necessary to provision a cluster, like: API Server endpoint, custom Certificate Authority, and Availability Zone information.
* Updates `clusterpyProvisioner` in the following:
    * Adds a `provider` field and implements a common `Supports` method.
    * Adds an optional `modifier`, which maybe used at a later provisioning stage 
    * Hides the interface from outside `provisioner` (the provisioners have a `clusterPyProvisioner` as a field).
    * Provides the AWS Adapter as a parameter to `provision()`. The EKS provisioner needs this adapter _before_ provisioning, to build a token source.
    * Refactors `prepareProvision()` to only apply default valuers to the various manifests. Gathering instance type information from AWS is now done by `provision`.
    * Calls back a modifier interface right after applying the first `cluster.yaml` CloudFormation.
    * Adds an optional Certificate Authority data to `decommission()`, necessary for decommissioning an EKS cluster.
* Updates the lower level Kubernetes functions (found in `pkg/kubernetes`) with support an optional parameter with custom Certificate Authority data. This certificate is necessary when provisioning an EKS cluster.
* Removes the token source parameter when creating the AWS Adapter. The token source is not used by the adapter.

This Pull Request does not add tests. A follow-up Pull Request to master will have more testing.