### PR TITLE
Fix git test by using standard branch name

### DIFF
--- a/channel/git.go
+++ b/channel/git.go
@@ -1,6 +1,7 @@
 package channel
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -115,9 +116,12 @@ func (g *Git) Update(ctx context.Context, logger *log.Entry) error {
 }
 
 func (g *Git) Version(channel string, _ map[string]string) (ConfigVersion, error) {
-	sha, err := exec.Command("git", "--git-dir", g.repoDir, "rev-parse", channel).Output()
+	stderr := new(bytes.Buffer)
+	cmd := exec.Command("git", "--git-dir", g.repoDir, "rev-parse", channel)
+	cmd.Stderr = stderr
+	sha, err := cmd.Output()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to execute git: %s: %w", stderr.String(), err)
 	}
 
 	return &gitVersion{

--- a/channel/git_test.go
+++ b/channel/git_test.go
@@ -14,7 +14,7 @@ import (
 
 // helper function to setup a test repository.
 func createGitRepo(t *testing.T, logger *log.Entry, dir string) {
-	err := exec.Command("git", "-C", dir, "init").Run()
+	err := exec.Command("git", "-C", dir, "init", "-b", "main").Run()
 	require.NoError(t, err)
 
 	execManager := command.NewExecManager(1)
@@ -76,9 +76,9 @@ func TestGitGet(t *testing.T) {
 	err = c.Update(context.Background(), logger)
 	require.NoError(t, err)
 
-	// check master channel
-	master := checkout(t, logger, c, "master")
-	verifyExampleConfig(t, master, "testsrc", "channel1")
+	// check main channel
+	main := checkout(t, logger, c, "main")
+	verifyExampleConfig(t, main, "testsrc", "channel1")
 
 	// check another channel
 	channel2 := checkout(t, logger, c, "channel2")
@@ -90,7 +90,7 @@ func TestGitGet(t *testing.T) {
 		"-C",
 		repoTempDir,
 		"rev-parse",
-		"master",
+		"main",
 	).Output()
 	require.NoError(t, err)
 


### PR DESCRIPTION
For me, locally, the git related tests were always failing with a strange 128 exit code.

```
--- FAIL: TestGitGet (0.07s)
    git_test.go:55:
        	Error Trace:	/home/moscar/projects/teapot/cluster-lifecycle-manager/channel/git_test.go:55
        	            				/home/moscar/projects/teapot/cluster-lifecycle-manager/channel/git_test.go:80
        	Error:      	Received unexpected error:
        	            	exit status 128
        	Test:       	TestGitGet
FAIL
```

The reason turned out be that I have configured: `defaultBranch = main` in my local config, but the tests assumes `master` is the default branch.

This PR changes the tests to do `git init -b main` and use main in all cases. This way it will be predictable no matter what the local config is. And we get rid of the use of `master`.

This also adds stderr to the git command err such that it's easier to debug such issues in the future as opposed to only see the exit code.