### PR TITLE
Address problems reported by the linter

### DIFF
--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -45,18 +45,6 @@ const (
 	clmCFBucketPattern          = "cluster-lifecycle-manager-%s-%s"
 	lifecycleStatusReady        = "ready"
 	stackUpdateRetryDuration    = time.Duration(5) * time.Minute
-
-	etcdInstanceTypeConfigItem      = "etcd_instance_type"
-	etcdInstanceCountConfigItem     = "etcd_instance_count"
-	etcdScalyrKeyConfigItem         = "etcd_scalyr_key"
-	etcdBackupBucketConfigItem      = "etcd_s3_backup_bucket"
-	etcdClientCAConfigItem          = "etcd_client_ca_cert"
-	etcdClientKeyConfigItem         = "etcd_client_server_key"
-	etcdClientCertificateConfigItem = "etcd_client_server_cert"
-	etcdImageConfigItem             = "etcd_image"
-
-	applicationTagKey = "application"
-	componentTagKey   = "component"
 )
 
 var (

--- a/provisioner/aws_test.go
+++ b/provisioner/aws_test.go
@@ -119,12 +119,6 @@ func (c *cloudFormationAPIStub) getStatus() *string {
 	return c.status
 }
 
-func (c *cloudFormationAPIStub) setStatusReason(statusReason string) {
-	c.statusMutex.Lock()
-	c.statusReason = &statusReason
-	c.statusMutex.Unlock()
-}
-
 func (c *cloudFormationAPIStub) getStatusReason() *string {
 	c.statusMutex.Lock()
 	defer c.statusMutex.Unlock()

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -60,6 +60,9 @@ const (
 	customSubnetTag                    = "zalando.org/custom-subnet"
 	etcdKMSKeyAlias                    = "alias/etcd-cluster"
 	karpenterNodePoolProfile           = "worker-karpenter"
+
+	applicationTagKey = "application"
+	componentTagKey   = "component"
 )
 
 type clusterpyProvisioner struct {
@@ -923,7 +926,7 @@ func (p *clusterpyProvisioner) updater(
 	}
 
 	noScheduleTaint := false
-	if v, _ := cluster.ConfigItems[decommissionNodeNoScheduleTaintKey]; v == "true" {
+	if v := cluster.ConfigItems[decommissionNodeNoScheduleTaintKey]; v == "true" {
 		noScheduleTaint = true
 	}
 	k8sClients, err := kubernetes.NewClientsCollection(

--- a/provisioner/jwks_test.go
+++ b/provisioner/jwks_test.go
@@ -70,6 +70,6 @@ func base64UrlEncode(input []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	trimmed := strings.TrimRight(string(buffer.Bytes()), "=")
+	trimmed := strings.TrimRight(buffer.String(), "=")
 	return []byte(trimmed), nil
 }

--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -263,7 +263,7 @@ func (p *KarpenterNodePoolProvisioner) Reconcile(ctx context.Context, updater up
 	}
 
 	nodes, err := p.k8sClients.List(ctx, "nodes", "", metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("karpenter.sh/nodepool"),
+		LabelSelector: "karpenter.sh/nodepool",
 	})
 	if err != nil {
 		return err
@@ -314,8 +314,7 @@ func (p *KarpenterNodePoolProvisioner) Reconcile(ctx context.Context, updater up
 // TODO: move AWS specific implementation to a separate file/package.
 type AWSNodePoolProvisioner struct {
 	NodePoolTemplateRenderer
-	azInfo          *AZInfo
-	templateContext *templateContext
+	azInfo *AZInfo
 }
 
 // Provision provisions node pools of the cluster.

--- a/provisioner/remote_files.go
+++ b/provisioner/remote_files.go
@@ -17,8 +17,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const kmsKeyPrefix = "arn:aws:kms"
-
 type FilesRenderer struct {
 	awsAdapter    *awsAdapter
 	cluster       *api.Cluster


### PR DESCRIPTION
This addresses some problems reported by the linter

1. Removed unused constants.
2. Removed unused function `setStatusReason` in `aws_test.go`
3. Move `applicationTagKey` and `componentTagKey` from `aws.go` to `clusterpy.go` where they're actually used, for better readability.
4. Other minor fixes to language; unnecessary `_` assignment, unnecessary use of `fmt.Sprintf` etc.