### PR TITLE
Add a cluster method Name to get canonical clusterName based on provider

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -12,8 +12,16 @@ import (
 	"github.com/zalando-incubator/cluster-lifecycle-manager/channel"
 )
 
+// A provider ID is a string that identifies a cluster provider.
+type ProviderID string
+
 const (
 	overrideChannelConfigItem = "override_channel"
+
+	// ZalandoAWSProvider is the provider ID for Zalando managed AWS clusters.
+	ZalandoAWSProvider ProviderID = "zalando-aws"
+	// ZalandoEKSProvider is the provider ID for AWS EKS clusters.
+	ZalandoEKSProvider ProviderID = "zalando-eks"
 )
 
 // Cluster describes a kubernetes cluster and related configuration.
@@ -29,7 +37,7 @@ type Cluster struct {
 	LifecycleStatus       string            `json:"lifecycle_status"       yaml:"lifecycle_status"`
 	LocalID               string            `json:"local_id"               yaml:"local_id"`
 	NodePools             []*NodePool       `json:"node_pools"             yaml:"node_pools"`
-	Provider              string            `json:"provider"               yaml:"provider"`
+	Provider              ProviderID        `json:"provider"               yaml:"provider"`
 	Region                string            `json:"region"                 yaml:"region"`
 	Status                *ClusterStatus    `json:"status"                 yaml:"status"`
 	Owner                 string            `json:"owner"                  yaml:"owner"`
@@ -73,7 +81,7 @@ func (cluster *Cluster) Version(channelVersion channel.ConfigVersion) (*ClusterV
 	if err != nil {
 		return nil, err
 	}
-	_, err = state.WriteString(cluster.Provider)
+	_, err = state.WriteString(string(cluster.Provider))
 	if err != nil {
 		return nil, err
 	}
@@ -194,4 +202,11 @@ func (cluster *Cluster) ASGBackedPools() []*NodePool {
 		}
 	}
 	return cp
+}
+
+func (cluster Cluster) Name() string {
+	if cluster.Provider == ZalandoEKSProvider {
+		return cluster.LocalID
+	}
+	return cluster.ID
 }

--- a/api/cluster_test.go
+++ b/api/cluster_test.go
@@ -116,3 +116,21 @@ func TestVersion(t *testing.T) {
 		require.NotEqual(t, version, newVersion, "cluster field: %s", field)
 	}
 }
+
+func TestName(t *testing.T) {
+	cluster := &Cluster{
+		ID:       "aws:123456789012:eu-central-1:test-cluster",
+		LocalID:  "test-cluster",
+		Provider: ZalandoAWSProvider,
+	}
+
+	require.Equal(t, cluster.ID, cluster.Name())
+
+	cluster = &Cluster{
+		ID:       "aws:123456789012:eu-central-1:test-cluster",
+		LocalID:  "test-cluster",
+		Provider: ZalandoEKSProvider,
+	}
+
+	require.Equal(t, cluster.LocalID, cluster.Name())
+}

--- a/cmd/clm/main.go
+++ b/cmd/clm/main.go
@@ -12,6 +12,7 @@ import (
 
 	kingpin "github.com/alecthomas/kingpin/v2"
 	log "github.com/sirupsen/logrus"
+	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/channel"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/config"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/controller"
@@ -115,8 +116,8 @@ func main() {
 
 	execManager := command.NewExecManager(cfg.ConcurrentExternalProcesses)
 
-	provisioners := map[provisioner.ProviderID]provisioner.Provisioner{
-		provisioner.ZalandoAWSProvider: provisioner.NewZalandoAWSProvisioner(
+	provisioners := map[api.ProviderID]provisioner.Provisioner{
+		api.ZalandoAWSProvider: provisioner.NewZalandoAWSProvisioner(
 			execManager,
 			clusterTokenSource,
 			secretDecrypter,
@@ -130,7 +131,7 @@ func main() {
 				ManageEtcdStack: cfg.ManageEtcdStack,
 			},
 		),
-		provisioner.ZalandoEKSProvider: provisioner.NewZalandoEKSProvisioner(
+		api.ZalandoEKSProvider: provisioner.NewZalandoEKSProvisioner(
 			execManager,
 			secretDecrypter,
 			cfg.AssumedRole,
@@ -218,7 +219,7 @@ func main() {
 			cluster.ConfigItems[key] = decryptedValue
 		}
 
-		p, ok := provisioners[provisioner.ProviderID(cluster.Provider)]
+		p, ok := provisioners[cluster.Provider]
 		if !ok {
 			log.Fatalf(
 				"Cluster %s: unknown provider %q",

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -44,7 +44,7 @@ type Controller struct {
 	logger               *log.Entry
 	execManager          *command.ExecManager
 	registry             registry.Registry
-	provisioners         map[provisioner.ProviderID]provisioner.Provisioner
+	provisioners         map[api.ProviderID]provisioner.Provisioner
 	providers            []string
 	channelConfigSourcer channel.ConfigSource
 	interval             time.Duration
@@ -58,7 +58,7 @@ func New(
 	logger *log.Entry,
 	execManager *command.ExecManager,
 	registry registry.Registry,
-	provisioners map[provisioner.ProviderID]provisioner.Provisioner,
+	provisioners map[api.ProviderID]provisioner.Provisioner,
 	channelConfigSourcer channel.ConfigSource,
 	options *Options,
 ) *Controller {
@@ -184,7 +184,7 @@ func (c *Controller) doProcessCluster(ctx context.Context, logger *log.Entry, cl
 		}
 	}()
 
-	provisioner, ok := c.provisioners[provisioner.ProviderID(cluster.Provider)]
+	provisioner, ok := c.provisioners[api.ProviderID(cluster.Provider)]
 	if !ok {
 		return fmt.Errorf(
 			"cluster %s: unknown provider %q",

--- a/pkg/updatestrategy/aws_asg.go
+++ b/pkg/updatestrategy/aws_asg.go
@@ -50,17 +50,17 @@ type ASGNodePoolsBackend struct {
 	asgClient autoscalingiface.AutoScalingAPI
 	ec2Client ec2iface.EC2API
 	elbClient elbiface.ELBAPI
-	clusterID string
+	cluster   *api.Cluster
 }
 
-// NewASGNodePoolsBackend initializes a new ASGNodePoolsBackend for the given clusterID and AWS
+// NewASGNodePoolsBackend initializes a new ASGNodePoolsBackend for the given cluster and AWS
 // session and.
-func NewASGNodePoolsBackend(clusterID string, sess *session.Session) *ASGNodePoolsBackend {
+func NewASGNodePoolsBackend(cluster *api.Cluster, sess *session.Session) *ASGNodePoolsBackend {
 	return &ASGNodePoolsBackend{
 		asgClient: autoscaling.New(sess),
 		ec2Client: ec2.New(sess),
 		elbClient: elb.New(sess),
-		clusterID: clusterID,
+		cluster:   cluster,
 	}
 }
 
@@ -432,7 +432,7 @@ func (n *ASGNodePoolsBackend) getNodePoolASGs(nodePool *api.NodePool) ([]*autosc
 
 	expectedTags := []*autoscaling.TagDescription{
 		{
-			Key:   aws.String(clusterIDTagPrefix + n.clusterID),
+			Key:   aws.String(clusterIDTagPrefix + n.cluster.Name()),
 			Value: aws.String(resourceLifecycleOwned),
 		},
 		{

--- a/pkg/updatestrategy/aws_asg_test.go
+++ b/pkg/updatestrategy/aws_asg_test.go
@@ -248,7 +248,7 @@ func TestGet(tt *testing.T) {
 				asgClient: tc.asgClient,
 				ec2Client: tc.ec2Client,
 				elbClient: tc.elbClient,
-				clusterID: "",
+				cluster:   &api.Cluster{},
 			}
 
 			_, err := backend.Get(context.Background(), &api.NodePool{Name: "test"})
@@ -670,7 +670,7 @@ func TestGetInstanceUpdateInfo(t *testing.T) {
 						},
 					},
 				},
-				clusterID: "",
+				cluster: &api.Cluster{},
 			}
 
 			res, err := backend.Get(context.Background(), &api.NodePool{Name: "test"})
@@ -689,6 +689,7 @@ func TestScale(t *testing.T) {
 	// test not getting the ASGs
 	backend := &ASGNodePoolsBackend{
 		asgClient: &mockASGAPI{},
+		cluster:   &api.Cluster{},
 	}
 	err := backend.Scale(context.Background(), &api.NodePool{Name: "test"}, 10)
 	assert.Error(t, err)
@@ -719,6 +720,7 @@ func TestScale(t *testing.T) {
 				},
 			},
 		},
+		cluster: &api.Cluster{},
 	}
 	err = backend.Scale(context.Background(), &api.NodePool{Name: "test"}, 10)
 	assert.NoError(t, err)
@@ -749,6 +751,7 @@ func TestScale(t *testing.T) {
 				},
 			},
 		},
+		cluster: &api.Cluster{},
 	}
 	err = backend.Scale(context.Background(), &api.NodePool{Name: "test"}, 1)
 	assert.NoError(t, err)
@@ -806,7 +809,7 @@ func TestDeleteTags(tt *testing.T) {
 		tt.Run(tc.msg, func(t *testing.T) {
 			backend := &ASGNodePoolsBackend{
 				asgClient: tc.asgClient,
-				clusterID: "",
+				cluster:   &api.Cluster{},
 			}
 
 			err := backend.deleteTags(tc.nodePool, tc.tags)

--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -375,11 +375,11 @@ func (p *AWSNodePoolProvisioner) provisionNodePool(ctx context.Context, nodePool
 	stackName := fmt.Sprintf("nodepool-%s-%s", nodePool.Name, strings.Replace(p.cluster.ID, ":", "-", -1))
 
 	tags := map[string]string{
-		tagNameKubernetesClusterPrefix + p.cluster.ID: resourceLifecycleOwned,
-		nodePoolRoleTagKey:                            "true",
-		nodePoolTagKey:                                nodePool.Name,
-		nodePoolTagKeyLegacy:                          nodePool.Name,
-		nodePoolProfileTagKey:                         nodePool.Profile,
+		tagNameKubernetesClusterPrefix + p.cluster.Name(): resourceLifecycleOwned,
+		nodePoolRoleTagKey:    "true",
+		nodePoolTagKey:        nodePool.Name,
+		nodePoolTagKeyLegacy:  nodePool.Name,
+		nodePoolProfileTagKey: nodePool.Profile,
 	}
 
 	err = p.awsAdapter.applyStack(stackName, template, "", tags, true, nil)
@@ -402,8 +402,8 @@ func (p *AWSNodePoolProvisioner) provisionNodePool(ctx context.Context, nodePool
 func (p *AWSNodePoolProvisioner) Reconcile(ctx context.Context, updater updatestrategy.UpdateStrategy) error {
 	// decommission orphaned node pools
 	tags := map[string]string{
-		tagNameKubernetesClusterPrefix + p.cluster.ID: resourceLifecycleOwned,
-		nodePoolRoleTagKey:                            "true",
+		tagNameKubernetesClusterPrefix + p.cluster.Name(): resourceLifecycleOwned,
+		nodePoolRoleTagKey: "true",
 	}
 
 	nodePoolStacks, err := p.awsAdapter.ListStacks(tags, nil)

--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -11,9 +11,6 @@ import (
 )
 
 type (
-	// A provider ID is a string that identifies a cluster provider.
-	ProviderID string
-
 	// Provisioner is an interface describing how to provision or decommission
 	// clusters.
 	Provisioner interface {
@@ -69,13 +66,6 @@ type (
 		ManageEtcdStack bool
 		Hook            CreationHook
 	}
-)
-
-const (
-	// ZalandoAWSProvider is the provider ID for Zalando managed AWS clusters.
-	ZalandoAWSProvider ProviderID = "zalando-aws"
-	// ZalandoEKSProvider is the provider ID for AWS EKS clusters.
-	ZalandoEKSProvider ProviderID = "zalando-eks"
 )
 
 var (

--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -97,7 +97,6 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		"split":                split,
 		"join":                 sprig.GenericFuncMap()["join"],
 		"eksID":                eksID,
-		"clusterName":          clusterName,
 		"mountUnitName":        mountUnitName,
 		"accountID":            accountID,
 		"portRanges":           portRanges,
@@ -839,13 +838,4 @@ func scaleQuantity(quantityStr string, factor float32) (string, error) {
 		quantity.Set(scaledValue)
 	}
 	return quantity.String(), nil
-}
-
-// clusterName returns the canonical cluster name based on the cluster
-// provider.
-func clusterName(cluster api.Cluster) (string, error) {
-	if cluster.Provider == string(ZalandoEKSProvider) {
-		return cluster.LocalID, nil
-	}
-	return cluster.ID, nil
 }

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -1563,24 +1563,24 @@ func TestClusterName(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "zalando-aws cluster has clusterName == ID",
+			name: "zalando-aws cluster has cluster.Name == ID",
 			cluster: api.Cluster{
-				Provider: string(ZalandoAWSProvider),
+				Provider: api.ZalandoAWSProvider,
 				ID:       "aws:12345678910:eu-central-1:zalando-aws",
 				LocalID:  "zalando-aws",
 			},
 			expected: "aws:12345678910:eu-central-1:zalando-aws",
-			input:    `{{ .Values.data.cluster | clusterName }}`,
+			input:    `{{ .Values.data.cluster.Name }}`,
 		},
 		{
-			name: "zalando-eks cluster has clusterName == LocalID",
+			name: "zalando-eks cluster has cluster.Name == LocalID",
 			cluster: api.Cluster{
-				Provider: string(ZalandoEKSProvider),
+				Provider: api.ZalandoEKSProvider,
 				ID:       "aws:12345678910:eu-central-1:zalando-eks",
 				LocalID:  "zalando-eks",
 			},
 			expected: "zalando-eks",
-			input:    `{{ .Values.data.cluster | clusterName }}`,
+			input:    `{{ .Values.data.cluster.Name }}`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/provisioner/zalando_aws.go
+++ b/provisioner/zalando_aws.go
@@ -50,7 +50,7 @@ func NewZalandoAWSProvisioner(
 }
 
 func (z *ZalandoAWSProvisioner) Supports(cluster *api.Cluster) bool {
-	return cluster.Provider == string(ZalandoAWSProvider)
+	return cluster.Provider == api.ZalandoAWSProvider
 }
 
 func (z *ZalandoAWSProvisioner) Provision(

--- a/provisioner/zalando_eks.go
+++ b/provisioner/zalando_eks.go
@@ -64,7 +64,7 @@ func NewZalandoEKSProvisioner(
 }
 
 func (z *ZalandoEKSProvisioner) Supports(cluster *api.Cluster) bool {
-	return cluster.Provider == string(ZalandoEKSProvider)
+	return cluster.Provider == api.ZalandoEKSProvider
 }
 
 func (z *ZalandoEKSProvisioner) Provision(

--- a/registry/http.go
+++ b/registry/http.go
@@ -214,7 +214,7 @@ func convertFromClusterModel(cluster *models.Cluster) (*api.Cluster, error) {
 		LifecycleStatus:       *cluster.LifecycleStatus,
 		LocalID:               *cluster.LocalID,
 		NodePools:             nodePools,
-		Provider:              *cluster.Provider,
+		Provider:              api.ProviderID(*cluster.Provider),
 		Region:                *cluster.Region,
 		Status:                convertFromClusterStatusModel(cluster.Status),
 	}, nil


### PR DESCRIPTION
This adds a cluster method `Name()` which returns the canonical cluster ID/Name based on the cluster Provider.

This is helpful as for non-EKS we use the full `ID` as cluster ID e.g. via tags on resources and for EKS we use only `LocalID` as the `ID` is not compatible with EKS because of `:` in the value.

This makes it simpler to template such that both EKS and non-EKS is supported.