### PR TITLE
Support separate subnets for LBs and workers

### DIFF
--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -229,7 +229,8 @@ func (p *clusterpyProvisioner) provision(
 		azInfoWorkers = azInfoWorkers.RestrictAZs(strings.Split(azNames, ","))
 	}
 
-	// TODO legacy, remove once we switch to Values in all clusters
+	// optional config item to hard-code subnets. This is useful for
+	// migrating between subnets.
 	if _, ok := cluster.ConfigItems[subnetsConfigItemKey]; !ok {
 		cluster.ConfigItems[subnetsConfigItemKey] = azInfoWorkers.SubnetsByAZ()[subnetAllAZName]
 	}

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -39,7 +39,7 @@ const (
 	defaultNamespace                   = "default"
 	tagNameKubernetesClusterPrefix     = "kubernetes.io/cluster/"
 	subnetELBRoleTagName               = "kubernetes.io/role/elb"
-	subnetWorkerRoleTagName            = "kubernetes.io/role/worker"
+	subnetNodeRoleTagName              = "kubernetes.io/role/node"
 	resourceLifecycleShared            = "shared"
 	resourceLifecycleOwned             = "owned"
 	mainStackTagKey                    = "cluster-lifecycle-controller.zalando.org/main-stack"
@@ -221,7 +221,7 @@ func (p *clusterpyProvisioner) provision(
 
 	// find the best subnet for each AZ
 	azInfoLBs := selectSubnetIDs(subnets, subnetELBRoleTagName)
-	azInfoWorkers := selectSubnetIDs(subnets, subnetWorkerRoleTagName)
+	azInfoWorkers := selectSubnetIDs(subnets, subnetNodeRoleTagName)
 
 	// if availability zones are defined, filter the subnet list
 	if azNames, ok := cluster.ConfigItems[availabilityZonesConfigItemKey]; ok {


### PR DESCRIPTION
Add support for choosing different subnets for running Load Balancers and nodes. Until now they all used the same subnets leading to challenges when wanting to use different ingress and egress rules.

The subnets are selected based on tags:

* LB: `kubernetes.io/role/elb`
* Nodes: `kubernetes.io/role/node`

For safe roll out, we will first add the `kubernetes.io/role/node` tag to existing subnets with the tag: `kubernetes.io/role/elb` such that there is no change for running clusters as a change will require a migration.