### PR TITLE
Add append template function

### DIFF
--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -131,6 +131,7 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		"indent":                                sprig.GenericFuncMap()["indent"],
 		"dict":                                  dict,
 		"list":                                  list,
+		"append":                                strAppend,
 		"scaleQuantity":                         scaleQuantity,
 		"instanceTypeCPUQuantity": func(instanceType string) (string, error) {
 			return instanceTypeCPUQuantity(context, instanceType)
@@ -281,6 +282,11 @@ func dict(args ...interface{}) (map[string]interface{}, error) {
 
 func list(args ...interface{}) []interface{} {
 	return args
+}
+
+func strAppend(list []string, item string, moreItems ...string) []string {
+	items := append(list, item)
+	return append(items, moreItems...)
 }
 
 func eksID(id string) string {

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -1309,6 +1309,40 @@ func TestJoin(t *testing.T) {
 	}
 }
 
+func TestStrAppend(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		template string
+		data     interface{}
+		expected string
+	}{
+		{
+			name:     "append to list",
+			template: `{{ append .Values.data.items .Values.data.item }}`,
+			data: map[string]interface{}{
+				"items": []string{"a", "b"},
+				"item":  "c",
+			},
+			expected: "[a b c]",
+		}, {
+			name:     "append multiple items to list",
+			template: `{{ append .Values.data.items .Values.data.item .Values.data.item2 }}`,
+			data: map[string]interface{}{
+				"items": []string{"a", "b"},
+				"item":  "c",
+				"item2": "d",
+			},
+			expected: "[a b c d]",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := renderSingle(t, tc.template, tc.data)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, res)
+		})
+	}
+}
+
 func TestScaleQuantity(t *testing.T) {
 	for _, tc := range []struct {
 		name     string


### PR DESCRIPTION
Add `append` template functions which can append an item to a list. It's intentially only implemented for `string` as we don't need more than this for now.

It's needed for https://github.com/zalando-incubator/kubernetes-on-aws/pull/8786