### PR TITLE
Delete leaked ENIs on decommissioning

### DIFF
--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -689,6 +689,7 @@ func (p *clusterpyProvisioner) decommission(
 	tokenSource oauth2.TokenSource,
 	cluster *api.Cluster,
 	caData []byte,
+	preClusterStackDeletionHooks ...func(ctx context.Context, cluster *api.Cluster) error,
 ) error {
 	logger.Infof("Decommissioning cluster: %s (%s)", cluster.Alias, cluster.ID)
 
@@ -747,6 +748,14 @@ func (p *clusterpyProvisioner) decommission(
 	}
 	if err != nil {
 		return err
+	}
+
+	// execute provider specific hooks, pre cluster stack deletion.
+	for _, hook := range preClusterStackDeletionHooks {
+		err := hook(ctx, cluster)
+		if err != nil {
+			return err
+		}
 	}
 
 	stack := &cloudformation.Stack{

--- a/provisioner/zalando_eks.go
+++ b/provisioner/zalando_eks.go
@@ -142,6 +142,7 @@ func (z *ZalandoEKSProvisioner) Decommission(
 		tokenSource,
 		cluster,
 		caData,
+		awsAdapter.DeleteLeakedAWSVPCCNIENIs,
 	)
 }
 


### PR DESCRIPTION
In EKS clusters there can be ENIs left over from the AWS VPC CNI which blocks the deletion of the cluster stack during decommissioning because the ENI refer to a security group in the stack.

To work around this issue which is mostly present during e2e cluster cleanup, this PR adds a hook to find and delete such ENIs before the cluster stack is being deleted.