### PR TITLE
Fix eks decommissioning for pet clusters

### DIFF
--- a/provisioner/zalando_eks.go
+++ b/provisioner/zalando_eks.go
@@ -119,14 +119,20 @@ func (z *ZalandoEKSProvisioner) Decommission(
 	if err != nil {
 		return err
 	}
+
+	clusterDetails, err := awsAdapter.GetEKSClusterDetails(cluster)
+	if err != nil {
+		return err
+	}
+	cluster.APIServerURL = clusterDetails.Endpoint
+
 	caData, err := base64.StdEncoding.DecodeString(
-		cluster.ConfigItems[KeyEKSCAData],
+		clusterDetails.CertificateAuthority,
 	)
 	if err != nil {
 		return err
 	}
 
-	cluster.APIServerURL = cluster.ConfigItems[KeyEKSEndpoint]
 	tokenSource := eks.NewTokenSource(awsAdapter.session, eksID(cluster.ID))
 
 	return z.decommission(


### PR DESCRIPTION
During decommission of EKS clusters CLM tried to get EKS endpoint URL and EKS endpoint CA from the config-item in cluster-registry. For pet clusters those config-items won't be set and thus the decommissioning won't work correctly.

Instead, simply discover the values dynamically from the EKS cluster.