### PR TITLE
increase maxApplyRetries

### DIFF
--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -54,7 +54,7 @@ const (
 	availabilityZonesValueKey          = "availability_zones"
 	vpcIDConfigItemKey                 = "vpc_id"
 	subnetAllAZName                    = "*"
-	maxApplyRetries                    = 10
+	maxApplyRetries                    = 15
 	configKeyUpdateStrategy            = "update_strategy"
 	updateStrategyRolling              = "rolling"
 	updateStrategyCLC                  = "clc"


### PR DESCRIPTION
This increases the maxApplyRetries from 10 to 15. 


This will help optimize e2e test pipeline `create-cluster-eks` step where the admission-controller deployment can take a while to be ready. 10 retries with exponential backoff amount to ~60s of retry period, if this exceeds (which has been happening very often in past few weeks) the apply fails. Leading to the `PlatformCredentialsSet` CRD not getting applied, and the `create-cluster-eks` step in the pipeline fails.

```golang
time="2026-03-06T11:46:16Z" level=error msg="Error from server (InternalError): error when creating \"STDIN\": Internal error occurred: failed calling webhook \"crd-admitter.teapot.zalan.do\": failed to call webhook: Post \"https://admission-controller.kube-system.svc:443/crd?timeout=10s\": no endpoints available for service \"admission-controller\"" module=02-platformcredentialsset
```

This change will introduce a worst case wait time of 3-4 minutes, but will save hours in e2e re-runs that we have to do right now in order to make the apply _eventually_ succeed.