### PR TITLE
Only update EKS config items when needed.

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -128,7 +128,10 @@ func (r *mockRegistry) UpdateLifecycleStatus(cluster *api.Cluster) error {
 	r.lastUpdate = cluster
 	return nil
 }
-func (r *mockRegistry) UpdateConfigItems(_ *api.Cluster) error {
+func (r *mockRegistry) UpdateConfigItems(
+	_ *api.Cluster,
+	_ map[string]string,
+) error {
 	return nil
 }
 

--- a/provisioner/zalando_eks.go
+++ b/provisioner/zalando_eks.go
@@ -180,10 +180,15 @@ func (z *ZalandoEKSCreationHook) Execute(
 		cluster.ConfigItems = map[string]string{}
 	}
 
-	// Update the cluster registry with the new configuration items
-	cluster.ConfigItems[KeyEKSEndpoint] = clusterInfo.Endpoint
-	cluster.ConfigItems[KeyEKSCAData] = clusterInfo.CertificateAuthority
-	err = z.clusterRegistry.UpdateConfigItems(cluster)
+	toUpdate := map[string]string{}
+	if cluster.ConfigItems[KeyEKSEndpoint] != clusterInfo.Endpoint {
+		toUpdate[KeyEKSEndpoint] = clusterInfo.Endpoint
+	}
+	if cluster.ConfigItems[KeyEKSCAData] != clusterInfo.CertificateAuthority {
+		toUpdate[KeyEKSCAData] = clusterInfo.CertificateAuthority
+	}
+
+	err = z.clusterRegistry.UpdateConfigItems(cluster, toUpdate)
 	if err != nil {
 		return nil, err
 	}

--- a/provisioner/zalando_eks_test.go
+++ b/provisioner/zalando_eks_test.go
@@ -34,7 +34,7 @@ func (r *mockRegistry) UpdateLifecycleStatus(_ *api.Cluster) error {
 	return nil
 }
 
-func (r *mockRegistry) UpdateConfigItems(_ *api.Cluster) error {
+func (r *mockRegistry) UpdateConfigItems(_ *api.Cluster, _ map[string]string) error {
 	return nil
 }
 

--- a/registry/file.go
+++ b/registry/file.go
@@ -68,7 +68,10 @@ func (r *fileRegistry) UpdateLifecycleStatus(cluster *api.Cluster) error {
 	return fmt.Errorf("failed to update the cluster: cluster %s not found", cluster.ID)
 }
 
-func (r *fileRegistry) UpdateConfigItems(cluster *api.Cluster) error {
+func (r *fileRegistry) UpdateConfigItems(
+	cluster *api.Cluster,
+	configItems map[string]string,
+) error {
 	if cluster == nil {
 		return fmt.Errorf(
 			"failed to update the cluster. Empty cluster is passed",
@@ -79,7 +82,7 @@ func (r *fileRegistry) UpdateConfigItems(cluster *api.Cluster) error {
 			log.Debugf(
 				"[Cluster %s updated] Config Items: %v",
 				cluster.ID,
-				cluster.ConfigItems,
+				configItems,
 			)
 			return nil
 		}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -20,7 +20,7 @@ type Filter struct {
 type Registry interface {
 	ListClusters(filter Filter) ([]*api.Cluster, error)
 	UpdateLifecycleStatus(cluster *api.Cluster) error
-	UpdateConfigItems(cluster *api.Cluster) error
+	UpdateConfigItems(cluster *api.Cluster, configItems map[string]string) error
 }
 
 // NewRegistry initializes a new registry source based on the uri.

--- a/registry/static.go
+++ b/registry/static.go
@@ -30,6 +30,9 @@ func (r *staticRegistry) UpdateLifecycleStatus(_ *api.Cluster) error {
 	return nil
 }
 
-func (r *staticRegistry) UpdateConfigItems(_ *api.Cluster) error {
+func (r *staticRegistry) UpdateConfigItems(
+	_ *api.Cluster,
+	_ map[string]string,
+) error {
 	return nil
 }


### PR DESCRIPTION
The config item update implemented in https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/801 used the wrong API call from Cluster Registry and updated all clulster's config items, including keys with defaults.

This Pull Requests ensures that CLM will update the EKS config items only if the keys do not exist, or if the corresponding values are different.