### PR TITLE
adding a special instance-types string 'not-specified'

### DIFF
--- a/api/node_pool.go
+++ b/api/node_pool.go
@@ -65,7 +65,7 @@ func (np NodePool) KarpenterRequirements() []v1.NodeSelectorRequirementApplyConf
 }
 
 func (np NodePool) KarpenterInstanceTypeStrategy() string {
-	if len(np.InstanceTypes) == 0 {
+	if len(np.InstanceTypes) == 1 && np.InstanceTypes[0] == "not-specified" {
 		return "not-specified"
 	}
 	if len(np.InstanceTypes) == 1 && np.InstanceTypes[0] == "default-for-karpenter" {

--- a/pkg/aws/instance_info.go
+++ b/pkg/aws/instance_info.go
@@ -168,13 +168,6 @@ func getCompatibleCPUArchitecture(instanceType *ec2.InstanceTypeInfo) (string, e
 	return "", fmt.Errorf("didn't find compatible cpu architecture within '%v'", supportedArchitectures)
 }
 
-func min(a int64, b int64) int64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func contains(s []string, e string) bool {
 	for _, a := range s {
 		if a == e {

--- a/pkg/updatestrategy/aws_asg.go
+++ b/pkg/updatestrategy/aws_asg.go
@@ -193,14 +193,14 @@ func (n *ASGNodePoolsBackend) Scale(_ context.Context, nodePool *api.NodePool, r
 	}
 
 	for _, asg := range asgs {
-		min := int64(math.Min(float64(aws.Int64Value(asg.DesiredCapacity)), float64(aws.Int64Value(asg.MinSize))))
-		max := int64(math.Max(float64(aws.Int64Value(asg.DesiredCapacity)), float64(aws.Int64Value(asg.MaxSize))))
+		minSize := int64(math.Min(float64(aws.Int64Value(asg.DesiredCapacity)), float64(aws.Int64Value(asg.MinSize))))
+		maxSize := int64(math.Max(float64(aws.Int64Value(asg.DesiredCapacity)), float64(aws.Int64Value(asg.MaxSize))))
 
 		params := &autoscaling.UpdateAutoScalingGroupInput{
 			AutoScalingGroupName: asg.AutoScalingGroupName,
 			DesiredCapacity:      asg.DesiredCapacity,
-			MinSize:              aws.Int64(min),
-			MaxSize:              aws.Int64(max),
+			MinSize:              aws.Int64(minSize),
+			MaxSize:              aws.Int64(maxSize),
 		}
 
 		_, err := n.asgClient.UpdateAutoScalingGroup(params)

--- a/pkg/updatestrategy/rolling_update_test.go
+++ b/pkg/updatestrategy/rolling_update_test.go
@@ -129,11 +129,11 @@ func getFailureDomain(nodes []*Node) string {
 		}
 	}
 
-	min := len(nodes)
+	minNodes := len(nodes)
 	failureDomain := "a"
 	for fd, num := range fdCount {
-		if num < min || (num == min && fd < failureDomain) {
-			min = num
+		if num < minNodes || (num == minNodes && fd < failureDomain) {
+			minNodes = num
 			failureDomain = fd
 		}
 	}


### PR DESCRIPTION
empty instance-types is not supported by cluster-registery. using `not-specified` will render karpenter node-pools without instance-type requirements

this way we can create node-pools like this
```yaml
  - config_items:
      taints: nvidia.com/gpu=present:NoSchedule
      requirements: |
        - key: karpenter.k8s.aws/instance-gpu-manufacturer
          operator: In
          values: 
            - nvidia
    discount_strategy: null
    instance_types:
      - not-specified
    max_size: null
    min_size: null
    name: karpenter-gpu
    profile: worker-karpenter
  - config_items:
    discount_strategy: null
    instance_types:
      - not-specified
    max_size: null
    min_size: null
    name: karpenter-catch-all
    profile: worker-karpenter
```