### PR TITLE
Etcd arm configs

### DIFF
--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -487,7 +487,11 @@ func createOrUpdateEtcdStack(
 		nodePool:      nil,
 		instanceTypes: instanceTypes,
 	}
-	values["instance_types_info"] = instanceTypes
+	etcdInstanceInfo, err := instanceTypes.InstanceInfo(cluster.ConfigItems["etcd_instance_type"])
+	if err != nil {
+		return err
+	}
+	values["etcd_instance_type_info"] = etcdInstanceInfo.InstanceType
 
 	s3Path, err := renderer.RenderAndUploadFiles(values, bucketName, etcdKmsKeyARN)
 	if err != nil {
@@ -496,12 +500,6 @@ func createOrUpdateEtcdStack(
 
 	logger.Debugf("Uploaded generated files to %s", s3Path)
 	values[s3GeneratedFilesPathValuesKey] = s3Path
-
-	etcdInstanceInfo, err := instanceTypes.InstanceInfo(cluster.ConfigItems["etcd_instance_type"])
-	if err != nil {
-		return err
-	}
-	values["etcd_instance_type_info"] = etcdInstanceInfo.InstanceType
 
 	rendered, err := renderSingleTemplate(template, cluster, nil, values, adapter, instanceTypes)
 	if err != nil {

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -497,6 +497,12 @@ func createOrUpdateEtcdStack(
 	logger.Debugf("Uploaded generated files to %s", s3Path)
 	values[s3GeneratedFilesPathValuesKey] = s3Path
 
+	etcdInstanceInfo, err := instanceTypes.InstanceInfo(cluster.ConfigItems["etcd_instance_type"])
+	if err != nil {
+		return err
+	}
+	values["etcd_instance_type_info"] = etcdInstanceInfo.InstanceType
+
 	rendered, err := renderSingleTemplate(template, cluster, nil, values, adapter, instanceTypes)
 	if err != nil {
 		return err


### PR DESCRIPTION
it was difficult to use the `instance_types_info` hashmap to render the templates. to simplify go templates, I am trying a different approach.

