### PR TITLE
Add very basic custom CF stack support

### DIFF
--- a/channel/combined.go
+++ b/channel/combined.go
@@ -124,6 +124,18 @@ func (c *combinedConfig) EtcdManifest(manifestName string) (Manifest, error) {
 	return mainConfig.EtcdManifest(manifestName)
 }
 
+func (c *combinedConfig) CFManifests() ([]Manifest, error) {
+	var result []Manifest
+	for i, config := range c.configs {
+		manifests, err := config.CFManifests()
+		if err != nil {
+			return nil, fmt.Errorf("unable to get CF manifests for source %s: %v", c.owner.sourceName(i), err)
+		}
+		result = append(result, manifests...)
+	}
+	return result, nil
+}
+
 func (c *combinedConfig) NodePoolManifest(profileName string, manifestName string) (Manifest, error) {
 	mainConfig, err := c.mainConfig()
 	if err != nil {

--- a/channel/config_source.go
+++ b/channel/config_source.go
@@ -41,6 +41,7 @@ type Component struct {
 type Config interface {
 	StackManifest(manifestName string) (Manifest, error)
 	EtcdManifest(manifestName string) (Manifest, error)
+	CFManifests() ([]Manifest, error)
 	NodePoolManifest(profileName string, manifestName string) (Manifest, error)
 	DefaultsManifests() ([]Manifest, error)
 	DeletionsManifests() ([]Manifest, error)

--- a/channel/simple_config.go
+++ b/channel/simple_config.go
@@ -8,12 +8,13 @@ import (
 )
 
 const (
-	configRoot    = "cluster"
-	poolConfigDir = "node-pools"
-	etcdConfigDir = "etcd"
-	defaultsFile  = "config-defaults.yaml"
-	manifestsDir  = "manifests"
-	deletionsFile = "deletions.yaml"
+	configRoot           = "cluster"
+	poolConfigDir        = "node-pools"
+	etcdConfigDir        = "etcd"
+	cfManifestsConfigDir = "cf-manifests"
+	defaultsFile         = "config-defaults.yaml"
+	manifestsDir         = "manifests"
+	deletionsFile        = "deletions.yaml"
 )
 
 type SimpleConfig struct {
@@ -48,6 +49,36 @@ func (c *SimpleConfig) readManifest(manifestDirectory string, name string) (Mani
 
 func (c *SimpleConfig) StackManifest(manifestName string) (Manifest, error) {
 	return c.readManifest(configRoot, manifestName)
+}
+
+func (c *SimpleConfig) CFManifests() ([]Manifest, error) {
+	var result []Manifest
+
+	cfManifestsDir := path.Join(c.baseDir, configRoot, cfManifestsConfigDir)
+	files, err := os.ReadDir(cfManifestsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(file.Name(), ".yaml") && !strings.HasSuffix(file.Name(), ".yml") {
+			continue
+		}
+		manifest, err := c.readManifest(path.Join(configRoot, cfManifestsConfigDir), file.Name())
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, manifest)
+	}
+
+	return result, nil
 }
 
 func (c *SimpleConfig) EtcdManifest(manifestName string) (Manifest, error) {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -193,6 +193,10 @@ func (c *mockConfig) EtcdManifest(_ string) (channel.Manifest, error) {
 	return c.mockManifest, nil
 }
 
+func (c *mockConfig) CFManifests() ([]channel.Manifest, error) {
+	return []channel.Manifest{c.mockManifest}, nil
+}
+
 func (c *mockConfig) NodePoolManifest(_ string, _ string) (channel.Manifest, error) {
 	return c.mockManifest, nil
 }

--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -2,6 +2,7 @@ package provisioner
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
@@ -199,17 +200,54 @@ func tagMapToCloudformationTags(tags map[string]string) []cftypes.Tag {
 	return cfTags
 }
 
-func tagsFromStackTemplate(template string) (map[string]string, error) {
-	var parsedTemplate struct {
-		Metadata struct {
-			Tags map[string]string `yaml:"Tags"`
-		} `yaml:"Metadata"`
-	}
+func parseCFTemplate(template string) (*CFManifest, error) {
+	var parsedTemplate CFManifest
 	err := yaml.Unmarshal([]byte(template), &parsedTemplate)
 	if err != nil {
 		return nil, err
 	}
-	return parsedTemplate.Metadata.Tags, nil
+	return &parsedTemplate, nil
+}
+
+func tagsFromStackTemplate(template string) (map[string]string, error) {
+	parsedStack, err := parseCFTemplate(template)
+	if err != nil {
+		return nil, err
+	}
+	return parsedStack.Metadata.Tags, nil
+}
+
+type CFManifest struct {
+	Metadata struct {
+		StackName string            `yaml:"StackName"`
+		Tags      map[string]string `yaml:"Tags"`
+	} `yaml:"Metadata"`
+	Template string
+	Path     string
+}
+
+func (a *awsAdapter) applyCFManifest(ctx context.Context, cfManifest *CFManifest, clusterID string, s3BucketName string) error {
+	var templateURL string
+	if len(cfManifest.Template) > stackMaxSize {
+		pathHash := fmt.Sprintf("%x", sha256.Sum256([]byte(cfManifest.Path)))
+
+		// Upload the stack template to S3
+		result, err := a.s3Uploader.UploadObject(ctx, &transfermanager.UploadObjectInput{
+			Bucket: aws.String(s3BucketName),
+			Key:    aws.String(fmt.Sprintf("%s.template", pathHash)),
+			Body:   strings.NewReader(cfManifest.Template),
+		})
+		if err != nil {
+			return err
+		}
+		templateURL = aws.ToString(result.Location)
+	}
+
+	stackTags := map[string]string{
+		tagNameKubernetesClusterPrefix + clusterID: resourceLifecycleOwned,
+	}
+
+	return a.applyStack(ctx, cfManifest.Metadata.StackName, cfManifest.Template, templateURL, stackTags, true, nil)
 }
 
 // applyStack applies a cloudformation stack.

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -347,6 +347,11 @@ func (p *clusterpyProvisioner) provision(
 		return err
 	}
 
+	err = applyCFManifests(ctx, awsAdapter, channelConfig, cluster, values, bucketName)
+	if err != nil {
+		return err
+	}
+
 	// TODO: having it this late means late feedback on invalid manifests
 	manifests, err := renderManifests(
 		channelConfig,
@@ -543,6 +548,42 @@ func createOrUpdateEtcdStack(
 	err = adapter.waitForStack(ctx, waitTime, etcdStackName)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func applyCFManifests(ctx context.Context, adapter *awsAdapter, config channel.Config, cluster *api.Cluster, values map[string]any, bucketName string) error {
+	manifests, err := config.CFManifests()
+	if err != nil {
+		return err
+	}
+
+	for _, manifest := range manifests {
+		rendered, err := renderSingleTemplate(manifest, cluster, nil, values, adapter, nil)
+		if err != nil {
+			return fmt.Errorf("failed to render manifest %s: %w", manifest.Path, err)
+		}
+
+		cfManifest, err := parseCFTemplate(rendered)
+		if err != nil {
+			return fmt.Errorf("failed to parse stack for manifest %s: %w", manifest.Path, err)
+		}
+
+		cfManifest.Template = rendered
+		cfManifest.Path = manifest.Path
+
+		err = adapter.applyCFManifest(ctx, cfManifest, cluster.Name(), bucketName)
+		if err != nil {
+			return fmt.Errorf("failed to apply stack for manifest %s: %w", manifest.Path, err)
+		}
+
+		ctx, cancel := context.WithTimeout(ctx, maxWaitTimeout)
+		defer cancel()
+		err = adapter.waitForStack(ctx, waitTime, cfManifest.Metadata.StackName)
+		if err != nil {
+			return fmt.Errorf("failed to wait for stack for manifest %s: %w", manifest.Path, err)
+		}
 	}
 
 	return nil

--- a/provisioner/clusterpy_test.go
+++ b/provisioner/clusterpy_test.go
@@ -292,6 +292,10 @@ func (c *mockConfig) EtcdManifest(_ string) (channel.Manifest, error) {
 	return channel.Manifest{}, errors.New("unsupported: EtcdManifest")
 }
 
+func (c *mockConfig) CFManifests() ([]channel.Manifest, error) {
+	return nil, errors.New("unsupported: CFManifests")
+}
+
 func (c *mockConfig) NodePoolManifest(_ string, _ string) (channel.Manifest, error) {
 	return channel.Manifest{}, errors.New("unsupported: NodePoolManifest")
 }


### PR DESCRIPTION
This adds very basic support for custom CF stacks to enable deploying resources outside of the "main" manifest repository that need some AWS resources like IAM roles or S3 buckets.

### How it works:

The manifest repo can now define a new folder `cluster/cf-manifests` which is a flat folder with an optional list of CloudFormation Manifests in the same format as for e.g. the cluster.yaml stack:

```yaml
Metadata:
  StackName: "custom-stack"
  Tags:
    application: "custom-application"

Resources:
...
```

The manifests defined in that folder are applied _after_ the cluster.yaml stack, but before any Kubernetes manifests (from `cluster/manifests` folder). The manifests are applied in lexicographical order, there is _no_ support for dependencies between the stacks.

Multiple config-sources can define stacks like this, they are just merged into a slice and applied one by one.

On cluster decommissioning the stacks are cleaned up in the reverse order e.g. before the `cluster.yaml` stack. The cleanup is out of the box because the stacks will be tagged with the cluster ID.