### PR TITLE
terminate deletion loop if a cluster is no longer found

### DIFF
--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -42,6 +42,7 @@ const (
 	stackMaxSize                = 51200
 	cloudformationValidationErr = "ValidationError"
 	cloudformationNoUpdateMsg   = "No updates are to be performed."
+	eksResourceNotFoundErr      = "ResourceNotFoundException"
 	clmCFBucketPattern          = "cluster-lifecycle-manager-%s-%s"
 	lifecycleStatusReady        = "ready"
 	stackUpdateRetryDuration    = time.Duration(5) * time.Minute
@@ -714,7 +715,7 @@ func isDoesNotExistsErr(err error) bool {
 
 func isClusterNotFoundErr(err error) bool {
 	if awsErr, ok := err.(awserr.Error); ok {
-		if strings.Contains(awsErr.Message(), "No cluster found") {
+		if awsErr.Code() == eksResourceNotFoundErr && strings.Contains(awsErr.Message(), "No cluster found") {
 			return true
 		}
 	}

--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -712,6 +712,15 @@ func isDoesNotExistsErr(err error) bool {
 	return false
 }
 
+func isClusterNotFoundErr(err error) bool {
+	if awsErr, ok := err.(awserr.Error); ok {
+		if strings.Contains(awsErr.Message(), "No cluster found") {
+			return true
+		}
+	}
+	return false
+}
+
 // isWrongStackStatusErr returns true if the error is of type awserr.Error and
 // describes a failure because of wrong Cloudformation stack status.
 func isWrongStackStatusErr(err error) bool {

--- a/provisioner/zalando_eks.go
+++ b/provisioner/zalando_eks.go
@@ -122,6 +122,10 @@ func (z *ZalandoEKSProvisioner) Decommission(
 
 	clusterDetails, err := awsAdapter.GetEKSClusterDetails(cluster)
 	if err != nil {
+		if isClusterNotFoundErr(err) {
+			logger.Infof("EKS cluster not found: %s", cluster.ID)
+			return nil
+		}
 		return err
 	}
 	cluster.APIServerURL = clusterDetails.Endpoint


### PR DESCRIPTION
## Summary
This fixes a bug in the EKS provisioner where a cluster decommissioning can be stuck indefinitely. 


## Details
We observed the following

1. A stack deletion for deleting an EKS cluster timed out, while leaving the stack in `DELETE_IN_PROGRESS` state.

```golang
time="2025-08-22T16:02:14Z" level=error msg="Failed to process cluster: wait for stack timeout exceeded" cluster=data-eun1-ipv4-test 
```


2. This continued as the deletion proceeded, and in the meantime the provisioner was stuck at this message. However this isn't an irrecoverable problem and simply means the stack is already being deleted:

```golang
time="2025-08-22T16:04:40Z" level=error msg="Failed to process cluster: ValidationError: Termination protection cannot be updated due to stack [data-eun1-ipv4-test] being in state [DELETE_IN_PROGRESS]\n\tstatus code: 400, request id: 41e7c5b6-8f53-4d12-9d30-38ecc8bd3ff6" cluster=data-eun1-ipv4-test 
```

3. However, once the stack was eventually deleted along with the cluster, there's nothing to check in the `Decommission()` function of the EKS provisioner which continues to `GetEKSClusterDetails` as the deletion didn't succeed normally and the cluster registry still shows the state as `decommission requested`. This causes CLM to be continuously stuck in a loop with this error:

```golang
time="2025-08-22T16:13:15Z" level=error msg="Failed to process cluster: ResourceNotFoundException: No cluster found for name: data-eun1-ipv4-test.\n{\n  RespMetadata: {\n    StatusCode: 404,\n    RequestID: \"c27674c6-2e70-4710-b512-a2d80dfa58df\"\n  },\n  ClusterName: \"data-eun1-ipv4-test\",\n  Message_: \"No cluster found for name: data-eun1-ipv4-test.\"\n}" cluster=data-eun1-ipv4-test 
```

This fixes this bug by checking for this error and prematurely returning from the `Decommission` function. This will cause the main controller loop function `doProcessCluster` to update the cluster status to `decommissioned` causing the loop to terminate and the decommissioning to conclude gracefully.