### PR TITLE
Improve decommissioning of karpenter nodes

### DIFF
--- a/pkg/util/generics.go
+++ b/pkg/util/generics.go
@@ -1,7 +1,5 @@
 package util
 
-import "sync"
-
 func Contains[T comparable](s []T, e T) bool {
 	for _, v := range s {
 		if v == e {
@@ -9,25 +7,4 @@ func Contains[T comparable](s []T, e T) bool {
 		}
 	}
 	return false
-}
-
-type LazyOf[T any] struct {
-	New   func() (T, error)
-	once  sync.Once
-	value T
-}
-
-func (l *LazyOf[T]) Value() (T, error) {
-	var err error
-	if l.New != nil {
-		l.once.Do(func() {
-			l.value, err = l.New()
-			l.New = nil
-		})
-	}
-	return l.value, err
-}
-
-func NewLazyOf[T any](newfunc func() (T, error)) *LazyOf[T] {
-	return &LazyOf[T]{New: newfunc}
 }


### PR DESCRIPTION
This improves the logic for decommissioning karpenter nodes during cluster decommissioning to avoid leaking karpenter nodes which can't be cleaned up and block full cluster decommissioning.

The problem today is that decommissioning depends on Kubernetes API access during decommissioning. If  a cluster is broken, e.g. in an e2e scenario, then CLM can fail to clean up karpenter nodes.

Instead of relying on the Kubernetes API, which is only really used to get an instance tag during decommissioning, instead only rely on AWS API and delete any EC2 instance matching the node pool and cluster tag.

Additionally, this PR removes the logic for handling legacy karpenter CRD names (provisioner and AWS template). We only need to handle the new resource names (nodepool and EC2NodeClass) so we can drop the complexity of supporting both.