### PR TITLE
Make sure written-back config items are available in the cluster object

### DIFF
--- a/registry/file.go
+++ b/registry/file.go
@@ -84,6 +84,9 @@ func (r *fileRegistry) UpdateConfigItems(
 				cluster.ID,
 				configItems,
 			)
+			for key, value := range configItems {
+				cluster.ConfigItems[key] = value
+			}
 			return nil
 		}
 	}


### PR DESCRIPTION
The ConfigItems written back by CLM didn't persist for he local file registry (used for pet clusters and e2e clusters) since it only printed them. This stores them on the cluster object so that the following templates have access to these Config items.

In production we're using the HTTP registry where the Config items are persisted on the server-side. I assume it currently works there by re-trying and therefore re-reading the values from the remote registry on the second try. We don't need to fix this right now.