### PR TITLE
Add OIDC issuer url as config item to the cluster

### DIFF
--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -123,9 +123,9 @@ type (
 
 	// awsInterface is an interface containing methods of an AWS Adapter.
 	//
-	// ProvisionModifier uses this interface in the GetPostOptions method.
+	// CreationHook uses this interface in the Execute method.
 	awsInterface interface {
-		GetEKSClusterCA(cluster *api.Cluster) (*EKSClusterInfo, error)
+		GetEKSClusterDetails(cluster *api.Cluster) (*EKSClusterDetails, error)
 	}
 )
 
@@ -768,13 +768,14 @@ func tagsToMap(tags []*ec2.Tag) map[string]string {
 	return tagMap
 }
 
-type EKSClusterInfo struct {
+// EKSClusterDetails contains details of an EKS cluster that are only available after creation.
+type EKSClusterDetails struct {
 	Endpoint             string
 	CertificateAuthority string
 	OIDCIssuerURL        string
 }
 
-func (a *awsAdapter) GetEKSClusterCA(cluster *api.Cluster) (*EKSClusterInfo, error) {
+func (a *awsAdapter) GetEKSClusterDetails(cluster *api.Cluster) (*EKSClusterDetails, error) {
 	resp, err := a.eksClient.DescribeCluster(&eks.DescribeClusterInput{
 		Name: aws.String(eksID(cluster.ID)),
 	})
@@ -782,7 +783,7 @@ func (a *awsAdapter) GetEKSClusterCA(cluster *api.Cluster) (*EKSClusterInfo, err
 		return nil, err
 	}
 
-	return &EKSClusterInfo{
+	return &EKSClusterDetails{
 		Endpoint:             aws.StringValue(resp.Cluster.Endpoint),
 		CertificateAuthority: aws.StringValue(resp.Cluster.CertificateAuthority.Data),
 		OIDCIssuerURL:        aws.StringValue(resp.Cluster.Identity.Oidc.Issuer),

--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -771,6 +771,7 @@ func tagsToMap(tags []*ec2.Tag) map[string]string {
 type EKSClusterInfo struct {
 	Endpoint             string
 	CertificateAuthority string
+	OIDCIssuerURL        string
 }
 
 func (a *awsAdapter) GetEKSClusterCA(cluster *api.Cluster) (*EKSClusterInfo, error) {
@@ -784,5 +785,6 @@ func (a *awsAdapter) GetEKSClusterCA(cluster *api.Cluster) (*EKSClusterInfo, err
 	return &EKSClusterInfo{
 		Endpoint:             aws.StringValue(resp.Cluster.Endpoint),
 		CertificateAuthority: aws.StringValue(resp.Cluster.CertificateAuthority.Data),
+		OIDCIssuerURL:        aws.StringValue(resp.Cluster.Identity.Oidc.Issuer),
 	}, nil
 }

--- a/provisioner/zalando_eks.go
+++ b/provisioner/zalando_eks.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	KeyEKSEndpoint = "eks_endpoint"
-	KeyEKSCAData   = "eks_certificate_authority_data"
+	KeyEKSEndpoint      = "eks_endpoint"
+	KeyEKSCAData        = "eks_certificate_authority_data"
+	KeyEKSOIDCIssuerURL = "eks_oidc_issuer_url"
 )
 
 type (
@@ -182,6 +183,9 @@ func (z *ZalandoEKSCreationHook) Execute(
 	}
 	if cluster.ConfigItems[KeyEKSCAData] != clusterInfo.CertificateAuthority {
 		toUpdate[KeyEKSCAData] = clusterInfo.CertificateAuthority
+	}
+	if cluster.ConfigItems[KeyEKSOIDCIssuerURL] != clusterInfo.OIDCIssuerURL {
+		toUpdate[KeyEKSOIDCIssuerURL] = clusterInfo.OIDCIssuerURL
 	}
 
 	err = z.clusterRegistry.UpdateConfigItems(cluster, toUpdate)

--- a/provisioner/zalando_eks.go
+++ b/provisioner/zalando_eks.go
@@ -162,12 +162,12 @@ func (z *ZalandoEKSCreationHook) Execute(
 ) (*HookResponse, error) {
 	res := &HookResponse{}
 
-	clusterInfo, err := adapter.GetEKSClusterCA(cluster)
+	clusterDetails, err := adapter.GetEKSClusterDetails(cluster)
 	if err != nil {
 		return nil, err
 	}
 	decodedCA, err := base64.StdEncoding.DecodeString(
-		clusterInfo.CertificateAuthority,
+		clusterDetails.CertificateAuthority,
 	)
 	if err != nil {
 		return nil, err
@@ -178,14 +178,14 @@ func (z *ZalandoEKSCreationHook) Execute(
 	}
 
 	toUpdate := map[string]string{}
-	if cluster.ConfigItems[KeyEKSEndpoint] != clusterInfo.Endpoint {
-		toUpdate[KeyEKSEndpoint] = clusterInfo.Endpoint
+	if cluster.ConfigItems[KeyEKSEndpoint] != clusterDetails.Endpoint {
+		toUpdate[KeyEKSEndpoint] = clusterDetails.Endpoint
 	}
-	if cluster.ConfigItems[KeyEKSCAData] != clusterInfo.CertificateAuthority {
-		toUpdate[KeyEKSCAData] = clusterInfo.CertificateAuthority
+	if cluster.ConfigItems[KeyEKSCAData] != clusterDetails.CertificateAuthority {
+		toUpdate[KeyEKSCAData] = clusterDetails.CertificateAuthority
 	}
-	if cluster.ConfigItems[KeyEKSOIDCIssuerURL] != clusterInfo.OIDCIssuerURL {
-		toUpdate[KeyEKSOIDCIssuerURL] = clusterInfo.OIDCIssuerURL
+	if cluster.ConfigItems[KeyEKSOIDCIssuerURL] != clusterDetails.OIDCIssuerURL {
+		toUpdate[KeyEKSOIDCIssuerURL] = clusterDetails.OIDCIssuerURL
 	}
 
 	err = z.clusterRegistry.UpdateConfigItems(cluster, toUpdate)
@@ -193,7 +193,7 @@ func (z *ZalandoEKSCreationHook) Execute(
 		return nil, err
 	}
 
-	res.APIServerURL = clusterInfo.Endpoint
+	res.APIServerURL = clusterDetails.Endpoint
 	res.CAData = decodedCA
 
 	subnets := map[string]string{}

--- a/provisioner/zalando_eks_test.go
+++ b/provisioner/zalando_eks_test.go
@@ -13,13 +13,14 @@ type (
 	mockRegistry   struct{}
 )
 
-func (m *mockAWSAdapter) GetEKSClusterCA(_ *api.Cluster) (
-	*EKSClusterInfo,
+func (m *mockAWSAdapter) GetEKSClusterDetails(_ *api.Cluster) (
+	*EKSClusterDetails,
 	error,
 ) {
-	return &EKSClusterInfo{
+	return &EKSClusterDetails{
 		Endpoint:             "https://api.cluster.local",
 		CertificateAuthority: "YmxhaA==",
+		OIDCIssuerURL:        "https://oidc.provider.local/id/foo",
 	}, nil
 }
 
@@ -38,7 +39,7 @@ func (r *mockRegistry) UpdateConfigItems(_ *api.Cluster, _ map[string]string) er
 	return nil
 }
 
-func TestGetPostOptions(t *testing.T) {
+func TestCreationHookExecute(t *testing.T) {
 	for _, tc := range []struct {
 		cfOutput map[string]string
 		expected *HookResponse

--- a/registry/http_test.go
+++ b/registry/http_test.go
@@ -99,6 +99,7 @@ func TestUpdateConfigItems(t *testing.T) {
 			configItems: map[string]string{
 				"eks_endpoint":                   "https://api.eks.eu-central-1.amazonaws.com",
 				"eks_certificate_authority_data": "YmxhaA==",
+				"eks_oidc_issuer_url":            "https://oidc.eks.eu-central-1.amazonaws.com/id/foo",
 			},
 		},
 	} {


### PR DESCRIPTION
For [ServiceAccount for IAM roles](https://github.bus.zalan.do/teapot/cluster-registry-deploy/blob/master/deploy/prod/iam-role.yaml#L22-L34) to work, we need to configure the right OIDC provider. As a first step, make the URL available via Config Items.

The ConfigItem can then be used to configure the right parameters here: https://github.com/zalando-incubator/kubernetes-on-aws/commit/f16824fcea0f74e25a92959142d4472342c7aef4

```yaml
  oidc-provider-arn: "arn:aws:iam::{{accountID .Cluster.InfrastructureAccount}}:oidc-provider/oidc.eks.eu-central-1.amazonaws.com/id/EKSID"
  oidc-subject-key: "oidc.eks.eu-central-1.amazonaws.com/id/EKSID:sub"
```