### PR TITLE
Improve parallism of kubectl applier

### DIFF
--- a/pkg/kubernetes/kubectl_apply.go
+++ b/pkg/kubernetes/kubectl_apply.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -30,10 +31,14 @@ import (
 )
 
 type Applier struct {
-	restConfig *rest.Config
-	discovery  discovery.CachedDiscoveryInterface
-	kubeClient kubernetes.Interface
-	maxRetries uint64
+	restConfig       *rest.Config
+	discovery        discovery.CachedDiscoveryInterface
+	kubeClient       kubernetes.Interface
+	maxRetries       uint64
+	mapper           meta.RESTMapper
+	openAPIOnce      sync.Once
+	openAPIResources openapi.Resources
+	openAPIErr       error
 }
 
 func NewApplier(restConfig *rest.Config, maxRetries uint64) (*Applier, error) {
@@ -56,11 +61,14 @@ func NewApplier(restConfig *rest.Config, maxRetries uint64) (*Applier, error) {
 		return nil, err
 	}
 
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryInterface)
+
 	return &Applier{
 		restConfig: restConfig,
 		discovery:  discoveryInterface,
 		kubeClient: client,
 		maxRetries: maxRetries,
+		mapper:     restmapper.NewShortcutExpander(mapper, discoveryInterface, func(a string) { logrus.Warn(a) }),
 	}, nil
 }
 
@@ -172,15 +180,12 @@ func decodeAndValidate(manifest *ResourceManifest, validator validation.Conjunct
 }
 
 func (d *Applier) getRESTMappingFor(gvk *schema.GroupVersionKind) (*meta.RESTMapping, error) {
-	mapper := restmapper.NewDeferredDiscoveryRESTMapper(d.discovery)
-	expander := restmapper.NewShortcutExpander(mapper, d.discovery, func(a string) {
-		logrus.Warn(a)
-	})
-
-	restMapping, err := expander.RESTMapping(gvk.GroupKind(), gvk.Version)
+	restMapping, err := d.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 	if meta.IsNoMatchError(err) {
-		mapper.Reset()
-		return expander.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if dm, ok := d.mapper.(interface{ Reset() }); ok {
+			dm.Reset()
+		}
+		return d.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 	}
 	return restMapping, err
 }
@@ -199,5 +204,8 @@ func (d *Applier) getRestClientFor(gvk *schema.GroupVersionKind) (*rest.RESTClie
 
 // OpenAPISchema implements openapi.OpenAPIResourcesGetter
 func (d *Applier) OpenAPISchema() (openapi.Resources, error) {
-	return openapi.NewOpenAPIParser(openapi.NewOpenAPIGetter(d.discovery)).Parse()
+	d.openAPIOnce.Do(func() {
+		d.openAPIResources, d.openAPIErr = openapi.NewOpenAPIParser(openapi.NewOpenAPIGetter(d.discovery)).Parse()
+	})
+	return d.openAPIResources, d.openAPIErr
 }


### PR DESCRIPTION
## Problem

At concurrency=100, the controller was consuming 10+ CPU cores and was slow to apply manifests for each cluster. Profiling via the pprof endpoint revealed two hot paths responsible for the majority of the CPU usage:

### 1. OpenAPI schema parsed on every manifest apply

`Applier.OpenAPISchema()` was creating a new `CachedOpenAPIParser` and `CachedOpenAPIGetter` on every call:

```go
// Before
func (d *Applier) OpenAPISchema() (openapi.Resources, error) {
    return openapi.NewOpenAPIParser(openapi.NewOpenAPIGetter(d.discovery)).Parse()
}
```

Although `CachedOpenAPIParser` contains a `sync.Once` internally, allocating a new instance on every call means the cache is never hit. For each manifest being applied, the full Kubernetes OpenAPI schema was fetched from the API server and re-parsed: protobuf unmarshal → YAML unmarshal of vendor extensions → kube-openapi schema construction. With 100 concurrent clusters each applying dozens of manifests, hundreds of these CPU-heavy operations ran in parallel.

### 2. New REST mapper created on every manifest apply

`getRESTMappingFor()` was constructing a fresh `DeferredDiscoveryRESTMapper` on every call:

```go
// Before
func (d *Applier) getRESTMappingFor(gvk *schema.GroupVersionKind) (*meta.RESTMapping, error) {
    mapper := restmapper.NewDeferredDiscoveryRESTMapper(d.discovery)
    expander := restmapper.NewShortcutExpander(mapper, d.discovery, ...)
    ...
}
```

Each fresh mapper's first use triggered a full re-discovery of all API group resources from the server (`ServerGroupsAndResources`), even when responses were already disk-cached, requiring file I/O and SHA256 hashing for every API group response. This ran 100× in parallel, creating significant I/O and CPU pressure.

## Fix

Both resources are now created once per `Applier` (i.e., once per cluster) and reused across all manifest applies.

```go
type Applier struct {
    // ... existing fields ...
    mapper           meta.RESTMapper
    openAPIOnce      sync.Once
    openAPIResources openapi.Resources
    openAPIErr       error
}
```

**OpenAPI schema** is fetched and parsed on the first `OpenAPISchema()` call per `Applier` and cached via `sync.Once`. All subsequent calls return the cached result.

**REST mapper** is constructed once in `NewApplier` and stored as a field. The existing "reset and retry on no-match" behaviour is preserved for CRDs installed mid-provisioning.

## Impact

| Metric | Before | After |
|---|---|---|
| OpenAPI schema parses per cluster provision | O(manifests) | 1 |
| REST discovery fetches per cluster provision | O(manifests) | 1 (+ reset on cache miss) |

This eliminates the dominant source of CPU usage and significantly reduces redundant network/disk I/O when applying manifests at high concurrency.

As a not so scientific study, on my machine the applying of all kubernetes-on-aws manifests to a pet clusters goes from 1 min 18s before to 44s after this change.