### PR TITLE
Get EKS endpoint data from Config Items

### DIFF
--- a/provisioner/zalando_eks.go
+++ b/provisioner/zalando_eks.go
@@ -118,18 +118,14 @@ func (z *ZalandoEKSProvisioner) Decommission(
 	if err != nil {
 		return err
 	}
-	clusterInfo, err := awsAdapter.GetEKSClusterCA(cluster)
-	if err != nil {
-		return err
-	}
 	caData, err := base64.StdEncoding.DecodeString(
-		clusterInfo.CertificateAuthority,
+		cluster.ConfigItems[KeyEKSCAData],
 	)
 	if err != nil {
 		return err
 	}
 
-	cluster.APIServerURL = clusterInfo.Endpoint
+	cluster.APIServerURL = cluster.ConfigItems[KeyEKSEndpoint]
 	tokenSource := eks.NewTokenSource(awsAdapter.session, eksID(cluster.ID))
 
 	return z.decommission(


### PR DESCRIPTION
```
time="2024-08-08T08:12:09Z" level=info msg="Decommissioning EKS cluster: playground-eks (aws:407797183256:eu-central-1:kube-eks-1)" cluster=playground-eks worker=87
time="2024-08-08T08:12:09Z" level=error msg="Failed to process cluster: ResourceNotFoundException: No cluster found for name: aws--407797183256--eu-central-1--kube-eks-1.\n{\n  RespMetadata: {\n    StatusCode: 404,\n    RequestID: \"fc70aa7e-c326-4701-9ec3-af9af5dbbf88\"\n  },\n  ClusterName: \"aws--407797183256--eu-central-1--kube-eks-1\",\n  Message_: \"No cluster found for name: aws--407797183256--eu-central-1--kube-eks-1.\"\n}" cluster=playground-eks version="main=13690717cecdfe45978226402643799ce384bde0;logging=5bd74e587dd237728ce7ad9e63a487cbdeb54578;eagle-eye=d16e8c3c56a51279b8abc300c0775bfd89cc299e;teapot-internal=2ded086b155b0799744b5c89ba2fbcb1aca54d4a;acid=4bfd837f522abfad7dc34effb5425531c0f990c5#OPl-B_oW4UY8L1DD4Ed2rK7ybHI" worker=87
```

When the decommissioning process was interrupted and restarted the cluster might already be deleted which results in a failure when getting its API server and CA data from AWS. Let's just fetch this data from Cluster Registry instead.