### PR TITLE
Update github actions to go v1.26

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-go@v6
       with:
-        go-version: '^1.25'
+        go-version: '^1.26'
     - run: go version
     - run: go install github.com/mattn/goveralls@latest
     - run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest


### PR DESCRIPTION
Update github actions to use Go v1.26