### PR TITLE
Use Karpenter drift signals for outdated nodes

### DIFF
--- a/pkg/updatestrategy/aws_ec2.go
+++ b/pkg/updatestrategy/aws_ec2.go
@@ -76,7 +76,12 @@ func NewEC2NodePoolBackend(cluster *api.Cluster, cfg aws.Config, karpenterClient
 // userData,ImageID and tags and 'outdated' for nodes with an outdated
 // configuration.
 func (n *EC2NodePoolBackend) Get(ctx context.Context, nodePool *api.NodePool) (*NodePool, error) {
-	if nodePool.Profile == "worker-karpenter" {
+	// scope the Karpenter Drift detection logic to only Karpenter node
+	// pools that use Bottlerocket or AL2023 AMIs.
+	// This is done to limit the change to the initial roll out as Drift
+	// detection has a potential issue as outlined in:
+	// https://github.com/aws/karpenter-provider-aws/pull/9083#issuecomment-5012830911
+	if alias, ok := nodePool.ConfigItems["karpenter_ami_family_alias"]; ok && (strings.HasPrefix(alias, "bottlerocket") || strings.HasPrefix(alias, "al2023")) {
 		return n.GetUsingKubernetesObjects(ctx, nodePool)
 	}
 

--- a/pkg/updatestrategy/aws_ec2.go
+++ b/pkg/updatestrategy/aws_ec2.go
@@ -16,6 +16,7 @@ import (
 	"github.com/zalando-incubator/cluster-lifecycle-manager/api"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/pkg/aws/iface"
 	"github.com/zalando-incubator/cluster-lifecycle-manager/pkg/util"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -75,6 +76,10 @@ func NewEC2NodePoolBackend(cluster *api.Cluster, cfg aws.Config, karpenterClient
 // userData,ImageID and tags and 'outdated' for nodes with an outdated
 // configuration.
 func (n *EC2NodePoolBackend) Get(ctx context.Context, nodePool *api.NodePool) (*NodePool, error) {
+	if nodePool.Profile == "worker-karpenter" {
+		return n.GetUsingKubernetesObjects(ctx, nodePool)
+	}
+
 	instances, err := n.getInstances(ctx, n.filterWithNodePool(nodePool))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list EC2 instances of the node pool: %w", err)
@@ -111,6 +116,67 @@ func (n *EC2NodePoolBackend) Get(ctx context.Context, nodePool *api.NodePool) (*
 
 	// We only set Generation and Nodes as nothing else is needed by the
 	// CLC strategy
+	return &NodePool{
+		Generation: currentNodeGeneration,
+		Nodes:      nodes,
+	}, nil
+}
+
+// GetUsingKubernetesObjects gets nodes for the node pool by looking at Kubernetes Node and
+// Karpenter NodeClaim objects. Node generation is based on NodeClaim drift status.
+func (n *EC2NodePoolBackend) GetUsingKubernetesObjects(ctx context.Context, nodePool *api.NodePool) (*NodePool, error) {
+	nodePoolObj := &karpv1.NodePool{}
+	err := n.karpenterClient.Get(ctx, client.ObjectKey{Name: nodePool.Name}, nodePoolObj, &client.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Karpenter NodePool %q: %w", nodePool.Name, err)
+	}
+
+	ec2NodeClassName := nodePoolObj.Spec.Template.Spec.NodeClassRef.Name
+	if ec2NodeClassName == "" {
+		// Keep compatibility with clusters where NodePool and NodeClass use the same name.
+		ec2NodeClassName = nodePool.Name
+	}
+
+	ec2NodeClassObj := &karpenterawsv1.EC2NodeClass{}
+	err = n.karpenterClient.Get(ctx, client.ObjectKey{Name: ec2NodeClassName}, ec2NodeClassObj, &client.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Karpenter EC2NodeClass %q: %w", ec2NodeClassName, err)
+	}
+
+	nodesList := &corev1.NodeList{}
+	err = n.karpenterClient.List(ctx, nodesList, client.MatchingLabels{nodePoolTag: nodePool.Name})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Kubernetes Nodes of the node pool: %w", err)
+	}
+
+	nodeClaimsList := &karpv1.NodeClaimList{}
+	err = n.karpenterClient.List(ctx, nodeClaimsList, client.MatchingLabels{karpv1.NodePoolLabelKey: nodePool.Name})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Karpenter NodeClaims of the node pool: %w", err)
+	}
+
+	driftByNodeClaimName, driftByNodeName := nodeClaimDriftMaps(nodeClaimsList.Items, nodePoolObj, ec2NodeClassObj.Annotations)
+
+	nodes := make([]*Node, 0, len(nodesList.Items))
+	for _, node := range nodesList.Items {
+		if node.Spec.ProviderID == "" {
+			continue
+		}
+
+		generation := currentNodeGeneration
+		if driftByNodeName[node.Name] {
+			generation = outdatedNodeGeneration
+		} else if nodeClaimName, ok := nodeClaimNameFromOwnerReferences(node); ok && driftByNodeClaimName[nodeClaimName] {
+			generation = outdatedNodeGeneration
+		}
+
+		nodes = append(nodes, &Node{
+			ProviderID:    node.Spec.ProviderID,
+			FailureDomain: nodeFailureDomain(node),
+			Generation:    generation,
+		})
+	}
+
 	return &NodePool{
 		Generation: currentNodeGeneration,
 		Nodes:      nodes,
@@ -312,4 +378,90 @@ func (r *KarpenterNodePoolClient) NodePoolConfigGetter(ctx context.Context, node
 		ImageID:  r.getAMIsFromSpec(ec2NodeClass.Spec),
 		Tags:     tags,
 	}, nil
+}
+
+func nodeClaimDriftMaps(nodeClaims []karpv1.NodeClaim, nodePool *karpv1.NodePool, ec2NodeClassAnnotations map[string]string) (map[string]bool, map[string]bool) {
+	driftByNodeClaimName := make(map[string]bool, len(nodeClaims))
+	driftByNodeName := make(map[string]bool, len(nodeClaims))
+
+	for _, nodeClaim := range nodeClaims {
+		drifted := isNodeClaimDrifted(&nodeClaim)
+		if !drifted && nodePool != nil {
+			drifted = isNodeClaimBehindObservedTemplates(&nodeClaim, nodePool, ec2NodeClassAnnotations)
+		}
+
+		if !drifted {
+			continue
+		}
+
+		driftByNodeClaimName[nodeClaim.GetName()] = true
+
+		nodeName := nodeClaim.Status.NodeName
+		if nodeName == "" {
+			continue
+		}
+		driftByNodeName[nodeName] = true
+	}
+
+	return driftByNodeClaimName, driftByNodeName
+}
+
+func isNodeClaimDrifted(nodeClaim *karpv1.NodeClaim) bool {
+	return nodeClaim.StatusConditions().Get(string(karpv1.ConditionTypeDrifted)).IsTrue()
+}
+
+func isNodeClaimBehindObservedTemplates(nodeClaim *karpv1.NodeClaim, nodePool *karpv1.NodePool, ec2NodeClassAnnotations map[string]string) bool {
+	if hasHashMismatch(nodeClaim.Annotations, nodePool.Annotations, karpv1.NodePoolHashAnnotationKey, karpv1.NodePoolHashVersionAnnotationKey) {
+		return true
+	}
+
+	if hasHashMismatch(nodeClaim.Annotations, ec2NodeClassAnnotations, karpenterawsv1.AnnotationEC2NodeClassHash, karpenterawsv1.AnnotationEC2NodeClassHashVersion) {
+		return true
+	}
+
+	return false
+}
+
+func hasHashMismatch(nodeClaimAnnotations, sourceAnnotations map[string]string, hashKey, hashVersionKey string) bool {
+	desiredHash, desiredHashFound := sourceAnnotations[hashKey]
+	observedHash, observedHashFound := nodeClaimAnnotations[hashKey]
+
+	// Missing hashes mean this signal is unavailable; caller should rely on other checks.
+	if !desiredHashFound || !observedHashFound || desiredHash == "" || observedHash == "" {
+		return false
+	}
+
+	if desiredHash != observedHash {
+		return true
+	}
+
+	desiredHashVersion, desiredHashVersionFound := sourceAnnotations[hashVersionKey]
+	observedHashVersion, observedHashVersionFound := nodeClaimAnnotations[hashVersionKey]
+	if desiredHashVersionFound && observedHashVersionFound && desiredHashVersion != observedHashVersion {
+		return true
+	}
+
+	return false
+}
+
+func nodeClaimNameFromOwnerReferences(node corev1.Node) (string, bool) {
+	for _, ownerRef := range node.GetOwnerReferences() {
+		if ownerRef.Kind == "NodeClaim" && ownerRef.Name != "" {
+			return ownerRef.Name, true
+		}
+	}
+
+	return "", false
+}
+
+func nodeFailureDomain(node corev1.Node) string {
+	if failureDomain, ok := node.Labels[corev1.LabelTopologyZone]; ok {
+		return failureDomain
+	}
+
+	if failureDomain, ok := node.Labels["failure-domain.beta.kubernetes.io/zone"]; ok {
+		return failureDomain
+	}
+
+	return ""
 }

--- a/pkg/updatestrategy/aws_ec2_test.go
+++ b/pkg/updatestrategy/aws_ec2_test.go
@@ -1,0 +1,215 @@
+package updatestrategy
+
+import (
+	"testing"
+
+	karpenterawsv1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
+	"github.com/awslabs/operatorpkg/status"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+)
+
+func TestNodeClaimNameFromOwnerReferences(t *testing.T) {
+	node := corev1.Node{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{
+		{Kind: "ReplicaSet", Name: "rs-a"},
+		{Kind: "NodeClaim", Name: "claim-a"},
+	}}}
+
+	nodeClaimName, ok := nodeClaimNameFromOwnerReferences(node)
+	if !ok {
+		t.Fatalf("expected NodeClaim owner reference to be found")
+	}
+	if nodeClaimName != "claim-a" {
+		t.Fatalf("expected node claim name claim-a, got %q", nodeClaimName)
+	}
+}
+
+func TestNodeClaimNameFromOwnerReferencesMissing(t *testing.T) {
+	node := corev1.Node{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{
+		{Kind: "ReplicaSet", Name: "rs-a"},
+	}}}
+
+	nodeClaimName, ok := nodeClaimNameFromOwnerReferences(node)
+	if ok {
+		t.Fatalf("expected NodeClaim owner reference to be absent, got %q", nodeClaimName)
+	}
+}
+
+func TestNodeClaimDriftMaps(t *testing.T) {
+	nodeClaims := []karpv1.NodeClaim{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "claim-a"},
+			Status: karpv1.NodeClaimStatus{
+				NodeName: "node-a",
+				Conditions: []status.Condition{
+					{Type: string(karpv1.ConditionTypeDrifted), Status: metav1.ConditionTrue},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "claim-b"},
+			Status: karpv1.NodeClaimStatus{
+				NodeName: "node-b",
+				Conditions: []status.Condition{
+					{Type: string(karpv1.ConditionTypeDrifted), Status: metav1.ConditionFalse},
+				},
+			},
+		},
+	}
+
+	nodePool := &karpv1.NodePool{}
+	ec2NodeClassAnnotations := map[string]string{}
+	driftByNodeClaimName, driftByNodeName := nodeClaimDriftMaps(nodeClaims, nodePool, ec2NodeClassAnnotations)
+
+	if !driftByNodeClaimName["claim-a"] {
+		t.Fatalf("expected claim-a to be drifted")
+	}
+	if driftByNodeClaimName["claim-b"] {
+		t.Fatalf("expected claim-b to not be drifted")
+	}
+
+	if !driftByNodeName["node-a"] {
+		t.Fatalf("expected node-a to be drifted")
+	}
+	if driftByNodeName["node-b"] {
+		t.Fatalf("expected node-b to not be drifted")
+	}
+}
+
+func TestNodeClaimDriftMapsByHashMismatch(t *testing.T) {
+	nodePool := &karpv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+			karpv1.NodePoolHashAnnotationKey:        "hash-current",
+			karpv1.NodePoolHashVersionAnnotationKey: "v3",
+		}},
+	}
+
+	ec2NodeClassAnnotations := map[string]string{
+		karpenterawsv1.AnnotationEC2NodeClassHash:        "class-hash-current",
+		karpenterawsv1.AnnotationEC2NodeClassHashVersion: "v3",
+	}
+
+	nodeClaims := []karpv1.NodeClaim{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "claim-a",
+				Annotations: map[string]string{
+					karpv1.NodePoolHashAnnotationKey:                 "hash-old",
+					karpv1.NodePoolHashVersionAnnotationKey:          "v3",
+					karpenterawsv1.AnnotationEC2NodeClassHash:        "class-hash-current",
+					karpenterawsv1.AnnotationEC2NodeClassHashVersion: "v3",
+				},
+			},
+			Status: karpv1.NodeClaimStatus{
+				NodeName: "node-a",
+				Conditions: []status.Condition{
+					{Type: string(karpv1.ConditionTypeDrifted), Status: metav1.ConditionFalse},
+				},
+			},
+		},
+	}
+
+	driftByNodeClaimName, driftByNodeName := nodeClaimDriftMaps(nodeClaims, nodePool, ec2NodeClassAnnotations)
+
+	if !driftByNodeClaimName["claim-a"] {
+		t.Fatalf("expected claim-a to be drifted by hash mismatch")
+	}
+
+	if !driftByNodeName["node-a"] {
+		t.Fatalf("expected node-a to be drifted by hash mismatch")
+	}
+}
+
+func TestIsNodeClaimBehindObservedTemplates(t *testing.T) {
+	tests := []struct {
+		name                 string
+		nodeClaim            *karpv1.NodeClaim
+		nodePool             *karpv1.NodePool
+		nodeClassAnnotations map[string]string
+		expected             bool
+	}{
+		{
+			name: "nodepool hash mismatch",
+			nodeClaim: &karpv1.NodeClaim{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				karpv1.NodePoolHashAnnotationKey:                 "old",
+				karpv1.NodePoolHashVersionAnnotationKey:          "v3",
+				karpenterawsv1.AnnotationEC2NodeClassHash:        "same",
+				karpenterawsv1.AnnotationEC2NodeClassHashVersion: "v3",
+			}}},
+			nodePool: &karpv1.NodePool{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				karpv1.NodePoolHashAnnotationKey:        "new",
+				karpv1.NodePoolHashVersionAnnotationKey: "v3",
+			}}},
+			nodeClassAnnotations: map[string]string{
+				karpenterawsv1.AnnotationEC2NodeClassHash:        "same",
+				karpenterawsv1.AnnotationEC2NodeClassHashVersion: "v3",
+			},
+			expected: true,
+		},
+		{
+			name: "no mismatch",
+			nodeClaim: &karpv1.NodeClaim{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				karpv1.NodePoolHashAnnotationKey:                 "same",
+				karpv1.NodePoolHashVersionAnnotationKey:          "v3",
+				karpenterawsv1.AnnotationEC2NodeClassHash:        "same",
+				karpenterawsv1.AnnotationEC2NodeClassHashVersion: "v3",
+			}}},
+			nodePool: &karpv1.NodePool{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				karpv1.NodePoolHashAnnotationKey:        "same",
+				karpv1.NodePoolHashVersionAnnotationKey: "v3",
+			}}},
+			nodeClassAnnotations: map[string]string{
+				karpenterawsv1.AnnotationEC2NodeClassHash:        "same",
+				karpenterawsv1.AnnotationEC2NodeClassHashVersion: "v3",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := isNodeClaimBehindObservedTemplates(tt.nodeClaim, tt.nodePool, tt.nodeClassAnnotations)
+			if actual != tt.expected {
+				t.Fatalf("expected isNodeClaimBehindObservedTemplates=%t, got %t", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestIsNodeClaimDrifted(t *testing.T) {
+	tests := []struct {
+		name      string
+		nodeClaim *karpv1.NodeClaim
+		expected  bool
+	}{
+		{
+			name: "drifted condition true",
+			nodeClaim: &karpv1.NodeClaim{Status: karpv1.NodeClaimStatus{Conditions: []status.Condition{
+				{Type: string(karpv1.ConditionTypeDrifted), Status: metav1.ConditionTrue},
+			}}},
+			expected: true,
+		},
+		{
+			name: "drifted condition false",
+			nodeClaim: &karpv1.NodeClaim{Status: karpv1.NodeClaimStatus{Conditions: []status.Condition{
+				{Type: string(karpv1.ConditionTypeDrifted), Status: metav1.ConditionFalse},
+			}}},
+			expected: false,
+		},
+		{
+			name:      "missing conditions",
+			nodeClaim: &karpv1.NodeClaim{},
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := isNodeClaimDrifted(tt.nodeClaim)
+			if actual != tt.expected {
+				t.Fatalf("expected isNodeClaimDrifted=%t, got %t", tt.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Historically CLM has used UserData, AMI ID and tags to define whether a node was outdated from the desired configuration and needed to be rotated.

With the introduction of EKS AMIs: https://github.com/zalando-incubator/kubernetes-on-aws/pull/11643 this no longer works as the UserData is dynamic for those AMIs. E.g. the UserData defined on the EC2NodeClass is just a subset of the final userdata set on the instance, so it's no longer possible to compare the userdata to determine if a node is outdated.

Karpenter provides the Drift feature and indicates on a NodeClaim if it's drifted from the desired.

This PR changes the logic to use the Drift signal of NodeClaims instead of trying to determine drift based on userdata and other ec2 level settings.

This is a simple way to make CLM behave similar and be responsible for the node rotation triggering while other tools like CLC will still work with this. In the future it makes sense to look into the native drift feature in Karpenter to avoid implementing half of it in CLM.

### Depends on

* [x] #949 