### PR TITLE
feat: deletions skip kind not exists to cover deleted CRDs

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -191,15 +191,27 @@ func (c *ClientsCollection) getResourceClient(kind, namespace string) (dynamic.R
 
 func (c *ClientsCollection) ResolveKind(kind string) (schema.GroupVersionResource, error) {
 	var gvr schema.GroupVersionResource
+	var lastErr error
 	fullySpecifiedGVR, groupResource := schema.ParseResourceArg(kind)
 
 	if fullySpecifiedGVR != nil {
-		gvr, _ = c.Mapper.ResourceFor(*fullySpecifiedGVR)
+		var err error
+		gvr, err = c.Mapper.ResourceFor(*fullySpecifiedGVR)
+		if err != nil {
+			lastErr = err
+		}
 	}
 	if gvr.Empty() {
-		gvr, _ = c.Mapper.ResourceFor(groupResource.WithVersion(""))
+		var err error
+		gvr, err = c.Mapper.ResourceFor(groupResource.WithVersion(""))
+		if err != nil {
+			lastErr = err
+		}
 	}
 	if gvr.Empty() {
+		if lastErr != nil {
+			return schema.GroupVersionResource{}, lastErr
+		}
 		return schema.GroupVersionResource{}, fmt.Errorf("unable to resolve kind %s (use either name or name.version.group)", kind)
 	}
 	return gvr, nil
@@ -296,6 +308,10 @@ func (c *ClientsCollection) deleteIfFound(ctx context.Context, logger *logrus.En
 		logger.Infof("Skipping deletion of %s %s: resource not found", kind, name)
 		return nil
 	}
+	if err != nil && meta.IsNoMatchError(err) {
+		logger.Infof("Skipping deletion of %s %s: resource type no longer registered (CRD may have been deleted)", kind, name)
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("unable to delete: %w", err)
 	}
@@ -339,6 +355,10 @@ func (c *ClientsCollection) DeleteResource(ctx context.Context, logger *logrus.E
 	}
 
 	items, err := c.ListResources(ctx, deletion)
+	if err != nil && meta.IsNoMatchError(err) {
+		logger.Infof("Skipping deletion of %s: resource type no longer registered (CRD may have been deleted)", deletion.Kind)
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -190,6 +190,17 @@ func (c *ClientsCollection) getResourceClient(kind, namespace string) (dynamic.R
 }
 
 func (c *ClientsCollection) ResolveKind(kind string) (schema.GroupVersionResource, error) {
+	gvr, err := c.resolveKind(kind)
+	if meta.IsNoMatchError(err) || meta.IsAmbiguousError(err) {
+		if dm, ok := c.Mapper.(interface{ Reset() }); ok {
+			dm.Reset()
+		}
+		gvr, err = c.resolveKind(kind)
+	}
+	return gvr, err
+}
+
+func (c *ClientsCollection) resolveKind(kind string) (schema.GroupVersionResource, error) {
 	var gvr schema.GroupVersionResource
 	var lastErr error
 	fullySpecifiedGVR, groupResource := schema.ParseResourceArg(kind)
@@ -204,7 +215,7 @@ func (c *ClientsCollection) ResolveKind(kind string) (schema.GroupVersionResourc
 	if gvr.Empty() {
 		var err error
 		gvr, err = c.Mapper.ResourceFor(groupResource.WithVersion(""))
-		if err != nil {
+		if err != nil && lastErr == nil {
 			lastErr = err
 		}
 	}
@@ -308,7 +319,7 @@ func (c *ClientsCollection) deleteIfFound(ctx context.Context, logger *logrus.En
 		logger.Infof("Skipping deletion of %s %s: resource not found", kind, name)
 		return nil
 	}
-	if err != nil && meta.IsNoMatchError(err) {
+	if err != nil && (meta.IsNoMatchError(err) || meta.IsAmbiguousError(err)) {
 		logger.Infof("Skipping deletion of %s %s: resource type no longer registered (CRD may have been deleted)", kind, name)
 		return nil
 	}
@@ -355,7 +366,7 @@ func (c *ClientsCollection) DeleteResource(ctx context.Context, logger *logrus.E
 	}
 
 	items, err := c.ListResources(ctx, deletion)
-	if err != nil && meta.IsNoMatchError(err) {
+	if err != nil && (meta.IsNoMatchError(err) || meta.IsAmbiguousError(err)) {
 		logger.Infof("Skipping deletion of %s: resource type no longer registered (CRD may have been deleted)", deletion.Kind)
 		return nil
 	}


### PR DESCRIPTION
Root cause: ResolveKind was silently discarding mapper errors (using _), then generating its own opaque error string when the GVR was empty. Callers couldn't detect whether the failure was a NoMatchError/AmbiguousError (CRD not registered) vs a genuinely misconfigured kind — so deleteIfFound couldn't treat it as "already gone, skip gracefully."

Changes in pkg/kubernetes/kubernetes.go:

1. resolveKind (new private helper) — contains the original ResolveKind logic but now preserves the real mapper error instead of discarding it with _. The first error is kept if both lookups fail, so the more specific one is always returned. Falls back to the original error message only when the mapper returns an empty GVR with no error.
2. ResolveKind — now wraps resolveKind with a reset-and-retry on NoMatchError or AmbiguousError, matching the pattern already used in getRESTMappingFor (kubectl_apply.go). This handles stale discovery cache without permanently failing.
3. deleteIfFound — now skips gracefully on IsNoMatchError or IsAmbiguousError instead of hard-failing. Covers both NoKindMatchError (CRD deleted) and AmbiguousResourceError (CRD has multiple versions registered).
4. DeleteResource — same graceful skip applied to the ListResources call in the selector/labels path.

NOTE: Generate with help of AI