### PR TITLE
Optionally support dedicated pod subnets

### DIFF
--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -41,6 +41,7 @@ const (
 	subnetELBRoleTagName               = "kubernetes.io/role/elb"
 	subnetNodeRoleTagName              = "kubernetes.io/role/node"
 	subnetInternalNodeRoleTagName      = "kubernetes.io/role/internal-node"
+	subnetPodRoleTagName               = "kubernetes.io/role/pod"
 	resourceLifecycleShared            = "shared"
 	resourceLifecycleOwned             = "owned"
 	mainStackTagKey                    = "cluster-lifecycle-controller.zalando.org/main-stack"
@@ -224,6 +225,7 @@ func (p *clusterpyProvisioner) provision(
 	azInfoLBs := selectSubnetIDs(subnets, subnetELBRoleTagName)
 	azInfoNodes := selectSubnetIDs(subnets, subnetNodeRoleTagName)
 	azInfoIntenalNodes := selectSubnetIDs(subnets, subnetInternalNodeRoleTagName)
+	azInfoPods := selectSubnetIDs(subnets, subnetPodRoleTagName)
 
 	// if availability zones are defined, filter the subnet list
 	if azNames, ok := cluster.ConfigItems[availabilityZonesConfigItemKey]; ok {
@@ -270,6 +272,7 @@ func (p *clusterpyProvisioner) provision(
 		subnetIPV6CIDRsKey:          strings.Join(azInfoNodes.SubnetIPv6CIDRs(), ","),
 		"lb_subnets":                azInfoLBs.SubnetsByAZ(),
 		"internal_node_subnets":     azInfoIntenalNodes.SubnetsByAZ(),
+		"pod_subnets":               azInfoPods.SubnetsByAZ(),
 		"hosted_zone":               hostedZone,
 		"load_balancer_certificate": loadBalancerCert.ID(),
 		"vpc_ipv4_cidr":             aws.StringValue(vpc.CidrBlock),


### PR DESCRIPTION
ref: https://github.com/zalando-incubator/kubernetes-on-aws/pull/8510

Adds support for discovering subnets for pods if using [Custom Networking](https://docs.aws.amazon.com/eks/latest/best-practices/custom-networking.html)