### PR TITLE
Expose vpc ipv6 cidrs as Values

### DIFF
--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -252,6 +252,11 @@ func (p *clusterpyProvisioner) provision(
 		return err
 	}
 
+	vpcIPv6CIDRs := make([]string, 0, len(vpc.Ipv6CidrBlockAssociationSet))
+	for _, ipv6Cidr := range vpc.Ipv6CidrBlockAssociationSet {
+		vpcIPv6CIDRs = append(vpcIPv6CIDRs, aws.StringValue(ipv6Cidr.Ipv6CidrBlock))
+	}
+
 	values := map[string]interface{}{
 		subnetsValueKey:             azInfo.SubnetsByAZ(),
 		availabilityZonesValueKey:   azInfo.AvailabilityZones(),
@@ -259,6 +264,7 @@ func (p *clusterpyProvisioner) provision(
 		"hosted_zone":               hostedZone,
 		"load_balancer_certificate": loadBalancerCert.ID(),
 		"vpc_ipv4_cidr":             aws.StringValue(vpc.CidrBlock),
+		"vpc_ipv6_cidrs":            vpcIPv6CIDRs,
 	}
 
 	// render the manifests to find out if they're valid

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -95,6 +95,7 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		"azID":                 azID,
 		"azCount":              azCount,
 		"split":                split,
+		"join":                 strings.Join,
 		"eksID":                eksID,
 		"mountUnitName":        mountUnitName,
 		"accountID":            accountID,

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -95,7 +95,7 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		"azID":                 azID,
 		"azCount":              azCount,
 		"split":                split,
-		"join":                 strings.Join,
+		"join":                 sprig.GenericFuncMap()["join"],
 		"eksID":                eksID,
 		"mountUnitName":        mountUnitName,
 		"accountID":            accountID,

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -1285,6 +1285,30 @@ func TestList(t *testing.T) {
 `, result)
 }
 
+func TestJoin(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		template string
+		data     interface{}
+		expected string
+	}{
+		{
+			name:     "join items",
+			template: `{{ .Values.data.items | join "," }}`,
+			data: map[string]interface{}{
+				"items": []interface{}{"a", "b", "c"},
+			},
+			expected: `a,b,c`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := renderSingle(t, tc.template, tc.data)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, res)
+		})
+	}
+}
+
 func TestScaleQuantity(t *testing.T) {
 	for _, tc := range []struct {
 		name     string


### PR DESCRIPTION
This adds the optional `.Values.vpc_ipv6_cidrs` field to the template context such that the vpc IPv6 CIDRs can be used e.g. in skipper-ingress config as needed for: https://github.com/zalando-incubator/kubernetes-on-aws/pull/8304

it also adds a standard `join` template function which makes it easier to work with `[]string`