### PR TITLE
Remove legacy karpenter_pools_enabled logic

### DIFF
--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -421,25 +421,21 @@ func (p *clusterpyProvisioner) provision(
 		return err
 	}
 
-	if karpenterProvisioner.isKarpenterEnabled() {
-		err = p.apply(
-			ctx,
-			logger,
-			tokenSource,
-			cluster,
-			deletions,
-			manifests,
-			postOptions,
-		)
-		if err != nil {
-			return err
-		}
+	err = p.apply(
+		ctx,
+		logger,
+		tokenSource,
+		cluster,
+		deletions,
+		manifests,
+		postOptions,
+	)
+	if err != nil {
+		return err
 	}
 
-	if karpenterProvisioner.isKarpenterEnabled() {
-		if err = nodePoolGroups["karpenterPools"].provisionNodePoolGroup(ctx, values, updater, cluster, p.applyOnly); err != nil {
-			return err
-		}
+	if err = nodePoolGroups["karpenterPools"].provisionNodePoolGroup(ctx, values, updater, cluster, p.applyOnly); err != nil {
+		return err
 	}
 
 	// clean up removed node pools
@@ -447,27 +443,11 @@ func (p *clusterpyProvisioner) provision(
 	if err != nil {
 		return err
 	}
-	if karpenterProvisioner.isKarpenterEnabled() {
-		err = karpenterProvisioner.Reconcile(ctx, updater)
-		if err != nil {
-			return err
-		}
+	err = karpenterProvisioner.Reconcile(ctx, updater)
+	if err != nil {
+		return err
 	}
 
-	if !karpenterProvisioner.isKarpenterEnabled() {
-		err = p.apply(
-			ctx,
-			logger,
-			tokenSource,
-			cluster,
-			deletions,
-			manifests,
-			postOptions,
-		)
-		if err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/provisioner/node_pools.go
+++ b/provisioner/node_pools.go
@@ -234,13 +234,6 @@ func (p *KarpenterNodePoolProvisioner) provisionNodePool(ctx context.Context, no
 	return nil
 }
 
-func (p *KarpenterNodePoolProvisioner) isKarpenterEnabled() bool {
-	if v, found := p.cluster.ConfigItems["karpenter_pools_enabled"]; found && v == "true" {
-		return true
-	}
-	return false
-}
-
 func (p *KarpenterNodePoolProvisioner) Reconcile(ctx context.Context, updater updatestrategy.UpdateStrategy) error {
 	karpenterPools := p.cluster.KarpenterPools()
 


### PR DESCRIPTION
Remove legacy logic for determining order of apply steps based on `karpenter_pools_enabled=true` config-item.

The config-item was removed in https://github.com/zalando-incubator/kubernetes-on-aws/pull/9147 making CLM behave in the old way even though karpenter is the default in all clusters.

This currently breaks e2e and node pools are not created before manifests are applied.

Fix it by just dropping the custom logic that anyway was always true in practice.