### PR TITLE
Fix generating EKS token

### DIFF
--- a/pkg/aws/eks/token.go
+++ b/pkg/aws/eks/token.go
@@ -2,6 +2,7 @@ package eks
 
 import (
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"golang.org/x/oauth2"
 	awsiamtoken "sigs.k8s.io/aws-iam-authenticator/pkg/token"
 )
@@ -25,10 +26,9 @@ func (ts *TokenSource) Token() (*oauth2.Token, error) {
 		return nil, err
 	}
 
-	tokenOpts := &awsiamtoken.GetTokenOptions{
-		ClusterID: ts.clusterName,
-	}
-	awsToken, err := gen.GetWithOptions(tokenOpts)
+	stsAPI := sts.New(ts.session)
+
+	awsToken, err := gen.GetWithSTS(ts.clusterName, stsAPI)
 	if err != nil {
 		return nil, err
 	}

--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -103,7 +103,6 @@ type (
 		acmClient            acmiface.ACMAPI
 		eksClient            eksiface.EKSAPI
 		region               string
-		apiServer            string
 		dryRun               bool
 		logger               *log.Entry
 		kmsClient            kmsiface.KMSAPI
@@ -118,7 +117,7 @@ type (
 )
 
 // newAWSAdapter initializes a new awsAdapter.
-func newAWSAdapter(logger *log.Entry, apiServer string, region string, sess *session.Session, dryRun bool) *awsAdapter {
+func newAWSAdapter(logger *log.Entry, region string, sess *session.Session, dryRun bool) *awsAdapter {
 	return &awsAdapter{
 		session:              sess,
 		cloudformationClient: cloudformation.New(sess),
@@ -130,7 +129,6 @@ func newAWSAdapter(logger *log.Entry, apiServer string, region string, sess *ses
 		acmClient:            acm.New(sess),
 		eksClient:            eks.New(sess),
 		region:               region,
-		apiServer:            apiServer,
 		dryRun:               dryRun,
 		logger:               logger,
 		kmsClient:            kms.New(sess),

--- a/provisioner/aws_test.go
+++ b/provisioner/aws_test.go
@@ -176,7 +176,6 @@ func newAWSAdapterWithStubs(status string, groupName string) *awsAdapter {
 		s3Uploader:           &s3UploaderAPIStub{},
 		ec2Client:            &ec2APIStub{},
 		autoscalingClient:    &autoscalingAPIStub{groupName: groupName},
-		apiServer:            "",
 		dryRun:               false,
 		logger:               logger,
 	}

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -848,7 +848,7 @@ func (p *clusterpyProvisioner) setupAWSAdapter(logger *log.Entry, cluster *api.C
 		return nil, err
 	}
 
-	adapter := newAWSAdapter(logger, cluster.APIServerURL, cluster.Region, sess, p.dryRun)
+	adapter := newAWSAdapter(logger, cluster.Region, sess, p.dryRun)
 	err = adapter.VerifyAccount(cluster.InfrastructureAccount)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes getting a correct token for EKS clusters such that CLM can authenticate to an EKS cluster cross account.

This broke in #834 as the aws-iam-authenticator library was updated and the call was changed to not pass the existing session.

The problem was that when not passing the session, it falls back to setup a session from the current environment. When CLM is running centrally the current environment is an IAM role in the central account instead of an assumed role in the target account which has access to the targeted EKS cluster. The fix is to get a token in a way where we use the assumed role session to setup an STS client. Other API calls were removed from the upstream library in https://github.com/kubernetes-sigs/aws-iam-authenticator/pull/750