### PR TITLE
Add ipv6 eks support

### DIFF
--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -761,6 +761,7 @@ type EKSClusterDetails struct {
 	Endpoint             string
 	CertificateAuthority string
 	OIDCIssuerURL        string
+	ServiceIPv6CIDR      string
 }
 
 func (a *awsAdapter) GetEKSClusterDetails(cluster *api.Cluster) (*EKSClusterDetails, error) {
@@ -775,5 +776,6 @@ func (a *awsAdapter) GetEKSClusterDetails(cluster *api.Cluster) (*EKSClusterDeta
 		Endpoint:             aws.StringValue(resp.Cluster.Endpoint),
 		CertificateAuthority: aws.StringValue(resp.Cluster.CertificateAuthority.Data),
 		OIDCIssuerURL:        aws.StringValue(resp.Cluster.Identity.Oidc.Issuer),
+		ServiceIPv6CIDR:      aws.StringValue(resp.Cluster.KubernetesNetworkConfig.ServiceIpv6Cidr),
 	}, nil
 }

--- a/provisioner/aws_az.go
+++ b/provisioner/aws_az.go
@@ -4,14 +4,20 @@ import (
 	"sort"
 )
 
+// SubnetInfo has information about a subnet.
+type SubnetInfo struct {
+	SubnetID        string
+	SubnetIPV6CIDRs []string
+}
+
 // AZInfo tracks information about available AZs based on explicit restrictions or available subnets
 type AZInfo struct {
-	subnets map[string]string
+	subnets map[string]SubnetInfo
 }
 
 // RestrictAZs returns a new AZInfo that is restricted to provided AZs
 func (info *AZInfo) RestrictAZs(availableAZs []string) *AZInfo {
-	result := make(map[string]string)
+	result := make(map[string]SubnetInfo)
 
 	for _, az := range availableAZs {
 		if subnet, ok := info.subnets[az]; ok {
@@ -28,13 +34,22 @@ func (info *AZInfo) SubnetsByAZ() map[string]string {
 	result := make(map[string]string)
 	for _, az := range info.AvailabilityZones() {
 		subnet := info.subnets[az]
-		result[az] = subnet
+		result[az] = subnet.SubnetID
 
 		if existing, ok := result[subnetAllAZName]; ok {
-			result[subnetAllAZName] = existing + "," + subnet
+			result[subnetAllAZName] = existing + "," + subnet.SubnetID
 		} else {
-			result[subnetAllAZName] = subnet
+			result[subnetAllAZName] = subnet.SubnetID
 		}
+	}
+	return result
+}
+
+// SubnetIPv6CIDRs returns a list of available subnet IPV6 CIDRs.
+func (info *AZInfo) SubnetIPv6CIDRs() []string {
+	var result []string
+	for _, subnetInfo := range info.subnets {
+		result = append(result, subnetInfo.SubnetIPV6CIDRs...)
 	}
 	return result
 }

--- a/provisioner/aws_az_test.go
+++ b/provisioner/aws_az_test.go
@@ -8,10 +8,19 @@ import (
 
 var (
 	info = &AZInfo{
-		subnets: map[string]string{
-			"eu-central-1a": "subnet-1a",
-			"eu-central-1b": "subnet-1b",
-			"eu-central-1c": "subnet-1c",
+		subnets: map[string]SubnetInfo{
+			"eu-central-1a": {
+				SubnetID:        "subnet-1a",
+				SubnetIPV6CIDRs: []string{"2001:db8::/64"},
+			},
+			"eu-central-1b": {
+				SubnetID:        "subnet-1b",
+				SubnetIPV6CIDRs: []string{"2001:db8::/64"},
+			},
+			"eu-central-1c": {
+				SubnetID:        "subnet-1c",
+				SubnetIPV6CIDRs: []string{"2001:db8::/64"},
+			},
 		},
 	}
 )
@@ -35,4 +44,8 @@ func TestRestrictAZs(t *testing.T) {
 	require.NotEqual(t, info, restricted)
 	require.Equal(t, map[string]string{"*": "subnet-1b", "eu-central-1b": "subnet-1b"}, restricted.SubnetsByAZ())
 	require.Equal(t, []string{"eu-central-1b"}, restricted.AvailabilityZones())
+}
+
+func TestSubnetIPv6CIDRs(t *testing.T) {
+	require.Equal(t, []string{"2001:db8::/64", "2001:db8::/64", "2001:db8::/64"}, info.SubnetIPv6CIDRs())
 }

--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -46,7 +46,6 @@ type (
 		Execute(
 			adapter awsInterface,
 			cluster *api.Cluster,
-			cloudFormationOutput map[string]string,
 		) (
 			*HookResponse,
 			error,
@@ -56,10 +55,9 @@ type (
 	// HookResponse contain configuration parameters that a provisioner can use
 	// at a later stage.
 	HookResponse struct {
-		APIServerURL   string
-		AZInfo         *AZInfo
-		CAData         []byte
-		TemplateValues map[string]interface{}
+		APIServerURL    string
+		CAData          []byte
+		ServiceIPv6CIDR string
 	}
 
 	// Options is the options that can be passed to a provisioner when initialized.

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -116,6 +116,7 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		},
 		"nodeCIDRMaxNodesPodCIDR":               nodeCIDRMaxNodes,
 		"nodeCIDRMaxPods":                       nodeCIDRMaxPods,
+		"addressNFromIPv6CIDR":                  addressNFromIPv6CIDR,
 		"parseInt64":                            parseInt64,
 		"generateJWKSDocument":                  generateJWKSDocument,
 		"generateOIDCDiscoveryDocument":         generateOIDCDiscoveryDocument,
@@ -579,6 +580,26 @@ func nodeCIDRMaxPods(maskSize int64, extraCapacity int64) (int64, error) {
 		maxPods = 110
 	}
 	return maxPods, nil
+}
+
+// addressNFromIPv6CIDR takes an IPv6 CIDR and returns the Nth address in the
+// subnet.
+func addressNFromIPv6CIDR(cidr string, n int) (string, error) {
+	_, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", err
+	}
+
+	ip := ipNet.IP
+	ip = ip.To16()
+	if ip == nil {
+		return "", fmt.Errorf("invalid IP address: %s", ipNet.IP)
+	}
+	ip = ip.Mask(ipNet.Mask)
+	for i := 0; i < n; i++ {
+		ip[15]++
+	}
+	return ip.String(), nil
 }
 
 func kubernetesSizeToKiloBytes(quantity string, scale float64) (string, error) {

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -1485,3 +1485,36 @@ func TestScalingTemplate(t *testing.T) {
 		})
 	}
 }
+
+func TestAddressNFromIPv6CIDR(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		cidr     string
+		input    string
+		expected string
+		err      bool
+	}{
+		{
+			name:     "50th address of IPv6 CIDR",
+			cidr:     "2a05:d014:9c0:bf05::/64",
+			input:    `{{ addressNFromIPv6CIDR .Values.data.cidr 50 }}`,
+			expected: "2a05:d014:9c0:bf05::32",
+		},
+		{
+			name:  "invalid CIDR causes error",
+			cidr:  "2a05:d014:9c0:bf05::/2000", // invalid CIDR
+			input: `{{ addressNFromIPv6CIDR .Values.data.cidr 50 }}`,
+			err:   true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := renderSingle(t, tc.input, map[string]string{"cidr": tc.cidr})
+			if tc.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.EqualValues(t, tc.expected, result)
+			}
+		})
+	}
+}

--- a/provisioner/zalando_eks.go
+++ b/provisioner/zalando_eks.go
@@ -164,7 +164,6 @@ func NewZalandoEKSCreationHook(
 func (z *ZalandoEKSCreationHook) Execute(
 	adapter awsInterface,
 	cluster *api.Cluster,
-	cloudFormationOutput map[string]string,
 ) (*HookResponse, error) {
 	res := &HookResponse{}
 
@@ -201,25 +200,7 @@ func (z *ZalandoEKSCreationHook) Execute(
 
 	res.APIServerURL = clusterDetails.Endpoint
 	res.CAData = decodedCA
-
-	subnets := map[string]string{}
-	for key, az := range map[string]string{
-		"EKSSubneta": "eu-central-1a",
-		"EKSSubnetb": "eu-central-1b",
-		"EKSSubnetc": "eu-central-1c",
-	} {
-		if v, ok := cloudFormationOutput[key]; ok {
-			subnets[az] = v
-		}
-	}
-	if len(subnets) > 0 {
-		res.AZInfo = &AZInfo{
-			subnets: subnets,
-		}
-		res.TemplateValues = map[string]interface{}{
-			subnetsValueKey: subnets,
-		}
-	}
+	res.ServiceIPv6CIDR = clusterDetails.ServiceIPv6CIDR
 
 	return res, nil
 }

--- a/provisioner/zalando_eks_test.go
+++ b/provisioner/zalando_eks_test.go
@@ -41,36 +41,9 @@ func (r *mockRegistry) UpdateConfigItems(_ *api.Cluster, _ map[string]string) er
 
 func TestCreationHookExecute(t *testing.T) {
 	for _, tc := range []struct {
-		cfOutput map[string]string
 		expected *HookResponse
 	}{
 		{
-			cfOutput: map[string]string{
-				"EKSSubneta": "subnet-123",
-				"EKSSubnetb": "subnet-456",
-				"EKSSubnetc": "subnet-789",
-			},
-			expected: &HookResponse{
-				APIServerURL: "https://api.cluster.local",
-				CAData:       []byte("blah"),
-				AZInfo: &AZInfo{
-					subnets: map[string]string{
-						"eu-central-1a": "subnet-123",
-						"eu-central-1b": "subnet-456",
-						"eu-central-1c": "subnet-789",
-					},
-				},
-				TemplateValues: map[string]interface{}{
-					subnetsValueKey: map[string]string{
-						"eu-central-1a": "subnet-123",
-						"eu-central-1b": "subnet-456",
-						"eu-central-1c": "subnet-789",
-					},
-				},
-			},
-		},
-		{
-			cfOutput: map[string]string{},
 			expected: &HookResponse{
 				APIServerURL: "https://api.cluster.local",
 				CAData:       []byte("blah"),
@@ -81,7 +54,6 @@ func TestCreationHookExecute(t *testing.T) {
 		res, err := z.Execute(
 			&mockAWSAdapter{},
 			&api.Cluster{},
-			tc.cfOutput,
 		)
 
 		require.NoError(t, err)


### PR DESCRIPTION
This adds some missing part for getting eks based ipv6 clusters working.

1. Change the AZInfo structure to also include IPv6 CIDR information such that it can be passed to templates via the `.Value.subnet_ipv6_cidrs` varaible. This is so we can pass the list of ipv6 subnets to skipper-ingress for determining internal vs. external traffic.
2. Expose the EKS IPv6 Service CIDR as config-item `service_ipv6_cidr` and add a template function `addressNFromIPV6CIDR` which given a ipv6 cidr and a number `n` can return the nth address from the CIDR. This is done to have a predictable way to get a service IP for the skipper-internal service which is used for `ingress.cluster.local` hostnames.
3. Clean up some CF Output/EKSSubnet handling code, which was left over from some past experiments but are no longer used in the eks branch.