### PR TITLE
Retry Karpenter get ec2nodeclass

### DIFF
--- a/pkg/updatestrategy/node_pool_manager.go
+++ b/pkg/updatestrategy/node_pool_manager.go
@@ -101,7 +101,7 @@ func NewKubernetesNodePoolManager(logger *log.Entry, kubeClient kubernetes.Inter
 func (m *KubernetesNodePoolManager) GetPool(ctx context.Context, nodePoolDesc *api.NodePool) (*NodePool, error) {
 	nodePool, err := m.backend.Get(ctx, nodePoolDesc)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get node pool details: %#v", err)
+		return nil, fmt.Errorf("failed to get node pool details: %w", err)
 	}
 
 	var (


### PR DESCRIPTION
Add retry logic to the logic for managing karpenter pools

The motivation for this is that during Karpenter v1 upgrade (https://github.com/zalando-incubator/kubernetes-on-aws/pull/8900) there will be installed a webhook for migrating the CRDs. When we apply via CLM there is a short time where the webhook is not yet rolled out (needs to update the karpenter deployment). This fails the update of the node pool as reading the CRDs invokes the webhook. The error is:

```
time="2025-02-18T13:56:57Z" level=fatal msg="Fail to provision: failed to get node pool details: &errors.StatusError{ErrStatus:v1.Status{TypeMeta:v1.TypeMeta{Kind:\"Status\", APIVersion:\"v1\"}, ListMeta:v1.ListMeta{SelfLink:\"\", ResourceVersion:\"\", Continue:\"\", RemainingItemCount:(*int64)(nil)}, Status:\"Failure\", Message:\"conversion webhook for karpenter.k8s.aws/v1beta1, Kind=EC2NodeClass failed: Post \\\"https://karpenter.kube-system.svc:8443/?timeout=30s\\\": dial tcp 10.5.59.58:8443: connect: connection refused\", Reason:\"\", Details:(*v1.StatusDetails)(nil), Code:500}}"
```

This issue ultimately make e2e fail because CLM only tries once. (In normal clusters CLM, would just rerun and eventually succeed).

By retrying we work around the temporary unavailability of the webhook similar to what we do when applying manifests.

The PR also adds some context to the errors in the related code.