### PR TITLE
add simple cf-deletions similar to the k8s resources deletions

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,13 +182,15 @@ The `cf-deletions.yaml` file inside the `cf-manifests` folder has the following 
 
 ```yaml
 pre_apply: # everything defined under here will be deleted before applying the manifests
-- stack-name-1
-- stack-name-2
+- stackName: stack-name-1
+- stackName: stack-name-2
 
 post_apply: # everything defined under here will be deleted after applying the manifests
-- stack-name-1
-- stack-name-2
+- stackName: stack-name-1
+- stackName: stack-name-2
 ```
+
+Each stack deletion is specified as an object with a `stackName` field. This structured format allows for future extensions, such as tag-based selection or other selection criteria.
 
 
 ## Configuration defaults

--- a/README.md
+++ b/README.md
@@ -122,7 +122,12 @@ clusters:
 
 By default the Cluster Lifecycle Manager will just apply any manifest defined
 in the manifests folder. In order to support deletion of deprecated resources
-the CLM will read a `deletions.yaml` file of the following format:
+the CLM will read a `deletions.yaml` file for the Kubernetes manifests and a
+`cf-deletions.yaml` for the Cloudformation stacks.
+
+### Kubernetes deletions
+
+The `deletions.yaml` file inside the `manifests` folder has the following format:
 
 ```yaml
 pre_apply: # everything defined under here will be deleted before applying the manifests
@@ -170,6 +175,21 @@ An optional boolean `has_owner` may be specified to narrow down resources identi
 It is possible to specify deletion options via optional:
 - `propagation_policy` - one of "Orphan", "Background" or "Foreground" - corresponds to `kubectl delete --cascade` flag
 - `grace_period_seconds` - corresponds to `kubectl delete --grace-period` flag
+
+### Cloudformation deletions
+
+The `cf-deletions.yaml` file inside the `cf-manifests` folder has the following format:
+
+```yaml
+pre_apply: # everything defined under here will be deleted before applying the manifests
+- stack-name-1
+- stack-name-2
+
+post_apply: # everything defined under here will be deleted after applying the manifests
+- stack-name-1
+- stack-name-2
+```
+
 
 ## Configuration defaults
 

--- a/channel/combined.go
+++ b/channel/combined.go
@@ -168,6 +168,18 @@ func (c *combinedConfig) DeletionsManifests() ([]Manifest, error) {
 	return result, nil
 }
 
+func (c *combinedConfig) CFDeletionsManifests() ([]Manifest, error) {
+	var result []Manifest
+	for i, config := range c.configs {
+		configs, err := config.CFDeletionsManifests()
+		if err != nil {
+			return nil, fmt.Errorf("unable to get CF deletions for source %s: %v", c.owner.sourceName(i), err)
+		}
+		result = append(result, configs...)
+	}
+	return result, nil
+}
+
 func (c *combinedConfig) Components() ([]Component, error) {
 	var result []Component
 

--- a/channel/config_source.go
+++ b/channel/config_source.go
@@ -45,6 +45,7 @@ type Config interface {
 	NodePoolManifest(profileName string, manifestName string) (Manifest, error)
 	DefaultsManifests() ([]Manifest, error)
 	DeletionsManifests() ([]Manifest, error)
+	CFDeletionsManifests() ([]Manifest, error)
 	Components() ([]Component, error)
 	Delete() error
 }

--- a/channel/simple_config.go
+++ b/channel/simple_config.go
@@ -15,6 +15,7 @@ const (
 	defaultsFile         = "config-defaults.yaml"
 	manifestsDir         = "manifests"
 	deletionsFile        = "deletions.yaml"
+	cfDeletionsFile      = "cf-deletions.yaml"
 )
 
 type SimpleConfig struct {
@@ -70,6 +71,11 @@ func (c *SimpleConfig) CFManifests() ([]Manifest, error) {
 		if !strings.HasSuffix(file.Name(), ".yaml") && !strings.HasSuffix(file.Name(), ".yml") {
 			continue
 		}
+
+		if file.Name() == cfDeletionsFile {
+			continue
+		}
+
 		manifest, err := c.readManifest(path.Join(configRoot, cfManifestsConfigDir), file.Name())
 		if err != nil {
 			return nil, err
@@ -102,6 +108,17 @@ func (c *SimpleConfig) DefaultsManifests() ([]Manifest, error) {
 
 func (c *SimpleConfig) DeletionsManifests() ([]Manifest, error) {
 	res, err := c.readManifest(path.Join(configRoot, manifestsDir), deletionsFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return []Manifest{res}, nil
+}
+
+func (c *SimpleConfig) CFDeletionsManifests() ([]Manifest, error) {
+	res, err := c.readManifest(path.Join(configRoot, cfManifestsConfigDir), cfDeletionsFile)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -209,6 +209,10 @@ func (c *mockConfig) DeletionsManifests() ([]channel.Manifest, error) {
 	return []channel.Manifest{c.mockManifest}, nil
 }
 
+func (c *mockConfig) CFDeletionsManifests() ([]channel.Manifest, error) {
+	return []channel.Manifest{c.mockManifest}, nil
+}
+
 func (c *mockConfig) Components() ([]channel.Component, error) {
 	return nil, nil
 }

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -1222,7 +1222,6 @@ type cfDeletions struct {
 // CFDeletions deletes the CloudFormation stacks from the account.
 func (p *clusterpyProvisioner) CFDeletions(
 	ctx context.Context,
-	logger *log.Entry,
 	adapter *awsAdapter,
 	deletions []*string,
 ) error {
@@ -1372,7 +1371,7 @@ func (p *clusterpyProvisioner) apply(
 	}
 
 	logger.Debugf("Running PreApply CF deletions (%d)", len(cfDeletions.PreApply))
-	err = p.CFDeletions(ctx, logger, adapter, cfDeletions.PreApply)
+	err = p.CFDeletions(ctx, adapter, cfDeletions.PreApply)
 	if err != nil {
 		return err
 	}
@@ -1445,7 +1444,7 @@ func (p *clusterpyProvisioner) apply(
 	}
 
 	logger.Debugf("Running PostApply CF deletions (%d)", len(cfDeletions.PostApply))
-	err = p.CFDeletions(ctx, logger, adapter, cfDeletions.PostApply)
+	err = p.CFDeletions(ctx, adapter, cfDeletions.PostApply)
 	if err != nil {
 		return err
 	}

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -1212,22 +1212,27 @@ func parseDeletions(config channel.Config, cluster *api.Cluster, values map[stri
 	return result, nil
 }
 
+// cfStackDeletion represents a CloudFormation stack to be deleted with optional selection criteria.
+type cfStackDeletion struct {
+	StackName string `yaml:"stackName"`
+}
+
 // cfDeletions defines two lists of CF stacks to be deleted. One before applying
 // all manifests and one after applying all manifests.
 type cfDeletions struct {
-	PreApply  []*string `yaml:"pre_apply"`
-	PostApply []*string `yaml:"post_apply"`
+	PreApply  []*cfStackDeletion `yaml:"pre_apply"`
+	PostApply []*cfStackDeletion `yaml:"post_apply"`
 }
 
 // CFDeletions deletes the CloudFormation stacks from the account.
 func (p *clusterpyProvisioner) CFDeletions(
 	ctx context.Context,
 	adapter *awsAdapter,
-	deletions []*string,
+	deletions []*cfStackDeletion,
 ) error {
 	for _, deletion := range deletions {
 		err := adapter.DeleteStack(ctx, &cftypes.Stack{
-			StackName: deletion,
+			StackName: &deletion.StackName,
 		})
 		if err != nil {
 			return err

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -282,8 +282,14 @@ func (p *clusterpyProvisioner) provision(
 		"vpc_ipv6_cidrs":            vpcIPv6CIDRs,
 	}
 
-	// render the manifests to find out if they're valid
+	// render the k8s deletions manifests to find out if they're valid
 	deletions, err := parseDeletions(channelConfig, cluster, values, awsAdapter, instanceTypes)
+	if err != nil {
+		return err
+	}
+
+	// render the cf deletions stacks to find out if they're valid
+	cfDeletions, err := parseCFDeletions(channelConfig, cluster, values, awsAdapter, instanceTypes)
 	if err != nil {
 		return err
 	}
@@ -439,7 +445,9 @@ func (p *clusterpyProvisioner) provision(
 		logger,
 		tokenSource,
 		cluster,
+		awsAdapter,
 		deletions,
+		cfDeletions,
 		manifests,
 		postOptions,
 	)
@@ -1204,6 +1212,60 @@ func parseDeletions(config channel.Config, cluster *api.Cluster, values map[stri
 	return result, nil
 }
 
+// cfDeletions defines two lists of CF stacks to be deleted. One before applying
+// all manifests and one after applying all manifests.
+type cfDeletions struct {
+	PreApply  []*string `yaml:"pre_apply"`
+	PostApply []*string `yaml:"post_apply"`
+}
+
+// CFDeletions deletes the CloudFormation stacks from the account.
+func (p *clusterpyProvisioner) CFDeletions(
+	ctx context.Context,
+	logger *log.Entry,
+	adapter *awsAdapter,
+	deletions []*string,
+) error {
+	for _, deletion := range deletions {
+		err := adapter.DeleteStack(ctx, &cftypes.Stack{
+			StackName: deletion,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// parseCFDeletions reads and parses the deletions from the config for cloudformation manifests.
+func parseCFDeletions(config channel.Config, cluster *api.Cluster, values map[string]interface{}, adapter *awsAdapter, instanceTypes *awsUtils.InstanceTypes) (*cfDeletions, error) {
+	result := &cfDeletions{}
+
+	deletionsFiles, err := config.CFDeletionsManifests()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, deletionsFile := range deletionsFiles {
+		res, err := renderSingleTemplate(deletionsFile, cluster, nil, values, adapter, instanceTypes)
+		if err != nil {
+			return nil, err
+		}
+
+		var cfDel cfDeletions
+		err = yaml.Unmarshal([]byte(res), &cfDel)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal deletions file %s: %w", deletionsFile.Path, err)
+		}
+
+		result.PreApply = append(result.PreApply, cfDel.PreApply...)
+		result.PostApply = append(result.PostApply, cfDel.PostApply...)
+	}
+
+	return result, nil
+}
+
 func remarshalYAML(contents string) (string, error) {
 	decoder := yaml.NewDecoder(strings.NewReader(contents))
 	result := &bytes.Buffer{}
@@ -1290,7 +1352,9 @@ func (p *clusterpyProvisioner) apply(
 	logger *log.Entry,
 	tokenSource oauth2.TokenSource,
 	cluster *api.Cluster,
+	adapter *awsAdapter,
 	deletions *deletions,
+	cfDeletions *cfDeletions,
 	renderedManifests []manifestPackage,
 	options *HookResponse,
 ) error {
@@ -1303,6 +1367,12 @@ func (p *clusterpyProvisioner) apply(
 		deletions.PreApply,
 		options,
 	)
+	if err != nil {
+		return err
+	}
+
+	logger.Debugf("Running PreApply CF deletions (%d)", len(cfDeletions.PreApply))
+	err = p.CFDeletions(ctx, logger, adapter, cfDeletions.PreApply)
 	if err != nil {
 		return err
 	}
@@ -1370,6 +1440,12 @@ func (p *clusterpyProvisioner) apply(
 		deletions.PostApply,
 		options,
 	)
+	if err != nil {
+		return err
+	}
+
+	logger.Debugf("Running PostApply CF deletions (%d)", len(cfDeletions.PostApply))
+	err = p.CFDeletions(ctx, logger, adapter, cfDeletions.PostApply)
 	if err != nil {
 		return err
 	}

--- a/provisioner/clusterpy_test.go
+++ b/provisioner/clusterpy_test.go
@@ -281,7 +281,7 @@ func TestLabelsString(t *testing.T) {
 }
 
 type mockConfig struct {
-	deletions []channel.Manifest
+	deletions   []channel.Manifest
 	cfDeletions []channel.Manifest
 }
 

--- a/provisioner/clusterpy_test.go
+++ b/provisioner/clusterpy_test.go
@@ -282,6 +282,7 @@ func TestLabelsString(t *testing.T) {
 
 type mockConfig struct {
 	deletions []channel.Manifest
+	cfDeletions []channel.Manifest
 }
 
 func (c *mockConfig) StackManifest(_ string) (channel.Manifest, error) {
@@ -306,6 +307,10 @@ func (c *mockConfig) DefaultsManifests() ([]channel.Manifest, error) {
 
 func (c *mockConfig) DeletionsManifests() ([]channel.Manifest, error) {
 	return c.deletions, nil
+}
+
+func (c *mockConfig) CFDeletionsManifests() ([]channel.Manifest, error) {
+	return c.cfDeletions, nil
 }
 
 func (c *mockConfig) Components() ([]channel.Component, error) {


### PR DESCRIPTION
add simple cf-deletions similar to the k8s resources deletions.

Using the same strategy with `pre_apply` and `post_apply`, and pass a list of objects with the Cloudformation stack names. This allow us to later extend it without breaking changes, as mentioned in the comment https://github.com/zalando-incubator/cluster-lifecycle-manager/pull/938#discussion_r3466278293

```yaml
pre_apply: # everything defined under here will be deleted before applying the manifests
- stackName: stack-name-1
- stackName: stack-name-2

post_apply: # everything defined under here will be deleted after applying the manifests
- stackName: stack-name-1
- stackName: stack-name-2
```

Other important decision:
- if the file does not exists in one/all config repos nothing will be deleted and it will not cause an error
- deletion of CF stacks is done after the deletion of the kubernetes resources
- using a different file name `cf-deletions.yaml` to avoid confusion (I'm not 100% sure about this decison), and the file is inside `cf-manifests` folder.
- the file `cf-deletions.yaml` is excluded from the CF apply since the files for CF manifests are not nested.

Test:
- add cf-deletions.yaml from some sources and not from others
- having sources without the file defined
- add a non existent stack to the cf-deletions.yaml

More details on the current use-case here: https://github.com/zalando-build/dbaas-kubernetes-manifests/pull/146