### PR TITLE
Use localID for eksID to remove some redundancy

### DIFF
--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -282,7 +282,8 @@ func list(args ...interface{}) []interface{} {
 }
 
 func eksID(id string) string {
-	return strings.Replace(id, ":", "--", -1)
+	parts := strings.Split(id, ":")
+	return parts[len(parts)-1]
 }
 
 // accountID returns just the ID part of an account

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -284,7 +284,7 @@ func TestEKSID(t *testing.T) {
 		`{{ eksID "aws:000000:eu-north-1:kube-1" }}`,
 		"")
 	require.NoError(t, err)
-	require.EqualValues(t, "aws--000000--eu-north-1--kube-1", result)
+	require.EqualValues(t, "kube-1", result)
 }
 
 func TestParsePortRanges(t *testing.T) {


### PR DESCRIPTION
This is a less invasive version of https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/817.

It changes the `eksID` to _just_ be the `LocalID` of the cluster (rather than _also_ including region and AWS account ID which is redundant because it's already part of the ARN). `LocalID` should be unique in the account and if we go with the pattern `Alias == LocalID` then it's kind of implied.

When creating clusters via `aws-account-creator` with `--local-id=kube-1` (what we do today) this would lead to `kube-1` as both the CF Stack and EKS cluster name which seems reasonable.

If we start to create EKS clusters where the localID is equal to alias (e.g. `--local-id=teapot`) this would lead to `teapot` as both the CF Stack and EKS cluster name. With this it's more understandable how a second cluster in the same account can live side by side, e.g `--local-id=linki-test` will result in `linki-test` as both the CF Stack and EKS cluster name.

In practice I think it makes sense to create EKS clusters with, e.g. `--local-id=cluster-teapot`. This would lead to `cluster-teapot` as both the CF Stack and EKS cluster name and avoids clashes with another CF Stack that's called `teapot`. We do the same for the node pool Stacks, where [we prefix each of them](https://github.com/zalando-incubator/cluster-lifecycle-manager/blob/de0462b3ea2dbcc727a44d732b1752e3d923302d/provisioner/node_pools.go#L376) with `nodepool-`.

In any case, with this change, we can still pursue both variants.