### PR TITLE
Store the account name as a field on the cluster object

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -33,6 +33,7 @@ type Cluster struct {
 	Region                string            `json:"region"                 yaml:"region"`
 	Status                *ClusterStatus    `json:"status"                 yaml:"status"`
 	Owner                 string            `json:"owner"                  yaml:"owner"`
+	AccountName           string            `json:"account_name"           yaml:"account_name"`
 }
 
 // Version returns the version derived from a sha1 hash of the cluster struct

--- a/api/cluster_test.go
+++ b/api/cluster_test.go
@@ -83,7 +83,7 @@ func TestVersion(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, field := range fields {
-		if field == "Alias" || field == "NodePools" || field == "Owner" || field == "Status" {
+		if field == "Alias" || field == "NodePools" || field == "Owner" || field == "AccountName" || field == "Status" {
 			continue
 		}
 

--- a/registry/http.go
+++ b/registry/http.go
@@ -75,6 +75,7 @@ func (r *httpRegistry) ListClusters(filter Filter) ([]*api.Cluster, error) {
 		}
 		if account, ok := accounts[c.InfrastructureAccount]; ok {
 			c.Owner = *account.Owner
+			c.AccountName = *account.Name
 		}
 		result = append(result, c)
 	}


### PR DESCRIPTION
Similar to `Owner`, fetches the account details from the `/infrastructure-accounts` endpoint and stores the account name (e.g. eks-playground) under the `.AccountName` field so it can be used in templating.