### PR TITLE
LLM generated render command

### DIFF
--- a/cmd/clm/main.go
+++ b/cmd/clm/main.go
@@ -31,6 +31,7 @@ import (
 var (
 	provisionCmd    = kingpin.Command("provision", "Provision a cluster.")
 	decommissionCmd = kingpin.Command("decommission", "Decommission a cluster.")
+	renderCmd       = kingpin.Command("render", "Render and print manifests that would be applied.")
 	controllerCmd   = kingpin.Command("controller", "Run controller loop.")
 	version         = "unknown"
 )
@@ -205,6 +206,14 @@ func main() {
 			continue
 		}
 
+		if cmd == renderCmd.FullCommand() {
+			switch cluster.LifecycleStatus {
+			case "requested", "creating", "decommission-requested", "decommissioned":
+				log.Debugf("Skipping %s cluster with status %q", cluster.ID, cluster.LifecycleStatus)
+				continue
+			}
+		}
+
 		err := configSource.Update(context.Background(), rootLogger)
 		if err != nil {
 			log.Fatalf("%+v", err)
@@ -225,17 +234,24 @@ func main() {
 			log.Fatalf("%+v", err)
 		}
 
-		for key, value := range cluster.ConfigItems {
-			decryptedValue, err := secretDecrypter.Decrypt(ctx, value)
-			if err != nil {
-				log.Fatalf("%+v", err)
-			}
+		shouldDecrypt := !(cmd == renderCmd.FullCommand() && cfg.SkipDecrypt)
+		if shouldDecrypt {
+			for key, value := range cluster.ConfigItems {
+				decryptedValue, err := secretDecrypter.Decrypt(ctx, value)
+				if err != nil {
+					log.Fatalf("%+v", err)
+				}
 
-			cluster.ConfigItems[key] = decryptedValue
+				cluster.ConfigItems[key] = decryptedValue
+			}
 		}
 
 		p, ok := provisioners[cluster.Provider]
 		if !ok {
+			if cmd == renderCmd.FullCommand() {
+				log.Debugf("Skipping cluster %s, unsupported provider %q", cluster.ID, cluster.Provider)
+				continue
+			}
 			log.Fatalf(
 				"Cluster %s: unknown provider %q",
 				cluster.ID,
@@ -263,6 +279,22 @@ func main() {
 				log.Fatalf("Fail to decommission: %v", err)
 			}
 			log.Infof("Decommissioning done for cluster %s", cluster.ID)
+		case renderCmd.FullCommand():
+			if cfg.ClusterAlias != "" && cluster.Alias != cfg.ClusterAlias {
+				log.Debugf("Skipping cluster %s (alias: %s), not matching filter %s", cluster.ID, cluster.Alias, cfg.ClusterAlias)
+				continue
+			}
+			err = p.Render(
+				context.Background(),
+				rootLogger,
+				cluster,
+				config,
+				cfg.ResourceName,
+				cfg.Application,
+			)
+			if err != nil {
+				log.Fatalf("Fail to render: %v", err)
+			}
 		default:
 			log.Fatalf("unknown cmd: %s", cmd)
 		}

--- a/cmd/clm/main.go
+++ b/cmd/clm/main.go
@@ -234,7 +234,7 @@ func main() {
 			log.Fatalf("%+v", err)
 		}
 
-		shouldDecrypt := !(cmd == renderCmd.FullCommand() && cfg.SkipDecrypt)
+		shouldDecrypt := cmd != renderCmd.FullCommand() || !cfg.SkipDecrypt
 		if shouldDecrypt {
 			for key, value := range cluster.ConfigItems {
 				decryptedValue, err := secretDecrypter.Decrypt(ctx, value)

--- a/config/config.go
+++ b/config/config.go
@@ -59,6 +59,10 @@ type LifecycleManagerConfig struct {
 	UpdateStrategy              UpdateStrategy
 	RemoveVolumes               bool
 	ManageEtcdStack             bool
+	ClusterAlias                string
+	ResourceName                string
+	Application                 string
+	SkipDecrypt                 bool
 }
 
 // UpdateStrategy defines the default update strategy configured for the
@@ -113,5 +117,9 @@ func (cfg *LifecycleManagerConfig) ParseFlags() string {
 	kingpin.Flag("remove-volumes", "Remove EBS volumes when decommissioning.").BoolVar(&cfg.RemoveVolumes)
 	kingpin.Flag("concurrent-external-processes", "Number of external processes allowed to run in parallel").Default(defaultConcurrentExternalProcesses).UintVar(&cfg.ConcurrentExternalProcesses)
 	kingpin.Flag("manage-etcd-stack", "Enable creation/updates of the etcd stack (should be disabled for pet clusters)").BoolVar(&cfg.ManageEtcdStack)
+	kingpin.Flag("cluster-alias", "Filter rendered output by cluster alias (used with render command)").StringVar(&cfg.ClusterAlias)
+	kingpin.Flag("resource-name", "Filter rendered resources by metadata.name or CF stack name (used with render command)").StringVar(&cfg.ResourceName)
+	kingpin.Flag("application", "Filter rendered resources by application label (K8s) or tag (CF) (used with render command)").StringVar(&cfg.Application)
+	kingpin.Flag("skip-decrypt", "Skip decryption of config items (useful when KMS is in a different account)").BoolVar(&cfg.SkipDecrypt)
 	return kingpin.Parse()
 }

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -44,6 +44,10 @@ func (p *mockProvisioner) Decommission(_ context.Context, _ *log.Entry, _ *api.C
 	return nil
 }
 
+func (p *mockProvisioner) Render(_ context.Context, _ *log.Entry, _ *api.Cluster, _ channel.Config, _ string, _ string) error {
+	return nil
+}
+
 type mockErrProvisioner mockProvisioner
 
 func (p *mockErrProvisioner) Supports(_ *api.Cluster) bool {
@@ -61,6 +65,10 @@ func (p *mockErrProvisioner) Provision(
 
 func (p *mockErrProvisioner) Decommission(_ context.Context, _ *log.Entry, _ *api.Cluster) error {
 	return fmt.Errorf("failed to decommission")
+}
+
+func (p *mockErrProvisioner) Render(_ context.Context, _ *log.Entry, _ *api.Cluster, _ channel.Config, _ string, _ string) error {
+	return fmt.Errorf("failed to render")
 }
 
 type mockErrCreateProvisioner struct{ *mockProvisioner }

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -158,6 +158,112 @@ func (p *clusterpyProvisioner) propagateConfigItemsToNodePools(cluster *api.Clus
 	}
 }
 
+func (p *clusterpyProvisioner) buildTemplateValues(
+	ctx context.Context,
+	awsAdapter *awsAdapter,
+	cluster *api.Cluster,
+) (map[string]interface{}, error) {
+	// get VPC information
+	var vpc *ec2types.Vpc
+	vpcID, ok := cluster.ConfigItems[vpcIDConfigItemKey]
+	if !ok { // if vpcID is not defined, autodiscover it
+		var err error
+		vpc, err = awsAdapter.GetDefaultVPC(ctx)
+		if err != nil {
+			return nil, err
+		}
+		vpcID = aws.ToString(vpc.VpcId)
+		cluster.ConfigItems[vpcIDConfigItemKey] = vpcID
+	} else {
+		var err error
+		vpc, err = awsAdapter.GetVPC(ctx, vpcID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	subnets, err := awsAdapter.GetSubnets(ctx, vpcID)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	subnets = filterSubnets(subnets, subnetNot(isCustomSubnet))
+
+	// if subnets are defined in the config items, filter the subnet list
+	if subnetIDs, ok := cluster.ConfigItems[subnetsConfigItemKey]; ok {
+		ids := strings.Split(subnetIDs, ",")
+		subnets = filterSubnets(subnets, subnetIDIncluded(ids))
+		if len(subnets) != len(ids) {
+			return nil, fmt.Errorf("invalid or unknown subnets; desired %v", ids)
+		}
+	}
+
+	// find the best subnet for each AZ
+	azInfoLBs := selectSubnetIDs(subnets, subnetELBRoleTagName)
+	azInfoNodes := selectSubnetIDs(subnets, subnetNodeRoleTagName)
+	azInfoIntenalNodes := selectSubnetIDs(subnets, subnetInternalNodeRoleTagName)
+	azInfoPods := selectSubnetIDs(subnets, subnetPodRoleTagName)
+
+	// if availability zones are defined, filter the subnet list
+	if azNames, ok := cluster.ConfigItems[availabilityZonesConfigItemKey]; ok {
+		azInfoLBs = azInfoLBs.RestrictAZs(strings.Split(azNames, ","))
+		azInfoNodes = azInfoNodes.RestrictAZs(strings.Split(azNames, ","))
+		azInfoIntenalNodes = azInfoIntenalNodes.RestrictAZs(strings.Split(azNames, ","))
+	}
+
+	// optional config item to hard-code subnets. This is useful for
+	// migrating between subnets.
+	if _, ok := cluster.ConfigItems[subnetsConfigItemKey]; !ok {
+		cluster.ConfigItems[subnetsConfigItemKey] = azInfoNodes.SubnetsByAZ()[subnetAllAZName]
+	}
+
+	apiURL, err := url.Parse(cluster.APIServerURL)
+	if err != nil {
+		return nil, err
+	}
+
+	hostedZone, err := util.GetHostedZone(cluster.APIServerURL)
+	if err != nil {
+		return nil, err
+	}
+
+	certificates, err := awsAdapter.GetCertificates(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	loadBalancerCert, err := certs.FindBestMatchingCertificate(certificates, apiURL.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	vpcIPv6CIDRs := make([]string, 0, len(vpc.Ipv6CidrBlockAssociationSet))
+	for _, ipv6Cidr := range vpc.Ipv6CidrBlockAssociationSet {
+		vpcIPv6CIDRs = append(vpcIPv6CIDRs, aws.ToString(ipv6Cidr.Ipv6CidrBlock))
+	}
+
+	return map[string]interface{}{
+		subnetsValueKey:             azInfoNodes.SubnetsByAZ(),
+		availabilityZonesValueKey:   azInfoNodes.AvailabilityZones(),
+		subnetIPV6CIDRsKey:          strings.Join(azInfoNodes.SubnetIPv6CIDRs(), ","),
+		"lb_subnets":                azInfoLBs.SubnetsByAZ(),
+		"internal_node_subnets":     azInfoIntenalNodes.SubnetsByAZ(),
+		"pod_subnets":               azInfoPods.SubnetsByAZ(),
+		"hosted_zone":               hostedZone,
+		"load_balancer_certificate": loadBalancerCert.ID(),
+		"vpc_ipv4_cidr":             aws.ToString(vpc.CidrBlock),
+		"vpc_ipv6_cidrs":            vpcIPv6CIDRs,
+	}, nil
+}
+
 func (p *clusterpyProvisioner) provision(
 	ctx context.Context,
 	logger *log.Entry,
@@ -183,103 +289,21 @@ func (p *clusterpyProvisioner) provision(
 		return err
 	}
 
-	// get VPC information
-	var vpc *ec2types.Vpc
-	vpcID, ok := cluster.ConfigItems[vpcIDConfigItemKey]
-	if !ok { // if vpcID is not defined, autodiscover it
-		vpc, err = awsAdapter.GetDefaultVPC(ctx)
-		if err != nil {
-			return err
-		}
-		vpcID = aws.ToString(vpc.VpcId)
-		cluster.ConfigItems[vpcIDConfigItemKey] = vpcID
-	} else {
-		vpc, err = awsAdapter.GetVPC(ctx, vpcID)
-		if err != nil {
-			return err
-		}
-	}
-
-	if err = ctx.Err(); err != nil {
+	values, err := p.buildTemplateValues(ctx, awsAdapter, cluster)
+	if err != nil {
 		return err
 	}
 
+	// get azInfoNodes for later use in node provisioning
+	vpcID := cluster.ConfigItems[vpcIDConfigItemKey]
 	subnets, err := awsAdapter.GetSubnets(ctx, vpcID)
 	if err != nil {
 		return err
 	}
-
-	if err = ctx.Err(); err != nil {
-		return err
-	}
-
 	subnets = filterSubnets(subnets, subnetNot(isCustomSubnet))
-
-	// if subnets are defined in the config items, filter the subnet list
-	if subnetIDs, ok := cluster.ConfigItems[subnetsConfigItemKey]; ok {
-		ids := strings.Split(subnetIDs, ",")
-		subnets = filterSubnets(subnets, subnetIDIncluded(ids))
-		if len(subnets) != len(ids) {
-			return fmt.Errorf("invalid or unknown subnets; desired %v", ids)
-		}
-	}
-
-	// find the best subnet for each AZ
-	azInfoLBs := selectSubnetIDs(subnets, subnetELBRoleTagName)
 	azInfoNodes := selectSubnetIDs(subnets, subnetNodeRoleTagName)
-	azInfoIntenalNodes := selectSubnetIDs(subnets, subnetInternalNodeRoleTagName)
-	azInfoPods := selectSubnetIDs(subnets, subnetPodRoleTagName)
-
-	// if availability zones are defined, filter the subnet list
 	if azNames, ok := cluster.ConfigItems[availabilityZonesConfigItemKey]; ok {
-		azInfoLBs = azInfoLBs.RestrictAZs(strings.Split(azNames, ","))
 		azInfoNodes = azInfoNodes.RestrictAZs(strings.Split(azNames, ","))
-		azInfoIntenalNodes = azInfoIntenalNodes.RestrictAZs(strings.Split(azNames, ","))
-	}
-
-	// optional config item to hard-code subnets. This is useful for
-	// migrating between subnets.
-	if _, ok := cluster.ConfigItems[subnetsConfigItemKey]; !ok {
-		cluster.ConfigItems[subnetsConfigItemKey] = azInfoNodes.SubnetsByAZ()[subnetAllAZName]
-	}
-
-	apiURL, err := url.Parse(cluster.APIServerURL)
-	if err != nil {
-		return err
-	}
-
-	// TODO: should this be done like this or via a config item?
-	hostedZone, err := util.GetHostedZone(cluster.APIServerURL)
-	if err != nil {
-		return err
-	}
-
-	certificates, err := awsAdapter.GetCertificates(ctx)
-	if err != nil {
-		return err
-	}
-
-	loadBalancerCert, err := certs.FindBestMatchingCertificate(certificates, apiURL.Host)
-	if err != nil {
-		return err
-	}
-
-	vpcIPv6CIDRs := make([]string, 0, len(vpc.Ipv6CidrBlockAssociationSet))
-	for _, ipv6Cidr := range vpc.Ipv6CidrBlockAssociationSet {
-		vpcIPv6CIDRs = append(vpcIPv6CIDRs, aws.ToString(ipv6Cidr.Ipv6CidrBlock))
-	}
-
-	values := map[string]interface{}{
-		subnetsValueKey:             azInfoNodes.SubnetsByAZ(),
-		availabilityZonesValueKey:   azInfoNodes.AvailabilityZones(),
-		subnetIPV6CIDRsKey:          strings.Join(azInfoNodes.SubnetIPv6CIDRs(), ","),
-		"lb_subnets":                azInfoLBs.SubnetsByAZ(),
-		"internal_node_subnets":     azInfoIntenalNodes.SubnetsByAZ(),
-		"pod_subnets":               azInfoPods.SubnetsByAZ(),
-		"hosted_zone":               hostedZone,
-		"load_balancer_certificate": loadBalancerCert.ID(),
-		"vpc_ipv4_cidr":             aws.ToString(vpc.CidrBlock),
-		"vpc_ipv6_cidrs":            vpcIPv6CIDRs,
 	}
 
 	// render the manifests to find out if they're valid
@@ -923,14 +947,27 @@ func (p *clusterpyProvisioner) applyDefaultsToManifests(
 	channelConfig channel.Config,
 	instanceTypes *awsUtils.InstanceTypes,
 ) error {
+	return p.applyDefaultsToManifestsWithOptions(ctx, adapter, cluster, channelConfig, instanceTypes, false)
+}
+
+func (p *clusterpyProvisioner) applyDefaultsToManifestsWithOptions(
+	ctx context.Context,
+	adapter *awsAdapter,
+	cluster *api.Cluster,
+	channelConfig channel.Config,
+	instanceTypes *awsUtils.InstanceTypes,
+	skipDecrypt bool,
+) error {
 	err := p.updateDefaults(cluster, channelConfig, adapter, instanceTypes)
 	if err != nil {
 		return fmt.Errorf("unable to read configuration defaults: %v", err)
 	}
 
-	err = p.decryptConfigItems(ctx, cluster)
-	if err != nil {
-		return fmt.Errorf("unable to decrypt config items: %v", err)
+	if !skipDecrypt {
+		err = p.decryptConfigItems(ctx, cluster)
+		if err != nil {
+			return fmt.Errorf("unable to decrypt config items: %v", err)
+		}
 	}
 
 	p.propagateConfigItemsToNodePools(cluster)
@@ -1372,6 +1409,185 @@ func (p *clusterpyProvisioner) apply(
 	)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (p *clusterpyProvisioner) renderManifests(
+	ctx context.Context,
+	logger *log.Entry,
+	awsAdapter *awsAdapter,
+	cluster *api.Cluster,
+	channelConfig channel.Config,
+	resourceNameFilter string,
+	applicationFilter string,
+) error {
+	instanceTypes, err := awsUtils.NewInstanceTypesFromAWS(ctx, awsAdapter.ec2Client)
+	if err != nil {
+		return fmt.Errorf("failed to fetch instance types from AWS")
+	}
+
+	err = p.applyDefaultsToManifestsWithOptions(
+		ctx,
+		awsAdapter,
+		cluster,
+		channelConfig,
+		instanceTypes,
+		true,
+	)
+	if err != nil {
+		return err
+	}
+
+	err = p.populateMissingConfigItems(ctx, awsAdapter, cluster)
+	if err != nil {
+		return err
+	}
+
+	values, err := p.buildTemplateValues(ctx, awsAdapter, cluster)
+	if err != nil {
+		return err
+	}
+
+	err = p.renderCFManifests(ctx, logger, channelConfig, cluster, values, awsAdapter, resourceNameFilter, applicationFilter)
+	if err != nil {
+		return err
+	}
+
+	renderedManifests, err := renderManifests(channelConfig, cluster, values, awsAdapter, instanceTypes)
+	if err != nil {
+		return fmt.Errorf("failed to render manifests: %w", err)
+	}
+
+	err = p.outputManifests(logger, renderedManifests, resourceNameFilter, applicationFilter, true)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *clusterpyProvisioner) outputManifests(
+	logger *log.Entry,
+	renderedManifests []manifestPackage,
+	resourceNameFilter string,
+	applicationFilter string,
+	separateFromCF bool,
+) error {
+	first := true
+	needsSeparator := separateFromCF
+
+	for _, module := range renderedManifests {
+		for _, manifest := range module.manifests {
+			if resourceNameFilter != "" && manifest.Name != resourceNameFilter {
+				continue
+			}
+
+			if applicationFilter != "" {
+				var meta struct {
+					Metadata struct {
+						Labels map[string]string `yaml:"labels"`
+					} `yaml:"metadata"`
+				}
+				yamlStr, _ := manifest.ToYaml()
+				err := yaml.Unmarshal([]byte(yamlStr), &meta)
+				if err != nil || meta.Metadata.Labels["application"] != applicationFilter {
+					continue
+				}
+			}
+
+			if needsSeparator {
+				fmt.Println("---")
+				needsSeparator = false
+			} else if !first {
+				fmt.Println("---")
+			}
+			first = false
+
+			yaml, err := manifest.ToYaml()
+			if err != nil {
+				return fmt.Errorf("failed to convert manifest to yaml: %w", err)
+			}
+
+			fmt.Print(yaml)
+			if !strings.HasSuffix(yaml, "\n") {
+				fmt.Println()
+			}
+		}
+	}
+
+	return nil
+}
+
+func (p *clusterpyProvisioner) populateMissingConfigItems(ctx context.Context, adapter *awsAdapter, cluster *api.Cluster) error {
+	vpcID, ok := cluster.ConfigItems[vpcIDConfigItemKey]
+	if !ok {
+		vpc, err := adapter.GetDefaultVPC(ctx)
+		if err != nil {
+			return err
+		}
+		vpcID = aws.ToString(vpc.VpcId)
+		cluster.ConfigItems[vpcIDConfigItemKey] = vpcID
+	}
+	return nil
+}
+
+func (p *clusterpyProvisioner) renderCFManifests(
+	ctx context.Context,
+	logger *log.Entry,
+	config channel.Config,
+	cluster *api.Cluster,
+	values map[string]interface{},
+	adapter *awsAdapter,
+	resourceNameFilter string,
+	applicationFilter string,
+) error {
+	manifests, err := config.CFManifests()
+	if err != nil {
+		return err
+	}
+
+	if len(manifests) == 0 {
+		return nil
+	}
+
+	first := true
+	for _, manifest := range manifests {
+		rendered, err := renderSingleTemplate(manifest, cluster, nil, values, adapter, nil)
+		if err != nil {
+			return fmt.Errorf("failed to render CF manifest %s: %w", manifest.Path, err)
+		}
+
+		remarshaled, err := remarshalYAML(rendered)
+		if err != nil {
+			return fmt.Errorf("failed to remarshal CF manifest %s: %w", manifest.Path, err)
+		}
+
+		if remarshaled == "" {
+			logger.Debugf("Skipping empty CloudFormation manifest: %s", manifest.Path)
+			continue
+		}
+
+		cfManifest, err := parseCFTemplate(remarshaled)
+		if err != nil {
+			return fmt.Errorf("failed to parse CF manifest %s: %w", manifest.Path, err)
+		}
+
+		if resourceNameFilter != "" && cfManifest.Metadata.StackName != resourceNameFilter {
+			continue
+		}
+
+		if applicationFilter != "" && cfManifest.Metadata.Tags["application"] != applicationFilter {
+			continue
+		}
+
+		if !first {
+			fmt.Println("---")
+		}
+		first = false
+
+		fmt.Println(remarshaled)
 	}
 
 	return nil

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -1450,7 +1450,7 @@ func (p *clusterpyProvisioner) renderManifests(
 		return err
 	}
 
-	err = p.renderCFManifests(ctx, logger, channelConfig, cluster, values, awsAdapter, resourceNameFilter, applicationFilter)
+	err = p.renderCFManifests(logger, channelConfig, cluster, values, awsAdapter, resourceNameFilter, applicationFilter)
 	if err != nil {
 		return err
 	}
@@ -1460,7 +1460,7 @@ func (p *clusterpyProvisioner) renderManifests(
 		return fmt.Errorf("failed to render manifests: %w", err)
 	}
 
-	err = p.outputManifests(logger, renderedManifests, resourceNameFilter, applicationFilter, true)
+	err = p.outputManifests(renderedManifests, resourceNameFilter, applicationFilter, true)
 	if err != nil {
 		return err
 	}
@@ -1469,7 +1469,6 @@ func (p *clusterpyProvisioner) renderManifests(
 }
 
 func (p *clusterpyProvisioner) outputManifests(
-	logger *log.Entry,
 	renderedManifests []manifestPackage,
 	resourceNameFilter string,
 	applicationFilter string,
@@ -1521,20 +1520,18 @@ func (p *clusterpyProvisioner) outputManifests(
 }
 
 func (p *clusterpyProvisioner) populateMissingConfigItems(ctx context.Context, adapter *awsAdapter, cluster *api.Cluster) error {
-	vpcID, ok := cluster.ConfigItems[vpcIDConfigItemKey]
-	if !ok {
+	if _, ok := cluster.ConfigItems[vpcIDConfigItemKey]; !ok {
 		vpc, err := adapter.GetDefaultVPC(ctx)
 		if err != nil {
 			return err
 		}
-		vpcID = aws.ToString(vpc.VpcId)
+		vpcID := aws.ToString(vpc.VpcId)
 		cluster.ConfigItems[vpcIDConfigItemKey] = vpcID
 	}
 	return nil
 }
 
 func (p *clusterpyProvisioner) renderCFManifests(
-	ctx context.Context,
 	logger *log.Entry,
 	config channel.Config,
 	cluster *api.Cluster,

--- a/provisioner/provisioner.go
+++ b/provisioner/provisioner.go
@@ -28,6 +28,15 @@ type (
 			logger *log.Entry,
 			cluster *api.Cluster,
 		) error
+
+		Render(
+			ctx context.Context,
+			logger *log.Entry,
+			cluster *api.Cluster,
+			channelConfig channel.Config,
+			resourceNameFilter string,
+			applicationFilter string,
+		) error
 	}
 
 	// CreationHook is an interface that provisioners can use while provisioning

--- a/provisioner/stdout.go
+++ b/provisioner/stdout.go
@@ -38,3 +38,10 @@ func (p *stdoutProvisioner) Decommission(_ context.Context, logger *log.Entry, c
 
 	return nil
 }
+
+// Render mocks rendering manifests for a cluster.
+func (p *stdoutProvisioner) Render(_ context.Context, logger *log.Entry, cluster *api.Cluster, _ channel.Config, _ string, _ string) error {
+	logger.Infof("stdout: Rendering manifests for cluster %s.", cluster.ID)
+
+	return nil
+}

--- a/provisioner/zalando_aws.go
+++ b/provisioner/zalando_aws.go
@@ -101,3 +101,23 @@ func (z *ZalandoAWSProvisioner) Decommission(
 
 	return z.decommission(ctx, logger, awsAdapter, z.tokenSource, cluster, nil)
 }
+
+func (z *ZalandoAWSProvisioner) Render(
+	ctx context.Context,
+	logger *log.Entry,
+	cluster *api.Cluster,
+	channelConfig channel.Config,
+	resourceNameFilter string,
+	applicationFilter string,
+) error {
+	if !z.Supports(cluster) {
+		return ErrProviderNotSupported
+	}
+
+	awsAdapter, err := z.setupAWSAdapter(ctx, logger, cluster)
+	if err != nil {
+		return fmt.Errorf("failed to setup AWS Adapter: %v", err)
+	}
+
+	return z.renderManifests(ctx, logger, awsAdapter, cluster, channelConfig, resourceNameFilter, applicationFilter)
+}

--- a/provisioner/zalando_eks.go
+++ b/provisioner/zalando_eks.go
@@ -156,6 +156,26 @@ func (z *ZalandoEKSProvisioner) Decommission(
 	)
 }
 
+func (z *ZalandoEKSProvisioner) Render(
+	ctx context.Context,
+	logger *log.Entry,
+	cluster *api.Cluster,
+	channelConfig channel.Config,
+	resourceNameFilter string,
+	applicationFilter string,
+) error {
+	if !z.Supports(cluster) {
+		return ErrProviderNotSupported
+	}
+
+	awsAdapter, err := z.setupAWSAdapter(ctx, logger, cluster)
+	if err != nil {
+		return fmt.Errorf("failed to setup AWS Adapter: %v", err)
+	}
+
+	return z.renderManifests(ctx, logger, awsAdapter, cluster, channelConfig, resourceNameFilter, applicationFilter)
+}
+
 // NewZalandoEKSCreationHook returns a new hook for EKS cluster provisioning,
 // configured to use the given cluster registry.
 func NewZalandoEKSCreationHook(


### PR DESCRIPTION
LLM generated render command

The main limitations are:
- added a flag to skip the decrypt since not everyone has access to the KMS key
- added a flag to pass the cluster alias since the current rendering require access to the aws account to get info about some resources (maybe we can think on making it static with config-items on cluster creation and not dynamic)
- added a flag to pass the application name to just output a set of manifests