### PR TITLE
Add SiblingCluster method

### DIFF
--- a/api/cluster.go
+++ b/api/cluster.go
@@ -318,6 +318,29 @@ func policyStatements(workerRole string, identityProvider string, subjectKey str
 	}
 }
 
+// SiblingCluster returns the sibling cluster of the given cluster, or nil if
+// none exists. A sibling cluster is defined as another ready cluster in the
+// same account and region. If there are more than two clusters in the account
+// and region, the oldest sibling is returned.
+func (cluster Cluster) SiblingCluster() *Cluster {
+	var sibling *Cluster
+	for _, c := range cluster.AccountClusters {
+		if c.ID == cluster.ID {
+			continue
+		}
+		if c.Region != cluster.Region {
+			continue
+		}
+		if c.LifecycleStatus != models.ClusterLifecycleStatusReady {
+			continue
+		}
+		if sibling == nil || c.CreatedAt.Before(sibling.CreatedAt) {
+			sibling = c
+		}
+	}
+	return sibling
+}
+
 // IsOldestReadyClusterInTheRegion returns true if the cluster is the oldest ready cluster in its account and region.
 // It assumes that AccountClusters is sorted by creation time.
 // If there are no other clusters, the cluster is considered the oldest ready cluster by default.

--- a/api/cluster_test.go
+++ b/api/cluster_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/sirupsen/logrus"
@@ -333,4 +334,112 @@ func TestIsOldestReadyClusterPerRegion(t *testing.T) {
 	assert.True(t, clusters[0].IsOldestReadyClusterInTheRegion())
 	assert.True(t, clusters[1].IsOldestReadyClusterInTheRegion())
 	assert.False(t, clusters[2].IsOldestReadyClusterInTheRegion())
+}
+
+func TestSiblingCluster(t *testing.T) {
+	t1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	for _, tc := range []struct {
+		name            string
+		cluster         Cluster
+		accountClusters []*Cluster
+		expectedID      string
+	}{
+		{
+			name: "no account clusters",
+			cluster: Cluster{
+				ID:     "cluster-1",
+				Region: "eu-central-1",
+			},
+			accountClusters: nil,
+			expectedID:      "",
+		},
+		{
+			name: "only self in account",
+			cluster: Cluster{
+				ID:     "cluster-1",
+				Region: "eu-central-1",
+			},
+			accountClusters: []*Cluster{
+				{ID: "cluster-1", Region: "eu-central-1", CreatedAt: t1},
+			},
+			expectedID: "",
+		},
+		{
+			name: "sibling in same region",
+			cluster: Cluster{
+				ID:     "cluster-1",
+				Region: "eu-central-1",
+			},
+			accountClusters: []*Cluster{
+				{ID: "cluster-1", Region: "eu-central-1", CreatedAt: t1},
+				{ID: "cluster-2", Region: "eu-central-1", CreatedAt: t2, LifecycleStatus: models.ClusterLifecycleStatusReady},
+			},
+			expectedID: "cluster-2",
+		},
+		{
+			name: "no sibling in different region",
+			cluster: Cluster{
+				ID:     "cluster-1",
+				Region: "eu-central-1",
+			},
+			accountClusters: []*Cluster{
+				{ID: "cluster-1", Region: "eu-central-1", CreatedAt: t1},
+				{ID: "cluster-2", Region: "eu-west-1", CreatedAt: t2},
+			},
+			expectedID: "",
+		},
+		{
+			name: "oldest sibling wins with three clusters",
+			cluster: Cluster{
+				ID:     "cluster-3",
+				Region: "eu-central-1",
+			},
+			accountClusters: []*Cluster{
+				{ID: "cluster-1", Region: "eu-central-1", CreatedAt: t1, LifecycleStatus: models.ClusterLifecycleStatusReady},
+				{ID: "cluster-2", Region: "eu-central-1", CreatedAt: t2, LifecycleStatus: models.ClusterLifecycleStatusReady},
+				{ID: "cluster-3", Region: "eu-central-1", CreatedAt: t3},
+			},
+			expectedID: "cluster-1",
+		},
+		{
+			name: "oldest sibling wins ignoring other regions",
+			cluster: Cluster{
+				ID:     "cluster-1",
+				Region: "eu-central-1",
+			},
+			accountClusters: []*Cluster{
+				{ID: "cluster-1", Region: "eu-central-1", CreatedAt: t2},
+				{ID: "cluster-2", Region: "eu-west-1", CreatedAt: t1, LifecycleStatus: models.ClusterLifecycleStatusReady},
+				{ID: "cluster-3", Region: "eu-central-1", CreatedAt: t3, LifecycleStatus: models.ClusterLifecycleStatusReady},
+			},
+			expectedID: "cluster-3",
+		},
+		{
+			name: "ignores non-ready clusters",
+			cluster: Cluster{
+				ID:     "cluster-1",
+				Region: "eu-central-1",
+			},
+			accountClusters: []*Cluster{
+				{ID: "cluster-1", Region: "eu-central-1", CreatedAt: t2},
+				{ID: "cluster-2", Region: "eu-central-1", CreatedAt: t1, LifecycleStatus: models.ClusterLifecycleStatusDecommissioned},
+				{ID: "cluster-3", Region: "eu-central-1", CreatedAt: t3, LifecycleStatus: models.ClusterLifecycleStatusReady},
+			},
+			expectedID: "cluster-3",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.cluster.AccountClusters = tc.accountClusters
+			sibling := tc.cluster.SiblingCluster()
+			if tc.expectedID == "" {
+				assert.Nil(t, sibling)
+			} else {
+				require.NotNil(t, sibling)
+				assert.Equal(t, tc.expectedID, sibling.ID)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This adds a method to the *Cluster type called `SiblingCluster` which returns nil or the SiblingCluster. Sibling cluster is defined as a ready cluster in the same region and account. If an account have more than 2 clusters in the same region, the oldest _other_ cluster is defined as the Sibling.

The purpose of this feature is to allow cross references in templates for migration purpose. A concrete example is postgres migration from non-EKS to EKS which has the following bucket policy requirement.

```yaml
{{- if ne .Cluster.SiblingCluster() nil }}
PostgreS3BucketEKSPolicy:
  Type: AWS::S3::BucketPolicy
  Properties:
    Bucket: !Ref PostgreS3Bucket
    PolicyDocument:
      Version: 2012-10-17
      Statement:
        - Effect: "Allow"
          Principal:
            AWS: "arn:aws:iam::{{{AWS_ACCOUNT_ID}}}:role/postgres-pod-role-{{ .Cluster.SiblingCluster().LocalID }}"
          Action:
            - "s3:ListBucket"
          Resource:
            - "arn:aws:s3:::{{{WAL_S3_BUCKET}}}"
        - Effect: "Allow"
          Principal:
            AWS: "arn:aws:iam::{{{AWS_ACCOUNT_ID}}}:role/postgres-pod-role-{{ .Cluster.SiblingCluster().LocalID }}"
          Action:
            - "s3:GetObject"
          Resource:
            - "arn:aws:s3:::{{{WAL_S3_BUCKET}}}/*"
{{- end }}
```