### PR TITLE
Update config item locally to reflect remote change

### DIFF
--- a/registry/http.go
+++ b/registry/http.go
@@ -116,6 +116,10 @@ func (r *httpRegistry) UpdateConfigItems(
 		return err
 	}
 
+	if cluster.ConfigItems == nil {
+		cluster.ConfigItems = map[string]string{}
+	}
+
 	for key, value := range configItems {
 		_, err = r.apiClient.ConfigItems.AddOrUpdateConfigItem(
 			config_items.NewAddOrUpdateConfigItemParams().WithClusterID(
@@ -127,6 +131,8 @@ func (r *httpRegistry) UpdateConfigItems(
 		if err != nil {
 			return err
 		}
+
+		cluster.ConfigItems[key] = value
 	}
 
 	return nil


### PR DESCRIPTION
EKS cluster creation doesn't work on the first try because the intermediate update of the config items to cluster registry aren't reflected locally and hence these variables aren't available to the templates.

```
time="2024-09-16T10:31:41Z" level=error msg="Failed to process cluster: error rendering template main/cluster/manifests/deployment-service/01-config.yaml: template: main/cluster/manifests/deployment-service/01-config.yaml:15:46: executing \"main/cluster/manifests/deployment-service/01-config.yaml\" at <.Cluster.ConfigItems.eks_oidc_issuer_url>: map has no entry for key \"eks_oidc_issuer_url\"" ...
```

A retry of provisioning will fix it because it refetches the values from cluster registry.

This change updates the local copy to be aligned with the changes made remotely, which avoids the retry and allows the cluster to be created on the first try.