### PR TITLE
try to cleanup all possible cases to avoid disk size always growing

### DIFF
--- a/channel/combined.go
+++ b/channel/combined.go
@@ -91,7 +91,11 @@ func (v *combinedVersion) Get(ctx context.Context, logger *logrus.Entry) (Config
 		config, err := version.Get(ctx, logger)
 		if err != nil {
 			for j := 0; j < i; j++ {
-				configs[j].Delete()
+				err := configs[j].Delete()
+				if err != nil {
+					logrus.Errorf("Unable to delete config for source %s: %v", v.owner.sourceName(j), err)
+				}
+
 			}
 			return nil, fmt.Errorf("unable to checkout version %s for source %s: %v", version.ID(), v.owner.sourceName(i), err)
 		}

--- a/channel/combined.go
+++ b/channel/combined.go
@@ -90,6 +90,9 @@ func (v *combinedVersion) Get(ctx context.Context, logger *logrus.Entry) (Config
 	for i, version := range v.versions {
 		config, err := version.Get(ctx, logger)
 		if err != nil {
+			for j := 0; j < i; j++ {
+				configs[j].Delete()
+			}
 			return nil, fmt.Errorf("unable to checkout version %s for source %s: %v", version.ID(), v.owner.sourceName(i), err)
 		}
 		configs[i] = config

--- a/channel/git.go
+++ b/channel/git.go
@@ -64,6 +64,13 @@ func NewGit(execManager *command.ExecManager, name string, workdir, repositoryUR
 		return nil, err
 	}
 
+	entries, _ := os.ReadDir(absWorkdir)
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), repoName+"_") {
+			os.RemoveAll(path.Join(absWorkdir, e.Name()))
+		}
+	}
+
 	return &Git{
 		name:              name,
 		exec:              execManager,
@@ -112,6 +119,11 @@ func (g *Git) Update(ctx context.Context, logger *log.Entry) error {
 		return err
 	}
 
+	err = g.cmd(ctx, logger, "--git-dir", g.repoDir, "gc", "--prune=now")
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -147,6 +159,7 @@ func (g *Git) localClone(ctx context.Context, logger *log.Entry, channel string)
 
 	err = g.cmd(ctx, logger, "-C", repoDir, "checkout", channel)
 	if err != nil {
+		os.RemoveAll(repoDir)
 		return "", err
 	}
 


### PR DESCRIPTION
try to cleanup all possible cases to avoid disk size always growing

The introduction of the `git gc --prune=now` might introduce a few extra seconds per git update, but it will be sure that all references not needed are deleted right away.