### PR TITLE
add template function to compute EKS cluster ID

### DIFF
--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -95,6 +95,7 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		"azID":                 azID,
 		"azCount":              azCount,
 		"split":                split,
+		"eksID":                eksID,
 		"mountUnitName":        mountUnitName,
 		"accountID":            accountID,
 		"portRanges":           portRanges,
@@ -278,6 +279,10 @@ func dict(args ...interface{}) (map[string]interface{}, error) {
 
 func list(args ...interface{}) []interface{} {
 	return args
+}
+
+func eksID(id string) string {
+	return strings.Replace(id, ":", "--", -1)
 }
 
 // accountID returns just the ID part of an account


### PR DESCRIPTION
Part of https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/777 that adds `eksID()` template function in order to get on step further in the e2e pipeline: https://sunrise.zalando.net/cdp/gh/zalando-incubator/kubernetes-on-aws/l-74y3uns4qfjfz9nou1d55im83/steps/1/logs