### PR TITLE
Add hasPrefix and hasSuffix functions

### DIFF
--- a/provisioner/template.go
+++ b/provisioner/template.go
@@ -122,6 +122,8 @@ func renderTemplate(context *templateContext, file string) (string, error) {
 		"parseInt64":                            parseInt64,
 		"generateJWKSDocument":                  generateJWKSDocument,
 		"generateOIDCDiscoveryDocument":         generateOIDCDiscoveryDocument,
+		"hasPrefix":                             sprig.GenericFuncMap()["hasPrefix"],
+		"hasSuffix":                             sprig.GenericFuncMap()["hasSuffix"],
 		"kubernetesSizeToKiloBytes":             kubernetesSizeToKiloBytes,
 		"indexedList":                           indexedList,
 		"zoneDistributedNodePoolGroups":         zoneDistributedNodePoolGroups,
@@ -794,7 +796,6 @@ func awsValidID(id string) string {
 func instanceTypeCPUQuantity(context *templateContext, instanceType ec2types.InstanceType) (string, error) {
 	// get the instance type info
 	instanceTypeInfo, err := context.instanceTypes.InstanceInfo(instanceType)
-
 	if err != nil {
 		return "", err
 	}
@@ -808,7 +809,6 @@ func instanceTypeCPUQuantity(context *templateContext, instanceType ec2types.Ins
 func instanceTypeMemoryQuantity(context *templateContext, instanceType ec2types.InstanceType) (string, error) {
 	// get the instance type info
 	instanceTypeInfo, err := context.instanceTypes.InstanceInfo(instanceType)
-
 	if err != nil {
 		return "", err
 	}

--- a/provisioner/template_test.go
+++ b/provisioner/template_test.go
@@ -1302,6 +1302,86 @@ func TestJoin(t *testing.T) {
 	}
 }
 
+func TestHasPrefix(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		template string
+		data     string
+		expected string
+	}{
+		{
+			name:     "match",
+			template: `{{ hasPrefix "foo" .Values.data }}`,
+			data:     "foobar",
+			expected: "true",
+		},
+		{
+			name:     "no match",
+			template: `{{ hasPrefix "bar" .Values.data }}`,
+			data:     "foobar",
+			expected: "false",
+		},
+		{
+			name:     "empty prefix",
+			template: `{{ hasPrefix "" .Values.data }}`,
+			data:     "foobar",
+			expected: "true",
+		},
+		{
+			name:     "empty subject",
+			template: `{{ hasPrefix "foo" .Values.data }}`,
+			data:     "",
+			expected: "false",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := renderSingle(t, tc.template, tc.data)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, res)
+		})
+	}
+}
+
+func TestHasSuffix(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		template string
+		data     string
+		expected string
+	}{
+		{
+			name:     "match",
+			template: `{{ hasSuffix "bar" .Values.data }}`,
+			data:     "foobar",
+			expected: "true",
+		},
+		{
+			name:     "no match",
+			template: `{{ hasSuffix "foo" .Values.data }}`,
+			data:     "foobar",
+			expected: "false",
+		},
+		{
+			name:     "empty suffix",
+			template: `{{ hasSuffix "" .Values.data }}`,
+			data:     "foobar",
+			expected: "true",
+		},
+		{
+			name:     "empty subject",
+			template: `{{ hasSuffix "bar" .Values.data }}`,
+			data:     "",
+			expected: "false",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := renderSingle(t, tc.template, tc.data)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, res)
+		})
+	}
+}
+
 func TestStrAppend(t *testing.T) {
 	for _, tc := range []struct {
 		name     string


### PR DESCRIPTION
Add the `hasPrefix` and `hasSuffix` sprig functions to the template function map.