### PR TITLE
Disable coverage report

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,18 +14,18 @@ jobs:
       with:
         go-version: '^1.26'
     - run: go version
-    - run: go install github.com/t-yuki/gocover-cobertura@latest
+    # - run: go install github.com/t-yuki/gocover-cobertura@latest
     - run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
     - run: make lint
     - run: make build.docker
     - run: make test
-    - name: Convert coverage to Cobertura XML
-      if: ${{ hashFiles('profile.cov') != '' }}
-      run: gocover-cobertura < profile.cov > coverage.xml
-    - name: Upload coverage report
-      if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && hashFiles('coverage.xml') != '' }}
-      uses: actions/upload-code-coverage@v1
-      with:
-        file: coverage.xml
-        language: go
-        label: code-coverage/go-test
+    # - name: Convert coverage to Cobertura XML
+    #   if: ${{ hashFiles('profile.cov') != '' }}
+    #   run: gocover-cobertura < profile.cov > coverage.xml
+    # - name: Upload coverage report
+    #   if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && hashFiles('coverage.xml') != '' }}
+    #   uses: actions/upload-code-coverage@v1
+    #   with:
+    #     file: coverage.xml
+    #     language: go
+    #     label: code-coverage/go-test


### PR DESCRIPTION
Code Quality is disabled and can't be enabled at repo level. Need to clarify internally if it can be enabled or an alternative is needed.

Until then we disable it to avoid broken builds.