### PR TITLE
Use unique cluster alias as identifier rather than redundant eksID

### DIFF
--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -777,7 +777,7 @@ type EKSClusterDetails struct {
 
 func (a *awsAdapter) GetEKSClusterDetails(cluster *api.Cluster) (*EKSClusterDetails, error) {
 	resp, err := a.eksClient.DescribeCluster(&eks.DescribeClusterInput{
-		Name: aws.String(eksID(cluster.ID)),
+		Name: aws.String(cluster.Alias),
 	})
 	if err != nil {
 		return nil, err

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -95,7 +95,6 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		"azID":                 azID,
 		"azCount":              azCount,
 		"split":                split,
-		"eksID":                eksID,
 		"mountUnitName":        mountUnitName,
 		"accountID":            accountID,
 		"portRanges":           portRanges,
@@ -279,11 +278,6 @@ func dict(args ...interface{}) (map[string]interface{}, error) {
 
 func list(args ...interface{}) []interface{} {
 	return args
-}
-
-func eksID(id string) string {
-	parts := strings.Split(id, ":")
-	return parts[len(parts)-1]
 }
 
 // accountID returns just the ID part of an account

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -278,15 +278,6 @@ func TestAccountIDFailsOnInvalid(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestEKSID(t *testing.T) {
-	result, err := renderSingle(
-		t,
-		`{{ eksID "aws:000000:eu-north-1:kube-1" }}`,
-		"")
-	require.NoError(t, err)
-	require.EqualValues(t, "kube-1", result)
-}
-
 func TestParsePortRanges(t *testing.T) {
 	testTemplate := `{{- if index .Values.data.portRanges -}}
 {{- range $index, $element := portRanges .Values.data.portRanges -}}

--- a/provisioner/zalando_eks.go
+++ b/provisioner/zalando_eks.go
@@ -82,7 +82,7 @@ func (z *ZalandoEKSProvisioner) Provision(
 		return fmt.Errorf("failed to setup AWS Adapter: %v", err)
 	}
 
-	eksTokenSource := eks.NewTokenSource(awsAdapter.session, eksID(cluster.ID))
+	eksTokenSource := eks.NewTokenSource(awsAdapter.session, cluster.Alias)
 
 	logger.Infof(
 		"clusterpy: Prepare for provisioning EKS cluster %s (%s)..",
@@ -127,7 +127,7 @@ func (z *ZalandoEKSProvisioner) Decommission(
 	}
 
 	cluster.APIServerURL = cluster.ConfigItems[KeyEKSEndpoint]
-	tokenSource := eks.NewTokenSource(awsAdapter.session, eksID(cluster.ID))
+	tokenSource := eks.NewTokenSource(awsAdapter.session, cluster.Alias)
 
 	return z.decommission(
 		ctx,


### PR DESCRIPTION
Using `eksID()` generates redundant and unreadable EKS cluster names, as well as other resources that are based on it.

For example, a cluster with alias `playground-2` will have an EKS resource named `aws--123456789012--eu-central-1--kube-1` for which the ARN will become a long, unreadable and redundant:

```
arn:aws:eks:eu-central-1:123456789012:cluster/aws--123456789012--eu-central-1--kube-1
```

[Update] Since the merge of https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/818 the ARN will look like this:

```
arn:aws:eks:eu-central-1:123456789012:cluster/kube-1
```

This isn't too bad, but it's unclear which cluster "kube-1" is. One has to use the AWS account ID to figure that out. Subsequent clusters in the same account would likely use "kube-2", "kube-3" etc. which isn't really helpful.

With this change the cluster will show in the UI as `playground-2` and will always be unique as long as we pick unique cluster aliases. The ARN will become more useful and correct:

```
arn:aws:eks:eu-central-1:123456789012:cluster/playground-2
```

- [ ] Let's decommission any incompatible EKS cluster before merging this.