### PR TITLE
Improvements to CF apply and deletions

### DIFF
--- a/provisioner/aws.go
+++ b/provisioner/aws.go
@@ -476,7 +476,6 @@ func isStackDeleting(stack *cftypes.Stack) bool {
 // DeleteStack deletes a cloudformation stack.
 func (a *awsAdapter) DeleteStack(ctx context.Context, stack *cftypes.Stack) error {
 	stackName := aws.ToString(stack.StackName)
-	a.logger.Infof("Deleting stack '%s'", stackName)
 
 	if !isStackDeleting(stack) {
 		// disable termination protection on stack before deleting
@@ -488,6 +487,7 @@ func (a *awsAdapter) DeleteStack(ctx context.Context, stack *cftypes.Stack) erro
 		_, err := a.cloudformationClient.UpdateTerminationProtection(ctx, terminationParams)
 		if err != nil {
 			if isDoesNotExistsErr(err) {
+				a.logger.Infof("Skipping deletion of stack '%s': resource not found", stackName)
 				return nil
 			}
 			return err
@@ -500,6 +500,7 @@ func (a *awsAdapter) DeleteStack(ctx context.Context, stack *cftypes.Stack) erro
 		_, err = a.cloudformationClient.DeleteStack(ctx, deleteParams)
 		if err != nil {
 			if isDoesNotExistsErr(err) {
+				a.logger.Infof("Skipping deletion of stack '%s': resource not found", stackName)
 				return nil
 			}
 			return err
@@ -511,10 +512,13 @@ func (a *awsAdapter) DeleteStack(ctx context.Context, stack *cftypes.Stack) erro
 	err := a.waitForStack(ctxWithTimeout, waitTime, stackName)
 	if err != nil {
 		if isDoesNotExistsErr(err) {
+			a.logger.Infof("stack '%s' deleted", stackName)
 			return nil
 		}
 		return err
 	}
+
+	a.logger.Infof("stack '%s' deleted", stackName)
 	return nil
 }
 

--- a/provisioner/clusterpy.go
+++ b/provisioner/clusterpy.go
@@ -587,12 +587,12 @@ func applyCFManifests(ctx context.Context, logger *log.Entry, adapter *awsAdapte
 			continue
 		}
 
-		cfManifest, err := parseCFTemplate(remarshaled)
+		cfManifest, err := parseCFTemplate(rendered)
 		if err != nil {
 			return fmt.Errorf("failed to parse stack for manifest %s: %w", manifest.Path, err)
 		}
 
-		cfManifest.Template = remarshaled
+		cfManifest.Template = rendered
 		cfManifest.Path = manifest.Path
 
 		err = adapter.applyCFManifest(ctx, cfManifest, cluster.Name(), bucketName)


### PR DESCRIPTION
Improvements to CF apply and deletions

- [better cf stack delete logging to be easy to understand](https://github.com/zalando-incubator/cluster-lifecycle-manager/commit/c7b0378acb0a64facab6a7e7b6b21fd2083ba28e), avoiding sweet and panic when it says deleting stack but the stack did not really exist 😄 
- [apply original CF template after render to avoid strip macros](https://github.com/zalando-incubator/cluster-lifecycle-manager/commit/a15e5155a134c545c1b36c4be518cd1735ac151f), this should solve the issue of not being able to use e.g. !Sub and other short macros from CF.